### PR TITLE
Change SILClearML contructor logic to allow for deeper directories

### DIFF
--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -25,10 +25,9 @@ class SILClearML:
         self.name = self.name.replace("\\", "/")
         name_parts = self.name.split("/")
         project = name_parts[0]
-        if len(name_parts) == 1:
-            exp_name = name_parts[0]
-        else:
-            exp_name = name_parts[1]
+        exp_name = name_parts[-1]
+        if len(name_parts) > 2:
+            exp_name = '/'.join(name_parts[1:])
         if self.queue_name is None:
             self.task = None
             self._load_config()


### PR DESCRIPTION
This might be a design choice, and if it is, feel free to shoot this idea down (or at least this re-implementation of the logic), but it would be very helpful in the case of clowder (and I imagine other places as well) to be able to have an experiment more than 2 directories deep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/275)
<!-- Reviewable:end -->
