### PR TITLE
ignore OccursUnder in custom stylesheets when parsing book usfm

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -169,7 +169,7 @@ def get_stylesheet(project_path: Path) -> dict:
     if custom_stylesheet_path.exists():
         with custom_stylesheet_path.open("r", encoding="utf-8-sig") as file:
             custom_stylesheet = style.parse(file)
-        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet)
+        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, ignore_occurs_under=True)
     return usfm.relaxed_stylesheet
 
 

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -169,7 +169,7 @@ def get_stylesheet(project_path: Path) -> dict:
     if custom_stylesheet_path.exists():
         with custom_stylesheet_path.open("r", encoding="utf-8-sig") as file:
             custom_stylesheet = style.parse(file)
-        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, field_replace=style.FieldReplace.IGNORE)
+        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, field_update=style.FieldUpdate.IGNORE)
     return usfm.relaxed_stylesheet
 
 

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -169,7 +169,7 @@ def get_stylesheet(project_path: Path) -> dict:
     if custom_stylesheet_path.exists():
         with custom_stylesheet_path.open("r", encoding="utf-8-sig") as file:
             custom_stylesheet = style.parse(file)
-        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, ignore_occurs_under=True)
+        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, field_replace=style.FieldReplace.IGNORE)
     return usfm.relaxed_stylesheet
 
 

--- a/silnlp/sfm/style.py
+++ b/silnlp/sfm/style.py
@@ -195,7 +195,7 @@ def _reify(sheet):
                 r[f] = str(v)
 
 
-def update_sheet(sheet, ammendments={}, field_replace=False, **kwds):
+def update_sheet(sheet, ammendments={}, field_replace=False, ignore_occurs_under=False, **kwds):
     """
     Merge update an existing sheet with records from a supplied dictionary and
     any keyword arguments as well. Only non defaulted fields for each record
@@ -266,7 +266,10 @@ def update_sheet(sheet, ammendments={}, field_replace=False, **kwds):
         try:
             meta = sheet[marker]
             if not field_replace:
-                meta["OccursUnder"].update(new_meta.pop("OccursUnder", set()))
+                if ignore_occurs_under:
+                    new_meta.pop("OccursUnder")
+                else:
+                    meta["OccursUnder"].update(new_meta.pop("OccursUnder", set()))
                 meta["TextProperties"].update(new_meta.pop("TextProperties", set()))
             meta.update(fv for fv in new_meta.items() if fv[0] not in _fields or fv[1] != _fields[fv[0]][1])
         except KeyError:

--- a/silnlp/sfm/style.py
+++ b/silnlp/sfm/style.py
@@ -32,7 +32,7 @@ def _munge_records(rs):
     yield from ((r.pop("Marker").lstrip(), r) for r in rs)
 
 
-class FieldReplace(Enum):
+class FieldUpdate(Enum):
     REPLACE = 1
     MERGE = 2
     IGNORE = 3
@@ -202,7 +202,7 @@ def _reify(sheet):
                 r[f] = str(v)
 
 
-def update_sheet(sheet, ammendments={}, field_replace=FieldReplace.MERGE, **kwds):
+def update_sheet(sheet, ammendments={}, field_update=FieldUpdate.MERGE, **kwds):
     """
     Merge update an existing sheet with records from a supplied dictionary and
     any keyword arguments as well. Only non defaulted fields for each record
@@ -215,8 +215,9 @@ def update_sheet(sheet, ammendments={}, field_replace=FieldReplace.MERGE, **kwds
     sheet: The sheet to be updated.
     ammendments: A Mapping from marker names to marker records continaing
         the fields to be updated.
-    field_replace: When True replace OccursUnder and TextProperties.
-        When False merge them instead. Defaults to False.
+    field_update: When Replace, replace OccursUnder and TextProperties.
+        When Merge, merge update OccursUnder and TextProperties. Defaults to Merge.
+        When Ignore, don't update OccursUnder and TextProperties.
     **kwds: marker id keywords assigned to marker records continaing
         the fields to be updated.
     >>> from pprint import pprint
@@ -272,10 +273,10 @@ def update_sheet(sheet, ammendments={}, field_replace=FieldReplace.MERGE, **kwds
     for marker, new_meta in ammendments.items():
         try:
             meta = sheet[marker]
-            if field_replace == FieldReplace.IGNORE:
+            if field_update == FieldUpdate.IGNORE:
                 new_meta.pop("OccursUnder")
                 new_meta.pop("TextProperties")
-            elif field_replace == FieldReplace.MERGE:
+            elif field_update == FieldUpdate.MERGE:
                 meta["OccursUnder"].update(new_meta.pop("OccursUnder", set()))
                 meta["TextProperties"].update(new_meta.pop("TextProperties", set()))
             meta.update(fv for fv in new_meta.items() if fv[0] not in _fields or fv[1] != _fields[fv[0]][1])

--- a/silnlp/sfm/usfm.py
+++ b/silnlp/sfm/usfm.py
@@ -326,7 +326,9 @@ class parser(sfm.parser):
             ).copy()
             for n, m in private_metas.items()
         }
-        return style.update_sheet(sty, style.update_sheet(metas, private_metas))
+        return style.update_sheet(
+            sty, style.update_sheet(metas, private_metas, ignore_occurs_under=True), ignore_occurs_under=True
+        )
 
     def _force_close(self, parent, tok):
         if tok is not sfm.parser._eos and (

--- a/silnlp/sfm/usfm.py
+++ b/silnlp/sfm/usfm.py
@@ -328,8 +328,8 @@ class parser(sfm.parser):
         }
         return style.update_sheet(
             sty,
-            style.update_sheet(metas, private_metas, field_replace=style.FieldReplace.IGNORE),
-            field_replace=style.FieldReplace.IGNORE,
+            style.update_sheet(metas, private_metas, field_update=style.FieldUpdate.IGNORE),
+            field_update=style.FieldUpdate.IGNORE,
         )
 
     def _force_close(self, parent, tok):

--- a/silnlp/sfm/usfm.py
+++ b/silnlp/sfm/usfm.py
@@ -327,7 +327,9 @@ class parser(sfm.parser):
             for n, m in private_metas.items()
         }
         return style.update_sheet(
-            sty, style.update_sheet(metas, private_metas, ignore_occurs_under=True), ignore_occurs_under=True
+            sty,
+            style.update_sheet(metas, private_metas, field_replace=style.FieldReplace.IGNORE),
+            field_replace=style.FieldReplace.IGNORE,
         )
 
     def _force_close(self, parent, tok):


### PR DESCRIPTION
This change adds the parameter `ignore_occurs_under` to `update_sheet()` in style.py, with the default set to `False`. When set to `True`, `update_sheet()` ignores `OccursUnder` in custom stylesheets to prevent any parsing issues in `collect_segments_from_paragraph()`.  I set the option to `True` in every place where it is called when translating a book, and it is now handling the `\b` markers correctly in NIV84.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/269)
<!-- Reviewable:end -->
