### PR TITLE
always create tokenization_stats files in _build_vocabs();_calculate_tokenization_stats() should work even if no stats file exists

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -534,7 +534,10 @@ class Config(ABC):
         LOGGER.info("Calculating tokenization statistics")
 
         stats_path = self.exp_dir / "tokenization_stats.csv"
-        existing_stats = pd.read_csv(stats_path, header=[0, 1])
+        if stats_path.is_file():
+            existing_stats = pd.read_csv(stats_path, header=[0, 1])
+        else:
+            existing_stats = pd.DataFrame({(" ", "Translation Side"): ["Source", "Target"]})
 
         src_tokens_per_verse, src_chars_per_token = [], []
         for src_tok_file in self.exp_dir.glob("*.src.txt"):


### PR DESCRIPTION
No tokenization_stats file was being created when the tokenizer was not set to be updated in the config, causing the later _calculate_tokenization_stats() to fail since it depended on that file existing. I've adjusted the code so that it always creates the file and saves the statistics for added tokens in _build_vocabs() even if the tokenizer is not set to be updated. I've also added a check in _calculate_tokenization_stats() to make sure the file exists first, and if not to use a default dataframe containing just the column with the labels "source" and "target".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/315)
<!-- Reviewable:end -->
