### PR TITLE
add support for copying paratext projects from S3 bucket

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -62,6 +62,7 @@ def main() -> None:
     # Which projects have data we can find?
     projects_found: Set[str] = set()
     for project in projects:
+        SIL_NLP_ENV.copy_pt_project_from_bucket(project)
         project_path = SIL_NLP_ENV.pt_projects_dir / project
         if project_path.is_dir():
             projects_found.add(project)


### PR DESCRIPTION
The extract_corpus script was failing when trying to access paratext projects from the S3 bucket because it expected the bucket to be mounted. I added support for copying paratext projects from the S3 bucket to the cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/223)
<!-- Reviewable:end -->
