### PR TITLE
Use torch.compile() when inferencing

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -849,6 +849,7 @@ class HuggingFaceNMTModel(NMTModel):
             tgt_lang=self._config.test_trg_lang,
             device=0,
         )
+        pipeline.model = torch.compile(pipeline.model)
         for input_path, translation_path, vref_path in zip(
             input_paths,
             translation_paths,
@@ -901,6 +902,7 @@ class HuggingFaceNMTModel(NMTModel):
             tgt_lang=lang_codes.get(trg_iso, trg_iso),
             device=0,
         )
+        pipeline.model = torch.compile(pipeline.model)
         if not isinstance(sentences, list):
             sentences = list(sentences)
         for outputs in tqdm(


### PR DESCRIPTION
Using torch.compile() with the default backend `inductor` causes inferencing to run slightly faster (average of 3.5% improvement across 5 tests) with no impact on memory usage or BLEU score. I also ran tests with other backends (`openxla_eval`, `onnxrt`, `cudagraphs`, and `tvm`), but they all slowed down inferencing.

Compiling after the model is in the pipeline is equivalent to compiling directly after the model is created, but it prevents an irrelevant warning message from appearing.