### PR TITLE
make method signature consistent for _build_vocabs()

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -1326,7 +1326,7 @@ class Config(ABC):
         return self._iso_pairs[(src_iso, trg_iso)].has_multiple_test_projects
 
     @abstractmethod
-    def _build_vocabs(self) -> None:
+    def _build_vocabs(self, stats: bool=False) -> None:
         ...
 
     @abstractmethod

--- a/silnlp/nmt/open_nmt_config.py
+++ b/silnlp/nmt/open_nmt_config.py
@@ -450,7 +450,7 @@ class OpenNMTConfig(Config):
 
         return OpenNMTTokenizer(src_spp, trg_spp, self.write_trg_tag)
 
-    def _build_vocabs(self) -> None:
+    def _build_vocabs(self, stats: bool=False) -> None:
         if not self.data["tokenize"]:
             return
 


### PR DESCRIPTION
I changed the method signatures in config.py and open_nmt_config.py for` _build_vocabs()` so that they would match the function signature in hugging_face_config.py. The function signature now reads as `def _build_vocabs(self, stats: bool=False) -> None:`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/195)
<!-- Reviewable:end -->
