### PR TITLE
Implement chrF3+ and chrF3++ as scorers and early stopping metrics

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -1,8 +1,8 @@
 import argparse
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 import yaml
 
 from ..common.environment import SIL_NLP_ENV
@@ -10,7 +10,7 @@ from ..common.tf_utils import enable_memory_growth
 from ..common.utils import get_git_revision_hash, show_attrs
 from .clearml_connection import SILClearML
 from .config import Config, get_mt_exp_dir
-from .test import test
+from .test import test, _SUPPORTED_SCORERS
 from .translate import TranslationTask
 
 
@@ -27,6 +27,7 @@ class SILExperiment:
     run_train: bool = False
     run_test: bool = False
     run_translate: bool = False
+    scorers: Set[str] = field(default_factory=set)
     score_by_book: bool = False
     commit: Optional[str] = None
 
@@ -79,7 +80,7 @@ class SILExperiment:
             last=self.config.model_dir.exists(),
             best=self.config.model_dir.exists(),
             by_book=self.score_by_book,
-            scorers={"bleu", "sentencebleu", "chrf3", "wer", "ter", "spbleu"},
+            scorers=self.scorers.union({"bleu", "sentencebleu", "chrf3", "wer", "ter", "spbleu"}),
         )
         SIL_NLP_ENV.copy_experiment_to_bucket(
             self.name, patterns=("scores-*.csv", "test.*trg-predictions.*"), overwrite=True
@@ -158,6 +159,14 @@ def main() -> None:
     parser.add_argument(
         "--commit", type=str, default=None, help="The silnlp git commit id with which to run a remote job"
     )
+    parser.add_argument(
+        "--scorers",
+        nargs="*",
+        metavar="scorer",
+        choices=_SUPPORTED_SCORERS,
+        default=[],
+        help=f"List of scorers - {_SUPPORTED_SCORERS}",
+    )
 
     args = parser.parse_args()
 
@@ -188,6 +197,7 @@ def main() -> None:
         run_train=args.train,
         run_test=args.test,
         run_translate=args.translate,
+        scorers=set(s.lower() for s in args.scorers),
         score_by_book=args.score_by_book,
         commit=args.commit,
     )

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -80,7 +80,7 @@ class SILExperiment:
             last=self.config.model_dir.exists(),
             best=self.config.model_dir.exists(),
             by_book=self.score_by_book,
-            scorers=self.scorers.union({"bleu", "sentencebleu", "chrf3", "wer", "ter", "spbleu"}),
+            scorers=self.scorers,
         )
         SIL_NLP_ENV.copy_experiment_to_bucket(
             self.name, patterns=("scores-*.csv", "test.*trg-predictions.*"), overwrite=True
@@ -164,7 +164,7 @@ def main() -> None:
         nargs="*",
         metavar="scorer",
         choices=_SUPPORTED_SCORERS,
-        default=[],
+        default=["bleu", "sentencebleu", "chrf3", "chrf3++", "wer", "ter", "spbleu"],
         help=f"List of scorers - {_SUPPORTED_SCORERS}",
     )
 

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__package__ + ".test")
 
 logging.getLogger("sacrebleu").setLevel(logging.ERROR)
 
-_SUPPORTED_SCORERS = {"bleu", "sentencebleu", "chrf3", "meteor", "wer", "ter", "spbleu"}
+_SUPPORTED_SCORERS = {"bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "meteor", "wer", "ter", "spbleu"}
 
 
 class PairScore:
@@ -94,6 +94,14 @@ def score_pair(
     if "chrf3" in scorers:
         chrf3_score = sacrebleu.corpus_chrf(pair_sys, pair_refs, char_order=6, beta=3, remove_whitespace=True)
         other_scores["CHRF3"] = chrf3_score.score
+
+    if "chrf3+" in scorers:
+        chrfp_score = sacrebleu.corpus_chrf(pair_sys, pair_refs, char_order=6, beta=3, word_order=1, remove_whitespace=True, eps_smoothing=True)
+        other_scores["CHRF3+"] = chrfp_score.score
+
+    if "chrf3++" in scorers:
+        chrfpp_score = sacrebleu.corpus_chrf(pair_sys, pair_refs, char_order=6, beta=3, word_order=2, remove_whitespace=True, eps_smoothing=True)
+        other_scores["CHRF3++"] = chrfpp_score.score
 
     if "meteor" in scorers:
         meteor_score = compute_meteor_score(trg_iso, pair_sys, pair_refs)


### PR DESCRIPTION
The names of the new scorers are `chrf3+` and `chrf3++`. I also copied over the `--scorers` option to `experiment.py` from the test script, but unlike the test script, the standard set of scorers will always be used and any additional scorers specified like `chrf3++` will be added.

`chrf3`, `chrf3+`, and `chrf3++` can be passed as values of `metric_for_best_model` in the eval section of a config to be used as the eval/early stopping metric. Investigation may need to be done to find the best `min_improvement` values for each.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/351)
<!-- Reviewable:end -->
