### PR TITLE
Add special tokens for custom tags

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1040,7 +1040,7 @@ class HuggingFaceTokenizer(Tokenizer):
         if not add_dummy_prefix:
             tokens.remove("▁")
             tokens.remove("\ufffc")
-        return " ".join([t.strip() for t in tokens])
+        return " ".join(t.strip() for t in tokens)
 
     def normalize_normalized_string(self, line: NormalizedString) -> None:
         line.replace(Regex(".+"), self._mpn.normalize(str(line.normalized)))

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -15,7 +15,7 @@ import yaml
 from datasets import Dataset
 from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef
 from sacremoses import MosesPunctNormalizer
-from tokenizers import NormalizedString, Regex, SentencePieceBPETokenizer
+from tokenizers import AddedToken, NormalizedString, Regex, SentencePieceBPETokenizer
 from tokenizers.normalizers import Normalizer
 from torch import Tensor, TensorType, nn, optim
 from torch.utils.checkpoint import checkpoint  # noqa: 401
@@ -425,9 +425,7 @@ class HuggingFaceConfig(Config):
                 self._tokenizer.save_pretrained(self.exp_dir)
 
         if len(self._tags) > 0:
-            self._tokenizer.add_special_tokens(
-                {"additional_special_tokens": list(self._tags)}, replace_additional_special_tokens=False
-            )
+            self._tokenizer.add_tokens([AddedToken(tag, rstrip=True, special=True) for tag in self._tags])
 
     def get_or_create_tokenizer(self) -> PreTrainedTokenizer:
         if self._tokenizer is None:
@@ -1042,7 +1040,7 @@ class HuggingFaceTokenizer(Tokenizer):
         if not add_dummy_prefix:
             tokens.remove("▁")
             tokens.remove("\ufffc")
-        return " ".join(tokens)
+        return " ".join([t.strip() for t in tokens])
 
     def normalize_normalized_string(self, line: NormalizedString) -> None:
         line.replace(Regex(".+"), self._mpn.normalize(str(line.normalized)))

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -424,6 +424,11 @@ class HuggingFaceConfig(Config):
             if updated:
                 self._tokenizer.save_pretrained(self.exp_dir)
 
+        if len(self._tags) > 0:
+            self._tokenizer.add_special_tokens(
+                {"additional_special_tokens": list(self._tags)}, replace_additional_special_tokens=False
+            )
+
     def get_or_create_tokenizer(self) -> PreTrainedTokenizer:
         if self._tokenizer is None:
             tok_dict = self.data.get("tokenizer")


### PR DESCRIPTION
With multiple custom tags, space tokens are inserted between each one (e.g. "\<first\> _ \<second\> _ \<third\>"). Is that ok?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/270)
<!-- Reviewable:end -->
