### PR TITLE
Fix bug in get_last_verse

### DIFF
--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -449,7 +449,7 @@ def get_last_verse(project_dir: str, book: str, chapter: int) -> int:
     last_verse = "0"
     book_path = get_book_path(project_dir, book)
     try:
-        with book_path.open("r", encoding="utf-8", newline="\n") as book_file:
+        with book_path.open("r", encoding="utf-8", newline="\n", errors="ignore") as book_file:
             in_chapter = False
             for line in book_file:
                 chapter_marker = re.search(r"\\c ? ?([0-9]+).*", line)


### PR DESCRIPTION
Bethany had an issue like #340 as well. I was able to resolve the issue for that project by using the project's encoding, but the same did not work for the KBTFRA project because there was another error of the same type when using the project's encoding. Ignoring the errors should solve the problem because not every character needs to be present to determine the versification.