### PR TITLE
change default versification to English (versification 4)

### DIFF
--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -517,7 +517,7 @@ def detect_NT_versification(project_dir: str) -> List[VersificationType]:
 
 
 def check_versification(project_dir: str) -> Tuple[bool, List[VersificationType]]:
-    project_versification: str = parse_project_settings(project_dir).getroot().findtext("Versification", "0")
+    project_versification: str = parse_project_settings(project_dir).getroot().findtext("Versification", "4")
     project_versification: VersificationType = VersificationType(int(project_versification))
 
     check_ot, check_nt, matching = False, False, False


### PR DESCRIPTION
If a paratext versification setting is not included in the Settings.xml file for a project, the `check_versification()` function should assume the project is using the English versification (versification 4), since that is the default versification setting for paratext projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/257)
<!-- Reviewable:end -->
