### PR TITLE
Download paratext projects from S3 bucket to cache

### DIFF
--- a/silnlp/common/translate_google.py
+++ b/silnlp/common/translate_google.py
@@ -4,6 +4,7 @@ from typing import Iterable, Optional
 from google.cloud import translate_v2 as translate
 from machine.scripture import VerseRef, book_id_to_number
 
+from ..common.environment import SIL_NLP_ENV
 from .paratext import book_file_name_digits
 from .translator import Translator
 from .utils import get_git_revision_hash, get_mt_exp_dir
@@ -37,6 +38,9 @@ def main() -> None:
 
     get_git_revision_hash()
 
+    SIL_NLP_ENV.copy_experiment_from_bucket(args.experiment)
+    SIL_NLP_ENV.copy_pt_project_from_bucket(args.src_project)
+
     root_dir = get_mt_exp_dir(args.experiment)
     src_project: str = args.src_project
     book: str = args.book
@@ -50,6 +54,8 @@ def main() -> None:
 
     translator = GoogleTranslator()
     translator.translate_book(src_project, book, output_path, trg_iso)
+
+    SIL_NLP_ENV.copy_experiment_to_bucket(args.experiment)
 
 
 if __name__ == "__main__":

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -258,6 +258,8 @@ def main() -> None:
     if args.memory_growth:
         enable_memory_growth()
 
+    SIL_NLP_ENV.copy_pt_project_from_bucket(args.src_project)
+
     translator = TranslationTask(
         name=args.experiment,
         checkpoint=args.checkpoint,


### PR DESCRIPTION
Added `copy_pt_project_from_bucket()` to scripts that needed to download pt projects to cache, namely translate.py and translate_google.py. I also added `copy_experiment_from_bucket()` and `copy_experiment_to_bucket()` to translate_google.py since it was missing those.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/227)
<!-- Reviewable:end -->
