### PR TITLE
Give warning when base model is used for inferencing

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1157,6 +1157,7 @@ class HuggingFaceNMTModel(NMTModel):
             checkpoint_path, _ = self.get_checkpoint_path(ckpt)
             model_name = str(checkpoint_path)
         else:
+            LOGGER.warn("Model has no checkpoints. Using base model.")
             model_name = self._config.model
 
         dtype = torch.bfloat16 if self._is_t5 else torch.float16

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -565,7 +565,6 @@ def test(
             )
 
     if not config.model_dir.exists():
-        LOGGER.info("Model has no checkpoints. Testing with base model.")
         results[0] = test_checkpoint(
             config,
             model,


### PR DESCRIPTION
Previously the warning was given for testing but not translation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/364)
<!-- Reviewable:end -->
