### PR TITLE
Force 16-bit inference when using mixed precision

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -834,7 +834,7 @@ class HuggingFaceNMTModel(NMTModel):
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
     ) -> None:
         checkpoint_path, _ = self.get_checkpoint_path(ckpt)
-        model: PreTrainedModel = AutoModelForSeq2SeqLM.from_pretrained(str(checkpoint_path))
+        model: PreTrainedModel = AutoModelForSeq2SeqLM.from_pretrained(str(checkpoint_path), torch_dtype=torch.float16 if self._mixed_precision else "auto")
         if self._config.infer.get("better_transformer"):
             model = model.to_bettertransformer()
         tokenizer = self._config.get_tokenizer()
@@ -883,7 +883,7 @@ class HuggingFaceNMTModel(NMTModel):
             model_name = str(checkpoint_path)
         else:
             model_name = self._config.model
-        model: PreTrainedModel = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+        model: PreTrainedModel = AutoModelForSeq2SeqLM.from_pretrained(model_name, torch_dtype=torch.float16 if self._mixed_precision else "auto")
         if self._config.infer.get("better_transformer"):
             model = model.to_bettertransformer()
         if model.config.max_length < 512:


### PR DESCRIPTION
When running the tests on their own, memory usage was ~10% with `torch_dtype=torch.float16` vs ~25% without for all 4 experiments. Additionally, inferencing was around 20 seconds faster for each 8-10 minute test. The BLEU scores were unchanged, though I was still seeing the weird 5 point bump in score for the one experiment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/304)
<!-- Reviewable:end -->
