### PR TITLE
Add support for French and Indonesian key terms glosses

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -206,6 +206,9 @@ def parse_corpus_pairs(corpus_pairs: List[dict]) -> List[CorpusPair]:
 
         src_terms_files = get_terms_files(src_files) if is_set(type, DataFileType.TRAIN) else []
         trg_terms_files = get_terms_files(trg_files) if is_set(type, DataFileType.TRAIN) else []
+        print(f'This is the output of get_terms_files: {get_terms_files(src_files)}')
+        print(f'This is the output of the the conditional: {is_set(type, DataFileType.TRAIN)}')
+        print(f'Source terms files: {src_terms_files} \n Trg terms files: {trg_terms_files}')
 
         if "lexical" not in pair:
             pair["lexical"] = is_set(type, DataFileType.DICT)

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -370,11 +370,18 @@ class Config(ABC):
                 self.src_projects.update(sf.project for sf in corpus_pair.src_files)
                 self.trg_projects.update(sf.project for sf in corpus_pair.trg_files)
                 if terms_config["include_glosses"]:
-                    if "en" in pair_src_isos:
+                    print(f'pair_src_isos is {pair_src_isos}')
+                    if "en" in pair_src_isos or "fr" in pair_src_isos:
                         self.src_file_paths.update(get_terms_glosses_file_paths(corpus_pair.src_terms_files))
-                    if "en" in pair_trg_isos:
+                        print(f'corpus_pair.src_terms_files is {corpus_pair.src_terms_files}')
+                        ## this one below is getting empty input and giving empty output:
+                        print(f'get_terms_glosses_file_paths output is {get_terms_glosses_file_paths(corpus_pair.src_terms_files)}')
+                    if "en" in pair_trg_isos or "fr" in pair_trg_isos:
                         self.trg_file_paths.update(get_terms_glosses_file_paths(corpus_pair.trg_terms_files))
             self._tags.update(f"<{tag}>" for tag in corpus_pair.tags)
+
+            print(f'src_files contains {corpus_pair.src_files}')
+            print(f'trg_files contains {corpus_pair.trg_files}')
 
             for src_file in corpus_pair.src_files:
                 for trg_file in corpus_pair.trg_files:
@@ -816,10 +823,12 @@ class Config(ABC):
             )
 
         terms_config = self.data["terms"]
+        print(f'self.data[\'terms\'] terms here in 826 is {self.data["terms"]}')
         terms_train_count = 0
         if terms_config["train"]:
             terms_train_count = self._write_terms(tokenizer, pair, tags_str)
         train_count += terms_train_count
+        print(f'terms_train_count is {terms_train_count}')
 
         dict_count = 0
         if terms_config["dictionary"]:
@@ -1066,6 +1075,8 @@ class Config(ABC):
         if categories is not None and len(categories) == 0:
             return None
         categories_set: Optional[Set[str]] = None if categories is None else set(categories)
+        print(f'scr_terms_files are {pair.src_terms_files}')
+        print(f'trg_terms_files are {pair.trg_terms_files}')
         all_src_terms = [(src_terms_file, get_terms(src_terms_file.path)) for src_terms_file in pair.src_terms_files]
         all_trg_terms = [(trg_terms_file, get_terms(trg_terms_file.path)) for trg_terms_file in pair.trg_terms_files]
         for src_terms_file, src_terms in all_src_terms:
@@ -1089,6 +1100,14 @@ class Config(ABC):
                     cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
                     cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
                     cur_terms["source_lang"] = "en"
+                    cur_terms["target_lang"] = trg_terms_file.iso
+                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
+            if "fr" in self.src_isos:
+                print('yep')
+                for trg_terms_file, trg_terms in all_trg_terms:
+                    cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
+                    cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
+                    cur_terms["source_lang"] = "fr"
                     cur_terms["target_lang"] = trg_terms_file.iso
                     terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
         return terms

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -367,10 +367,11 @@ class Config(ABC):
                 self.src_projects.update(sf.project for sf in corpus_pair.src_files)
                 self.trg_projects.update(sf.project for sf in corpus_pair.trg_files)
                 if terms_config["include_glosses"]:
