### PR TITLE
Fix bug when adding multiple language codes

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -201,7 +201,7 @@ def delete_tokenizer(checkpoint_path: Path) -> None:
 
 
 def add_lang_code_to_tokenizer(tokenizer: PreTrainedTokenizer, lang_code: str) -> None:
-    tokenizer.add_special_tokens({"additional_special_tokens": tokenizer.additional_special_tokens + [lang_code]})
+    tokenizer.add_special_tokens({"additional_special_tokens": [lang_code]}, replace_additional_special_tokens=False)
     lang_id = tokenizer.convert_tokens_to_ids(lang_code)
     if not isinstance(tokenizer, (T5Tokenizer, T5TokenizerFast)):
         tokenizer.lang_code_to_id[lang_code] = lang_id


### PR DESCRIPTION
`add_special_tokens` will not add a token if that token is already in the special tokens, and since the default behavior is to replace the whole special tokens list with the new list, passing the current list of special tokens effectively cancels them out, leaving only the most recent token. This was fine before because only one new language code is typically added for NLLB experiments, but for MADLAD, language codes are not special tokens by default and so adding both the source and target language causes the issue.

I'm actually going to stop adding the source language token for MADLAD because it isn't used, but the fix is still needed for any time >1 new language code is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/331)
<!-- Reviewable:end -->
