### PR TITLE
Add commit arg

### DIFF
--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -20,6 +20,7 @@ class SILClearML:
     project_suffix: str = ""
     experiment_suffix: str = ""
     clearml_project_folder: str = ""
+    commit: Optional[str] = None
 
     def __post_init__(self) -> None:
         self.name = self.name.replace("\\", "/")
@@ -39,6 +40,7 @@ class SILClearML:
         from clearml.backend_api.session.session import LoginError
 
         try:
+            self.task: Task
             self.task = Task.init(
                 project_name=self.project_prefix + project + self.project_suffix,
                 task_name=exp_name + self.experiment_suffix,
@@ -58,6 +60,8 @@ class SILClearML:
                     "pipx install poetry==1.7.1",
                 ],
             )
+            if self.commit:
+                self.task.set_script(commit=self.commit)
             if self.queue_name.lower() not in ("local", "locally"):
                 self.task.execute_remotely(queue_name=self.queue_name)
         except LoginError as e:

--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -40,8 +40,7 @@ class SILClearML:
         from clearml.backend_api.session.session import LoginError
 
         try:
-            self.task: Task
-            self.task = Task.init(
+            self.task: Task = Task.init(
                 project_name=self.project_prefix + project + self.project_suffix,
                 task_name=exp_name + self.experiment_suffix,
             )

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -24,9 +24,10 @@ class SILExperiment:
     run_train: bool = False
     run_test: bool = False
     score_by_book: bool = False
+    commit: Optional[str] = None
 
     def __post_init__(self):
-        self.clearml = SILClearML(self.name, self.clearml_queue)
+        self.clearml = SILClearML(self.name, self.clearml_queue, commit=self.commit)
         self.name: str = self.clearml.name
         self.config: Config = self.clearml.config
         self.rev_hash = get_git_revision_hash()
@@ -104,6 +105,7 @@ def main() -> None:
         action="store_true",
         help="Show information about the environment variables and arguments.",
     )
+    parser.add_argument('--commit',type=str, default=None,help="The git commit id of silnlp with which to run the remote job")
 
     args = parser.parse_args()
 
@@ -133,6 +135,7 @@ def main() -> None:
         run_train=args.train,
         run_test=args.test,
         score_by_book=args.score_by_book,
+        commit=args.commit
     )
     exp.run()
 

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -105,7 +105,7 @@ def main() -> None:
         action="store_true",
         help="Show information about the environment variables and arguments.",
     )
-    parser.add_argument('--commit',type=str, default=None,help="The git commit id of silnlp with which to run the remote job")
+    parser.add_argument('--commit',type=str, default=None,help="The silnlp git commit id with which to run a remote job")
 
     args = parser.parse_args()
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -308,7 +308,7 @@ def main() -> None:
         action="store_true",
         help="Show information about the environment variables and arguments.",
     )
-    parser.add_argument('--commit',type=str, default=None,help="The git commit id of silnlp with which to run the remote job")
+    parser.add_argument('--commit',type=str, default=None,help="The silnlp git commit id with which to run a remote job")
 
     args = parser.parse_args()
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -35,6 +35,7 @@ class TranslationTask:
     name: str
     checkpoint: str = "last"
     clearml_queue: Optional[str] = None
+    commit: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.checkpoint is None:
@@ -232,6 +233,7 @@ class TranslationTask:
             self.clearml_queue,
             project_suffix="_infer",
             experiment_suffix=experiment_suffix,
+            commit=self.commit
         )
         self.name = clearml.name
 
@@ -306,6 +308,8 @@ def main() -> None:
         action="store_true",
         help="Show information about the environment variables and arguments.",
     )
+    parser.add_argument('--commit',type=str, default=None,help="The git commit id of silnlp with which to run the remote job")
+
     args = parser.parse_args()
 
     get_git_revision_hash()
@@ -320,6 +324,7 @@ def main() -> None:
         name=args.experiment,
         checkpoint=args.checkpoint,
         clearml_queue=args.clearml_queue,
+        commit=args.commit
     )
 
     if len(args.books) > 0:


### PR DESCRIPTION
Added `--commit` command-line argument to specify the commit with which to run the job on ClearML. This is particularly useful for clowder (i.e., can compare jobs across commits).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/281)
<!-- Reviewable:end -->