-                    if "en" in pair_src_isos or "fr" in pair_src_isos:
-                        self.src_file_paths.update(get_terms_glosses_file_paths(corpus_pair.src_terms_files))
-                    if "en" in pair_trg_isos or "fr" in pair_trg_isos:
-                        self.trg_file_paths.update(get_terms_glosses_file_paths(corpus_pair.trg_terms_files))
+                    for gloss_iso in ["fr","en","id"]:
+                        if gloss_iso in pair_src_isos:
+                            self.src_file_paths.update(get_terms_glosses_file_paths(corpus_pair.src_terms_files))
+                        if gloss_iso in pair_trg_isos:
+                            self.trg_file_paths.update(get_terms_glosses_file_paths(corpus_pair.trg_terms_files))
             self._tags.update(f"<{tag}>" for tag in corpus_pair.tags)
 
             for src_file in corpus_pair.src_files:
@@ -1074,34 +1075,21 @@ class Config(ABC):
                 cur_terms["target_lang"] = trg_terms_file.iso
                 terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
         if terms_config["include_glosses"]:
-            if "en" in self.trg_isos:
-                for src_terms_file, src_terms in all_src_terms:
-                    cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
-                    cur_terms = cur_terms.rename(columns={"rendering": "source", "gloss": "target"})
-                    cur_terms["source_lang"] = src_terms_file.iso
-                    cur_terms["target_lang"] = "en"
-                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
-            if "en" in self.src_isos:
-                for trg_terms_file, trg_terms in all_trg_terms:
-                    cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
-                    cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
-                    cur_terms["source_lang"] = "en"
-                    cur_terms["target_lang"] = trg_terms_file.iso
-                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
-            if "fr" in self.trg_isos:
-                for src_terms_file, src_terms in all_src_terms:
-                    cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
-                    cur_terms = cur_terms.rename(columns={"rendering": "source", "gloss": "target"})
-                    cur_terms["source_lang"] = src_terms_file.iso
-                    cur_terms["target_lang"] = "fr"
-                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
-            if "fr" in self.src_isos:
-                for trg_terms_file, trg_terms in all_trg_terms:
-                    cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
-                    cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
-                    cur_terms["source_lang"] = "fr"
-                    cur_terms["target_lang"] = trg_terms_file.iso
-                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
+            for gloss_iso in ["en", "fr", "id"]:
+                if gloss_iso in self.trg_isos:
+                    for src_terms_file, src_terms in all_src_terms:
+                        cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
+                        cur_terms = cur_terms.rename(columns={"rendering": "source", "gloss": "target"})
+                        cur_terms["source_lang"] = src_terms_file.iso
+                        cur_terms["target_lang"] = gloss_iso
+                        terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
+                if gloss_iso in self.src_isos:
+                    for trg_terms_file, trg_terms in all_trg_terms:
+                        cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
+                        cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
+                        cur_terms["source_lang"] = gloss_iso
+                        cur_terms["target_lang"] = trg_terms_file.iso
+                        terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
         return terms
         
     def _write_val_trg(self, tokenizer: Optional[Tokenizer], val: Dict[Tuple[str, str], pd.DataFrame]) -> None:

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -206,9 +206,6 @@ def parse_corpus_pairs(corpus_pairs: List[dict]) -> List[CorpusPair]:
 
         src_terms_files = get_terms_files(src_files) if is_set(type, DataFileType.TRAIN) else []
         trg_terms_files = get_terms_files(trg_files) if is_set(type, DataFileType.TRAIN) else []
-        print(f'This is the output of get_terms_files: {get_terms_files(src_files)}')
-        print(f'This is the output of the the conditional: {is_set(type, DataFileType.TRAIN)}')
-        print(f'Source terms files: {src_terms_files} \n Trg terms files: {trg_terms_files}')
 
         if "lexical" not in pair:
             pair["lexical"] = is_set(type, DataFileType.DICT)
@@ -370,18 +367,11 @@ class Config(ABC):
                 self.src_projects.update(sf.project for sf in corpus_pair.src_files)
                 self.trg_projects.update(sf.project for sf in corpus_pair.trg_files)
                 if terms_config["include_glosses"]:
