### PR TITLE
Check eflomal exists before importing

### DIFF
--- a/silnlp/alignment/config.py
+++ b/silnlp/alignment/config.py
@@ -8,6 +8,7 @@ from machine.scripture import ALL_BOOK_IDS, book_id_to_number, is_ot_nt
 from ..common.environment import SIL_NLP_ENV
 from ..common.flatcat_stemmer import FlatCatStemmer
 from ..common.null_stemmer import NullStemmer
+from ..common.packages_utils import is_eflomal_available
 from ..common.snowball_stemmer import SnowballStemmer
 from ..common.stemmer import Stemmer
 from ..common.utils import merge_dict
@@ -23,7 +24,10 @@ from .dotnet_machine_aligner import (
     Ibm4DotnetMachineAligner,
     ParatextDotnetMachineAligner,
 )
-from .eflomal import EflomalAligner
+
+if is_eflomal_available():
+    from .eflomal import EflomalAligner
+
 from .fast_align import FastAlign
 from .giza_aligner import HmmGizaAligner, Ibm1GizaAligner, Ibm2GizaAligner, Ibm3GizaAligner, Ibm4GizaAligner
 from .machine_aligner import (

--- a/silnlp/common/packages_utils.py
+++ b/silnlp/common/packages_utils.py
@@ -1,0 +1,5 @@
+from importlib.util import find_spec
+
+
+def is_eflomal_available() -> bool:
+    return find_spec("eflomal") is not None


### PR DESCRIPTION
I followed machine.py's methodology with a file containing functions that check if packages are available. I created a function to check if eflomal is available, and that function is called before importing eflomal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/206)
<!-- Reviewable:end -->
