### PR TITLE
Fix target project parsing issues in translator.py

### DIFF
--- a/silnlp/sfm/__init__.py
+++ b/silnlp/sfm/__init__.py
@@ -51,7 +51,7 @@ __all__ = (
     "copy",
 )  # functions
 
-
+EMPTY_PARAGRAPH = re.compile(r"(?<=\\p) (?=\\v)")
 EMPTY_VERSE_1 = re.compile(r"(?<=\\v \d) (?=(\\v)|$)")
 EMPTY_VERSE_2 = re.compile(r"(?<=\\v \d{2}) (?=(\\v)|$)")
 EMPTY_VERSE_3 = re.compile(r"(?<=\\v \d{3}) (?=(\\v)|$)")
@@ -969,6 +969,7 @@ def generate(doc):
             ):
                 end = "*"
 
+            body = re.sub(EMPTY_PARAGRAPH, "\n", body)
             body = re.sub(EMPTY_VERSE_1, "\n", body)
             body = re.sub(EMPTY_VERSE_2, "\n", body)
             body = re.sub(EMPTY_VERSE_3, "\n", body)


### PR DESCRIPTION
Fixes issues with not being able to insert translations into books with SFM structure but no text.

Correct formatting of empty books with multiple verse markers on a single line.
Insert empty strings as text for empty target verses so that they're recognized by `collect_segments`.
No longer get rid of target project inline elements. I think the intention of this was to not bring over irrelevant information from source projects, so I don't think it needs to be applied to target projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/357)
<!-- Reviewable:end -->
