### PR TITLE
Add argument in translate script for how to handle custom stylesheets

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -165,13 +165,9 @@ def update_segments(segments: List[Segment], translations: List[str]) -> None:
 
 
 def get_stylesheet(project_path: Path, field_update: str = "merge") -> dict:
-    if field_update.lower() == "replace":
-        field_update = style.FieldUpdate.REPLACE
-    elif field_update.lower() == "merge":
-        field_update = style.FieldUpdate.MERGE
-    elif field_update.lower() == "ignore":
-        field_update = style.FieldUpdate.IGNORE
-    else:
+    try:
+        field_update: style.FieldUpdate = style.FieldUpdate[field_update.upper()]
+    except Exception:
         raise ValueError(
             f"{field_update} is not a valid value for field_update. Must be one of 'replace', 'merge', or 'ignore'."
         )

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -164,12 +164,23 @@ def update_segments(segments: List[Segment], translations: List[str]) -> None:
             first_para.elem.insert(first_para.child_indices[0], sfm.Text(translation, parent=first_para.elem))
 
 
-def get_stylesheet(project_path: Path) -> dict:
+def get_stylesheet(project_path: Path, field_update: str = "merge") -> dict:
+    if field_update.lower() == "replace":
+        field_update = style.FieldUpdate.REPLACE
+    elif field_update.lower() == "merge":
+        field_update = style.FieldUpdate.MERGE
+    elif field_update.lower() == "ignore":
+        field_update = style.FieldUpdate.IGNORE
+    else:
+        raise ValueError(
+            f"{field_update} is not a valid value for field_update. Must be one of 'replace', 'merge', or 'ignore'."
+        )
+
     custom_stylesheet_path = project_path / "custom.sty"
     if custom_stylesheet_path.exists():
         with custom_stylesheet_path.open("r", encoding="utf-8-sig") as file:
             custom_stylesheet = style.parse(file)
-        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, field_update=style.FieldUpdate.IGNORE)
+        return style.update_sheet(usfm.relaxed_stylesheet, custom_stylesheet, field_update=field_update)
     return usfm.relaxed_stylesheet
 
 
@@ -275,6 +286,7 @@ class Translator(ABC):
         chapters: List[int] = [],
         trg_project: str = "",
         include_inline_elements: bool = False,
+        stylesheet_field_update: str = "merge",
         experiment_ckpt_str: str = "",
     ) -> None:
         src_project_dir = get_project_dir(src_project)
@@ -282,7 +294,7 @@ class Translator(ABC):
             settings_tree = etree.parse(settings_file)
         src_iso = get_iso(settings_tree)
         book_path = get_book_path(src_project, book)
-        stylesheet = get_stylesheet(src_project_dir)
+        stylesheet = get_stylesheet(src_project_dir, stylesheet_field_update)
 
         if not book_path.is_file():
             raise RuntimeError(f"Can't find file {book_path} for book {book}")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -47,6 +47,7 @@ class TranslationTask:
         trg_project: Optional[str],
         trg_iso: Optional[str],
         include_inline_elements: bool = False,
+        stylesheet_field_update: str = "merge",
     ):
         book_nums = get_chapters(books)
         translator, config, step_str = self._init_translation_task(
@@ -106,6 +107,7 @@ class TranslationTask:
                         chapters,
                         trg_project,
                         include_inline_elements,
+                        stylesheet_field_update,
                         f"{self.name}:{self.checkpoint}",
                     )
                 else:
@@ -117,6 +119,7 @@ class TranslationTask:
                         trg_iso,
                         chapters,
                         include_inline_elements=include_inline_elements,
+                        stylesheet_field_update=stylesheet_field_update,
                         experiment_ckpt_str=f"{self.name}:{self.checkpoint}",
                     )
             except Exception as e:
@@ -288,6 +291,12 @@ def main() -> None:
         help="Include inline elements for projects in USFM format",
     )
     parser.add_argument(
+        "--stylesheet-field-update",
+        default="merge",
+        type=str,
+        help="What to do with the OccursUnder and TextProperties fields of a project's custom stylesheet. Possible values are 'replace', 'merge', and 'ignore'.",
+    )
+    parser.add_argument(
         "--eager-execution",
         default=False,
         action="store_true",
@@ -327,7 +336,12 @@ def main() -> None:
             show_attrs(cli_args=args, actions=[f"Will attempt to translate books {args.books} into {args.trg_iso}"])
             exit()
         translator.translate_books(
-            ";".join(args.books), args.src_project, args.trg_project, args.trg_iso, args.include_inline_elements
+            ";".join(args.books),
+            args.src_project,
+            args.trg_project,
+            args.trg_iso,
+            args.include_inline_elements,
+            args.stylesheet_field_update,
         )
     elif args.src_prefix is not None:
         if args.debug:


### PR DESCRIPTION
There are a few individual projects that need to handle custom stylesheets differently. In #269, the change was made to ignore the OccursUnder and TextProperties fields by default to handle a parsing issue with the NIV84. With the ONAV, the updates to these fields need to be merged for correct parsing. This adds a command line argument to choose how to handle these fields, with merging being the default as it was previously.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/282)
<!-- Reviewable:end -->
