### PR TITLE
Fix issue where updated tokenizer not used during inference, add segment length stats to preprocess

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -520,7 +520,7 @@ class Config(ABC):
                         for line in f:
                             src_data.append(len(line.split()))
                 stats_file.write(f"Src segment length statistics:\n")
-                stats_file.write(f"Num seg lengths > 200: {sum(seg_length > 200 for seg_length in src_data)}\n")
+                stats_file.write(f"Num seg lengths >= 200: {sum(seg_length >= 200 for seg_length in src_data)}\n")
                 stats_file.write(f"Max seg length: {max(src_data)}\n")
                 stats_file.write(f"Avg seg length: {sum(src_data)/len(src_data)}\n")
                 trg_data = []
@@ -529,7 +529,7 @@ class Config(ABC):
                         for line in f:
                             trg_data.append(len(line.split()))
                 stats_file.write(f"Trg segment length statistics:\n")
-                stats_file.write(f"Num seg lengths > 200: {sum(seg_length > 200 for seg_length in trg_data)}\n")
+                stats_file.write(f"Num seg lengths >= 200: {sum(seg_length >= 200 for seg_length in trg_data)}\n")
                 stats_file.write(f"Max seg length: {max(trg_data)}\n")
                 stats_file.write(f"Avg seg length: {sum(trg_data)/len(trg_data)}\n")
         return train_count

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -510,6 +510,28 @@ class Config(ABC):
                 train_count += self._write_scripture_data_sets(tokenizer, pair, stats)
             else:
                 train_count += self._write_basic_data_sets(tokenizer, pair)
+        if stats:    
+            with ExitStack() as stack:
+                stats_file: Optional[TextIO] = None
+                stats_file = stack.enter_context(self._open_append("tokenization_stats.txt"))
+                src_data = []
+                for src_tok_file in self.exp_dir.glob("*.src.txt"):
+                    with open(self.exp_dir / src_tok_file, "r+", encoding="utf-8") as f:
+                        for line in f:
+                            src_data.append(len(line.split()))
+                stats_file.write(f"Src segment length statistics:\n")
+                stats_file.write(f"Num seg lengths > 200: {sum(seg_length > 200 for seg_length in src_data)}\n")
+                stats_file.write(f"Max seg length: {max(src_data)}\n")
+                stats_file.write(f"Avg seg length: {sum(src_data)/len(src_data)}\n")
+                trg_data = []
+                for trg_tok_file in self.exp_dir.glob("*.trg.txt"):
+                    with open(self.exp_dir / trg_tok_file, "r+", encoding="utf-8") as f:
+                        for line in f:
+                            trg_data.append(len(line.split()))
+                stats_file.write(f"Trg segment length statistics:\n")
+                stats_file.write(f"Num seg lengths > 200: {sum(seg_length > 200 for seg_length in trg_data)}\n")
+                stats_file.write(f"Max seg length: {max(trg_data)}\n")
+                stats_file.write(f"Avg seg length: {sum(trg_data)/len(trg_data)}\n")
         return train_count
 
     def _delete_files(self, pattern: str) -> None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -340,7 +340,7 @@ class HuggingFaceConfig(Config):
 
     def _build_vocabs(self, stats: bool=False) -> None:
         tokenizer_dict = self.root.get("data").get("tokenizer")
-        self._tokenizer = self.get_tokenizer(preprocess=True)
+        self._tokenizer = self.get_or_create_tokenizer()
         tokens = []
         trained_tokenizers = []
         if self.data["add_new_lang_code"]:
@@ -388,29 +388,32 @@ class HuggingFaceConfig(Config):
         if tokens:
             self._add_tokens(tokens, trained_tokenizers)
 
-    def get_tokenizer(self, preprocess: bool=False) -> PreTrainedTokenizer:
+    def get_or_create_tokenizer(self) -> PreTrainedTokenizer:
         if self._tokenizer is None:
