### PR TITLE
Debug experiments paths

### DIFF
--- a/silnlp/common/utils.py
+++ b/silnlp/common/utils.py
@@ -2,7 +2,6 @@ import logging
 import os
 import random
 import subprocess
-import time
 from abc import ABC, abstractmethod
 from enum import Enum, Flag, auto
 from inspect import getmembers
@@ -57,10 +56,6 @@ def show_attrs(cli_args, envs=SIL_NLP_ENV, actions=[]):
 
     for action in actions:
         print(action)
-
-    print()
-    print("Press Ctrl+C to exit. Will continue automatically in 30 seconds.")
-    time.sleep(30)
 
 
 def get_repo_dir() -> Path:

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -99,13 +99,16 @@ def main() -> None:
     parser.add_argument("--test", default=False, action="store_true", help="Run the test step.")
     parser.add_argument("--score-by-book", default=False, action="store_true", help="Score individual books")
     parser.add_argument("--mt-dir", default=None, type=str, help="The machine translation directory.")
+    parser.add_argument("--debug", default=False, action="store_true", help="Show information about the environment variables and arguments.")
 
     args = parser.parse_args()
 
     if args.mt_dir is not None:
         SIL_NLP_ENV.set_machine_translation_dir(SIL_NLP_ENV.data_dir / args.mt_dir)
 
-    show_attrs(cli_args=args)
+    if args.debug:
+        show_attrs(cli_args=args)
+        exit()
 
     if args.memory_growth:
         enable_memory_growth()

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -1,14 +1,14 @@
 import argparse
 import os
-import time
+#import time
 from dataclasses import dataclass
 from pathlib import Path
-from pprint import pprint
+#from types import FunctionType
 from typing import Optional
 
 from ..common.environment import SIL_NLP_ENV
 from ..common.tf_utils import enable_memory_growth
-from ..common.utils import get_git_revision_hash
+from ..common.utils import get_git_revision_hash, show_attrs
 from .clearml_connection import SILClearML
 from .config import Config, get_mt_exp_dir
 from .test import test
@@ -79,21 +79,6 @@ class SILExperiment:
             self.name, patterns=("scores-*.csv", "test.*trg-predictions.*"), overwrite=True
         )
 
-from types import FunctionType
-from inspect import getmembers
-
-def api(obj):
-    return [name for name in dir(obj) if name[0] != '_']
-
-def attrs(obj):
-    disallowed_properties = {
-        name for name, value in getmembers(type(obj)) 
-        if isinstance(value, (property, FunctionType))
-    }
-    return {
-        name: getattr(obj, name) for name in api(obj) 
-        if name not in disallowed_properties and hasattr(obj, name)
-    }
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run experiment - preprocess, train, and test")
@@ -119,10 +104,8 @@ def main() -> None:
 
     if args.mt_dir is not None:
         SIL_NLP_ENV.set_machine_translation_dir(SIL_NLP_ENV.data_dir / args.mt_dir)
-    
-    pprint(attrs(SIL_NLP_ENV))
-    print("Press Ctrl+C to exit. Will continue automatically in 30 seconds.")
-    time.sleep(30)
+
+    show_attrs(cli_args=args)
 
     if args.memory_growth:
         enable_memory_growth()

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -225,6 +225,7 @@ def main() -> None:
         type=str,
         help="Run remotely on ClearML queue.  Default: None - don't register with ClearML.  The queue 'local' will run it locally and register it with ClearML.",
     )
+    parser.add_argument("--debug", default=False, action="store_true", help="Show information about the environment variables and arguments.")
     args = parser.parse_args()
 
     get_git_revision_hash()
@@ -242,19 +243,25 @@ def main() -> None:
     )
 
     if len(args.books) > 0:
-        show_attrs(cli_args=args, actions=[f"Will attempt to translate books {args.books} into {args.trg_iso}"])
+        if args.debug:
+            show_attrs(cli_args=args, actions=[f"Will attempt to translate books {args.books} into {args.trg_iso}"])
+            exit()
         translator.translate_books(args.books, args.src_project, args.trg_iso)
     elif args.src_prefix is not None:
-        show_attrs(
-            cli_args=args, actions=[f"Will attempt to tranlate matching files from {args.src_iso} into {args.trg_iso}."]
-        )
+        if args.debug:
+            show_attrs(
+                cli_args=args, actions=[f"Will attempt to tranlate matching files from {args.src_iso} into {args.trg_iso}."]
+            )
+            exit()
         translator.translate_text_files(
             args.src_prefix, args.trg_prefix, args.start_seq, args.end_seq, args.src_iso, args.trg_iso
         )
     elif args.src is not None:
-        show_attrs(
-            cli_args=args, actions=[f"Will attempt to tranlate {args.src} from {args.src_iso} into {args.trg_iso}."]
-        )
+        if args.debug:
+            show_attrs(
+                cli_args=args, actions=[f"Will attempt to tranlate {args.src} from {args.src_iso} into {args.trg_iso}."]
+            )
+            exit()
         translator.translate_files(args.src, args.trg, args.src_iso, args.trg_iso)
     else:
         raise RuntimeError("A Scripture book, file, or file prefix must be specified.")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -210,6 +210,24 @@ def attrs(obj):
     return {name: getattr(obj, name) for name in api(obj) if name not in disallowed_properties and hasattr(obj, name)}
 
 
+def show_attrs(cli_args, envs=SIL_NLP_ENV, action=""):
+    for k,v in attrs(envs).items():
+        print(k,v, type(v))
+
+    for k in cli_args.__dict__:
+        v = cli_args.__dict__[k] 
+        
+        if v is not None:
+            print(k, v, type(v)) 
+            #print(f"{k}  :  {v}   : Path exists : {v.is_dir()}")
+            #else:    
+            #    print(f"{k}  :  {v}")
+            
+    print(action)
+    print("Press Ctrl+C to exit. Will continue automatically in 30 seconds.")
+    time.sleep(30)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Translates text using an NMT model")
     parser.add_argument("experiment", help="Experiment name")
@@ -249,9 +267,6 @@ def main() -> None:
     if args.memory_growth:
         enable_memory_growth()
 
-    pprint(attrs(SIL_NLP_ENV))
-    print("Press Ctrl+C to exit. Will continue automatically in 30 seconds.")
-    time.sleep(30)
     
     translator = TranslationTask(
         name=args.experiment,
@@ -260,12 +275,15 @@ def main() -> None:
     )
 
     if len(args.books) > 0:
+        show_attrs(cli_args = args, action=f"Will attempt to translate books {args.books} into {args.trg_iso}")
         translator.translate_books(args.books, args.src_project, args.trg_iso)
     elif args.src_prefix is not None:
+        show_attrs(cli_args = args, action=f"Will attempt to tranlate matching files from {args.src_iso} into {args.trg_iso}.")
         translator.translate_text_files(
             args.src_prefix, args.trg_prefix, args.start_seq, args.end_seq, args.src_iso, args.trg_iso
         )
     elif args.src is not None:
+        show_attrs(cli_args = args, action=f"Will attempt to tranlate {args.src} from {args.src_iso} into {args.trg_iso}.")
         translator.translate_files(args.src, args.trg, args.src_iso, args.trg_iso)
     else:
         raise RuntimeError("A Scripture book, file, or file prefix must be specified.")


### PR DESCRIPTION
Updated so that the code formats the data more clearly and reuses the same functions.
The functions were placed in the common.utils.py file.

TO DO:
Add similar reporting to the preprocess, train and test scripts maybe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/161)
<!-- Reviewable:end -->
