### PR TITLE
Add default learning rate for T5 models

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1002,6 +1002,8 @@ class HuggingFaceNMTModel(NMTModel):
         merge_dict(args, {"fp16": self._mixed_precision and not self._is_t5, 
                           "bf16": self._mixed_precision and self._is_t5, 
                           "tf32": self._mixed_precision})
+        if self._is_t5 and "learning_rate" not in args.keys():
+            args["learning_rate"] = 3e-4
         return parser.parse_dict(args)[0]
 
     def _get_dictionary(self) -> Dict[VerseRef, Set[str]]:


### PR DESCRIPTION
This isn't necessarily the best learning rate for all T5 models, but the documentation that suggested a higher learning rate would be better was talking about T5 models in general.

For the experiment I was testing with, increasing the learning rate resulted in a BLEU score bump of 8 (+14.6%) in 3k less steps/2 hours less.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/336)
<!-- Reviewable:end -->