-                    print(f'pair_src_isos is {pair_src_isos}')
                     if "en" in pair_src_isos or "fr" in pair_src_isos:
                         self.src_file_paths.update(get_terms_glosses_file_paths(corpus_pair.src_terms_files))
-                        print(f'corpus_pair.src_terms_files is {corpus_pair.src_terms_files}')
-                        ## this one below is getting empty input and giving empty output:
-                        print(f'get_terms_glosses_file_paths output is {get_terms_glosses_file_paths(corpus_pair.src_terms_files)}')
                     if "en" in pair_trg_isos or "fr" in pair_trg_isos:
                         self.trg_file_paths.update(get_terms_glosses_file_paths(corpus_pair.trg_terms_files))
             self._tags.update(f"<{tag}>" for tag in corpus_pair.tags)
-
-            print(f'src_files contains {corpus_pair.src_files}')
-            print(f'trg_files contains {corpus_pair.trg_files}')
 
             for src_file in corpus_pair.src_files:
                 for trg_file in corpus_pair.trg_files:
@@ -823,12 +813,10 @@ class Config(ABC):
             )
 
         terms_config = self.data["terms"]
-        print(f'self.data[\'terms\'] terms here in 826 is {self.data["terms"]}')
         terms_train_count = 0
         if terms_config["train"]:
             terms_train_count = self._write_terms(tokenizer, pair, tags_str)
         train_count += terms_train_count
-        print(f'terms_train_count is {terms_train_count}')
 
         dict_count = 0
         if terms_config["dictionary"]:
@@ -1075,8 +1063,6 @@ class Config(ABC):
         if categories is not None and len(categories) == 0:
             return None
         categories_set: Optional[Set[str]] = None if categories is None else set(categories)
-        print(f'scr_terms_files are {pair.src_terms_files}')
-        print(f'trg_terms_files are {pair.trg_terms_files}')
         all_src_terms = [(src_terms_file, get_terms(src_terms_file.path)) for src_terms_file in pair.src_terms_files]
         all_trg_terms = [(trg_terms_file, get_terms(trg_terms_file.path)) for trg_terms_file in pair.trg_terms_files]
         for src_terms_file, src_terms in all_src_terms:
@@ -1102,8 +1088,14 @@ class Config(ABC):
                     cur_terms["source_lang"] = "en"
                     cur_terms["target_lang"] = trg_terms_file.iso
                     terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
+            if "fr" in self.trg_isos:
+                for src_terms_file, src_terms in all_src_terms:
+                    cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
+                    cur_terms = cur_terms.rename(columns={"rendering": "source", "gloss": "target"})
+                    cur_terms["source_lang"] = src_terms_file.iso
+                    cur_terms["target_lang"] = "fr"
+                    terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
             if "fr" in self.src_isos:
-                print('yep')
                 for trg_terms_file, trg_terms in all_trg_terms:
                     cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
                     cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -1103,7 +1103,7 @@ class Config(ABC):
                     cur_terms["target_lang"] = trg_terms_file.iso
                     terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
         return terms
-
+        
     def _write_val_trg(self, tokenizer: Optional[Tokenizer], val: Dict[Tuple[str, str], pd.DataFrame]) -> None:
         with ExitStack() as stack:
             ref_files: List[TextIO] = []


### PR DESCRIPTION
This is a quick update for pulling the French and Indonesian glosses so that we can use terms renderings for French/Indo-sourced translations. There is one (French) project waiting for this feature. I'm not sure if this is how we want to handle this change. The original was hard-coded for English and this also uses a hard-coded list.  

Tested with the following corpora: 
English source only: S:\MT\experiments\FT-Dutch\BHM_Test_terms
French source only: S:\MT\experiments\FT-Benin\NLLB.1.3B.dist.fr_LBS21-ddn_DDN2_Terms
Indonesian source only: S:\MT\experiments\FT-Indonesian2\NLLB1.3B.id_TBI+DAABT-kzfDAAU8_Terms
Indonesian+English sources: S:\MT\experiments\FT-Indonesian2\NLLB1.3B.en_BSB+id_DAABT-kzfDAAU8_Terms 
 --> Pulled twice as many terms as the Indonesian-only version, with glosses for both languages

(I don't seem to have the ability to attach this to the silnlp project like Matthew recommended.)