-            if not preprocess:
-                model_name_or_path = str(self.exp_dir) if (self.exp_dir / "tokenizer_config.json").is_file() else self.model
-                self._tokenizer = NllbTokenizerFast.from_pretrained(model_name_or_path, use_fast=True)
+            tokenizer_dict = self.root.get("data").get("tokenizer")
+            if tokenizer_dict and (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg")) and (self.exp_dir / "sentencepiece.bpe.model").is_file() and not (
+                self.exp_dir / "tokenizer_config.json"
+            ).is_file():
+                self._tokenizer = NllbTokenizer.from_pretrained(str(self.exp_dir))
+                self._tokenizer = convert_slow_tokenizer(self._tokenizer)
+                self._tokenizer = NllbTokenizerFast(tokenizer_object=self._tokenizer)
+                self._tokenizer.save_pretrained(str(self.exp_dir))
             else:
-                tokenizer_dict = self.root.get("data").get("tokenizer")
-                if tokenizer_dict and (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg")) and (self.exp_dir / "sentencepiece.bpe.model").is_file() and not (
-                    self.exp_dir / "tokenizer_config.json"
-                ).is_file():
-                    self._tokenizer = NllbTokenizer.from_pretrained(str(self.exp_dir))
-                    self._tokenizer = convert_slow_tokenizer(self._tokenizer)
-                    self._tokenizer = NllbTokenizerFast(tokenizer_object=self._tokenizer)
-                    self._tokenizer.save_pretrained(str(self.exp_dir))
+                if (not tokenizer_dict or not (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg"))) and (self.exp_dir / "tokenizer_config.json").is_file():
+                    model_name_or_path = str(self.exp_dir)
+                elif (tokenizer_dict and (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg"))) and (SIL_NLP_ENV.assets_dir / "tokenizer_config.json").is_file():
+                    model_name_or_path = str(SIL_NLP_ENV.assets_dir)
                 else:
-                    if (not tokenizer_dict or not (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg"))) and (self.exp_dir / "tokenizer_config.json").is_file():
-                        model_name_or_path = str(self.exp_dir)
-                    elif (tokenizer_dict and (tokenizer_dict.get("update_src") or tokenizer_dict.get("update_trg"))) and (SIL_NLP_ENV.assets_dir / "tokenizer_config.json").is_file():
-                        model_name_or_path = str(SIL_NLP_ENV.assets_dir)
-                    else:
-                        model_name_or_path = self.model
-                    self._tokenizer = NllbTokenizerFast.from_pretrained(model_name_or_path, use_fast=True)
-                self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
+                    model_name_or_path = self.model
+                self._tokenizer = NllbTokenizerFast.from_pretrained(model_name_or_path, use_fast=True)
+            self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
+        return self._tokenizer
+
+    def get_tokenizer(self) -> PreTrainedTokenizer:
+        if self._tokenizer is None:
+            model_name_or_path = str(self.exp_dir) if (self.exp_dir / "tokenizer_config.json").is_file() else self.model
+            self._tokenizer = NllbTokenizerFast.from_pretrained(model_name_or_path, use_fast=True)
+            self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
         return self._tokenizer
 
     def _write_dictionary(self, tokenizer: Tokenizer, pair: CorpusPair) -> int:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from enum import Enum
 from itertools import repeat
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Set, TextIO, Tuple, TypeVar, Union, cast
 
 import datasets.utils.logging as datasets_logging
 import evaluate
@@ -383,7 +383,7 @@ class HuggingFaceConfig(Config):
                 with ExitStack() as stack:
                     stats_file: Optional[TextIO] = None
                     stats_file = stack.enter_context((self.exp_dir / "tokenization_stats.txt").open("w", encoding="utf-8", newline="\n"))
-                    stats_file.write(f"Added tokens: {len(missing_tokens)}")
+                    stats_file.write(f"Added tokens: {len(missing_tokens)}\n")
             tokens += missing_tokens
         if tokens:
             self._add_tokens(tokens, trained_tokenizers)


### PR DESCRIPTION
When I refactored the tokenizer code during the previous request, there was an unintended consequence where inferencing would unsuccessfully try to update the tokenizer even though the tokenizer had already been updated during preprocessing. This update adds an optional argument to get_tokenizer() to differentiate between preprocessing and other steps, so that during any step other than preprocessing it will just use the tokenizer found in the project directory.

I also added functionality to track the following stats: num segment lengths > 200, max segment length, and avg segment length. These will be helpful for tokenizer experiments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/191)
<!-- Reviewable:end -->
