### PR TITLE
Use silnlp source rather than binary and update documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ RUN apt-get install --no-install-recommends -y \
     nano \
     cmake \
     tar \
-    vim \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -64,19 +63,9 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y dotnet-sdk-7.0
 ENV DOTNET_ROLL_FORWARD=LatestMajor
 
-# Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install && \
-    rm awscliv2.zip
-
 # Install dependencies from poetry
 COPY --from=builder /src/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
-
-# Install silnlp
-COPY --from=builder /src/dist/*.whl .
-RUN pip install --no-deps *.whl && rm *.whl
 
 # Install eflomal
 RUN git clone https://github.com/robertostling/eflomal.git
@@ -120,6 +109,11 @@ ENV METEOR_PATH=/usr/local/bin
 ENV SIL_NLP_DATA_PATH=/aqua-ml-data
 RUN mkdir -p .cache/silnlp
 ENV SIL_NLP_CACHE_EXPERIMENT_DIR=/root/.cache/silnlp
+ENV CLEARML_API_HOST="https://api.sil.hosted.allegro.ai"
+
+# Clone silnlp and make it the starting directory
+RUN git clone https://github.com/sillsdev/silnlp.git
+WORKDIR /root/silnlp
 
 # Default docker run behavior
 ENTRYPOINT [ "/bin/bash", "-it" ]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The SILNLP repo itself is hosted on Github, mainly written in Python and calls S
    
    In a terminal, run:
    ```
-   docker pull ghcr.io/sillsdev/silnlp:0.1.2
+   docker pull ghcr.io/sillsdev/silnlp:latest
    ```
    * For Windows, use CMD Prompt
 
@@ -42,17 +42,38 @@ The SILNLP repo itself is hosted on Github, mainly written in Python and calls S
       
    In a terminal, run:
    ```
-   docker create -it --name silnlp ghcr.io/sillsdev/silnlp:0.1.2
+   docker create -it --name silnlp ghcr.io/sillsdev/silnlp:latest
    ```
 
-4. Start container
+4. Create file for environment variables
+
+   __If you do not intend to use SILNLP with ClearML and AWS, you can skip this step.__
    
+   Create a text file with the following content and insert your credentials.
+   ```
+   CLEARML_API_ACCESS_KEY=xxxxx
+   CLEARML_API_SECRET_KEY=xxxxx
+   AWS_ACCESS_KEY_ID=xxxxx
+   AWS_SECRET_ACCESS_KEY=xxxxx
+   ```
+   * Note that this does not give you direct access to an AWS S3 bucket from within the Docker container, it only allows you to run scripts referencing files in the bucket.
+
+5. Start container
+   
+   If you completed step 4: \
    In a terminal, run:
    ```
       docker start silnlp
-      docker exec -it silnlp bash
+      docker exec -it --env-file path/to/env_vars_file silnlp bash
    ```
-   * To leave the container, run ```exit```, and to stop it, run ```docker stop silnlp```. It can be started again by repeating the two lines above. Stopping the container will not erase any changes made in the container environment, but removing  it will.
+   If you did not complete step 4: \
+   In a terminal, run:
+   ```
+   docker start silnlp
+   docker exec -it silnlp bash
+   ```
+   * After this step, the terminal should change to say `root@xxxxx:~/silnlp#`, where `xxxxx` is a string of letters and numbers, instead of your current working directory. This is the command line for the docker container, and you're able to run SILNLP scripts from here.
+   * To leave the container, run `exit`, and to stop it, run `docker stop silnlp`. It can be started again by repeating step 5. Stopping the container will not erase any changes made in the container environment, but removing  it will.
 
 ### Option 2: Manual Installation
 


### PR DESCRIPTION
- Switched to installing SILNLP source code because using the binaries was causing the scripts to fail. 
- Removed the AWS CLI from the image because it's not practical to access the S3 bucket from inside the container.
- Clarified some of the documentation and added instructions for using ClearML/AWS credentials

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/217)
<!-- Reviewable:end -->
