### PR TITLE
Fix inconsistencies between function signatures and calls

### DIFF
--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -569,7 +569,7 @@ def test(
             checkpoint_name = f"best checkpoint {step}"
         else:
             checkpoint_name = f"checkpoint {step}"
-        books_str = "ALL" if len(books) == 0 else ", ".join(map(lambda n: book_number_to_id(n), sorted(books)))
+        books_str = "ALL" if len(books_nums) == 0 else ", ".join(sorted(books_nums.keys()))
         LOGGER.info(f"Test results for {checkpoint_name} ({num_refs} reference(s), books: {books_str})")
         for score in results[step]:
             output = StringIO()
@@ -615,6 +615,11 @@ def main() -> None:
     if args.memory_growth:
         enable_memory_growth()
 
+    if len(args.books) == 1:
+        books = args.books[0].split(";")
+    else:
+        books = args.books
+
     test(
         args.experiment,
         checkpoint=args.checkpoint,
@@ -624,7 +629,7 @@ def main() -> None:
         ref_projects=set(args.ref_projects),
         force_infer=args.force_infer,
         scorers=set(s.lower() for s in args.scorers),
-        books=args.books,
+        books=books,
         by_book=args.by_book,
     )
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -321,7 +321,7 @@ def main() -> None:
             show_attrs(cli_args=args, actions=[f"Will attempt to translate books {args.books} into {args.trg_iso}"])
             exit()
         translator.translate_books(
-            args.books, args.src_project, args.trg_project, args.trg_iso, args.include_inline_elements
+            ";".join(args.books), args.src_project, args.trg_project, args.trg_iso, args.include_inline_elements
         )
     elif args.src_prefix is not None:
         if args.debug:


### PR DESCRIPTION
I fixed an overcorrection from my first patch that caused a new bug in the translate script and made an adjustment in the test script. Both were issues stemming from mismatches between function signature types and the types of what was actually being passed to the functions.