### PR TITLE
Lora weight tying update

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1152,6 +1152,18 @@ class HuggingFaceNMTModel(NMTModel):
             elif self._config.model_prefix == "google/madlad400":
                 embedding = model.base_model.model.encoder.embed_tokens.modules_to_save.default.weight
                 model.base_model.model.decoder.embed_tokens.modules_to_save.default.weight = embedding
+        elif "embed_tokens" in target_modules:
+            if self._config.model_prefix == "facebook/nllb-200":
+                # TODO: figure out how to tie embedding weights and lm_head weights together
+                embedding_A = model.base_model.model.model.encoder.embed_tokens.lora_embedding_A.default
+                embedding_B = model.base_model.model.model.encoder.embed_tokens.lora_embedding_B.default
+                model.base_model.model.model.decoder.embed_tokens.lora_embedding_A.default = embedding_A
+                model.base_model.model.model.decoder.embed_tokens.lora_embedding_B.default = embedding_B
+            elif self._config.model_prefix == "google/madlad400":
+                embedding_A = model.base_model.model.encoder.embed_tokens.lora_embedding_A.default
+                embedding_B = model.base_model.model.encoder.embed_tokens.lora_embedding_B.default
+                model.base_model.model.decoder.embed_tokens.lora_embedding_A.default = embedding_A
+                model.base_model.model.decoder.embed_tokens.lora_embedding_B.default = embedding_B
 
         # Necessary to allow gradients to propogate through frozen layers when using PEFT + gradient checkpointing + Trainer
         if self._config.train["gradient_checkpointing"]:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1134,7 +1134,7 @@ class HuggingFaceNMTModel(NMTModel):
             elif self._config.model_prefix == "google/madlad400":
                 embedding = model.base_model.model.encoder.embed_tokens.modules_to_save.default.weight
                 model.base_model.model.decoder.embed_tokens.modules_to_save.default.weight = embedding
-                model.base_model.model.lm_head.embed_tokens.modules_to_save.default.weight = embedding
+                model.base_model.model.lm_head.modules_to_save.default.weight = embedding
 
         # Necessary to allow gradients to propogate through frozen layers when using PEFT + gradient checkpointing + Trainer
         if self._config.train["gradient_checkpointing"]:
@@ -1199,7 +1199,7 @@ class HuggingFaceNMTModel(NMTModel):
                 base_model.resize_token_embeddings(
                     len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None
                 )
-            model = self._create_tied_embedding_weights(model)
+            base_model = self._create_tied_embedding_weights(base_model)
             model = PeftModel.from_pretrained(base_model, model_name)
         else:
             model: PreTrainedModel = AutoModelForSeq2SeqLM.from_pretrained(

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1087,11 +1087,15 @@ class HuggingFaceNMTModel(NMTModel):
                     terms.add(trg_line.strip())
 
         return self._dictionary
-    
+
     # Tie embedding weights to "shared" module weights and untie the embeddings modules if necessary
     def _create_tied_embedding_weights(self, model: PreTrainedModel) -> PreTrainedModel:
-        encoder_embeddings = torch.nn.Embedding(model.config.vocab_size, model.config.d_model, model.config.pad_token_id)
-        decoder_embeddings = torch.nn.Embedding(model.config.vocab_size, model.config.d_model, model.config.pad_token_id)
+        encoder_embeddings = torch.nn.Embedding(
+            model.config.vocab_size, model.config.d_model, model.config.pad_token_id
+        )
+        decoder_embeddings = torch.nn.Embedding(
+            model.config.vocab_size, model.config.d_model, model.config.pad_token_id
+        )
 
         if self._config.model_prefix == "facebook/nllb-200":
             model.base_model.encoder.embed_tokens = encoder_embeddings
@@ -1100,7 +1104,7 @@ class HuggingFaceNMTModel(NMTModel):
             model.encoder.embed_tokens = encoder_embeddings
             model.decoder.embed_tokens = decoder_embeddings
             model.config.tie_word_embeddings = True
-        
+
         model.tie_weights()
         return model
 
@@ -1109,8 +1113,12 @@ class HuggingFaceNMTModel(NMTModel):
         model = self._create_tied_embedding_weights(model)
 
         lora_config = self._config.train["lora_config"]
-        target_modules = lora_config.get("target_modules", LORA_DEFAULT_CONFIGS[self._config.model_prefix]["target_modules"])
-        modules_to_save = lora_config.get("modules_to_save", LORA_DEFAULT_CONFIGS[self._config.model_prefix]["modules_to_save"])
+        target_modules = lora_config.get(
+            "target_modules", LORA_DEFAULT_CONFIGS[self._config.model_prefix]["target_modules"]
+        )
+        modules_to_save = lora_config.get(
+            "modules_to_save", LORA_DEFAULT_CONFIGS[self._config.model_prefix]["modules_to_save"]
+        )
         if isinstance(target_modules, str):
             target_modules = target_modules.split(",")
         if isinstance(modules_to_save, str):
@@ -1443,12 +1451,18 @@ class SilSeq2SeqTrainer(Seq2SeqTrainer):
             if self._better_transformer:
                 self.model = self.model.reverse_bettertransformer()
                 self.model.save_pretrained(
-                    output_dir, state_dict=state_dict, safe_serialization=self.args.save_safetensors, save_embedding_layers=True
+                    output_dir,
+                    state_dict=state_dict,
+                    safe_serialization=self.args.save_safetensors,
+                    save_embedding_layers=True,
                 )
                 self.model = self.model.to_bettertransformer()
             else:
                 self.model.save_pretrained(
-                    output_dir, state_dict=state_dict, safe_serialization=self.args.save_safetensors, save_embedding_layers=True
+                    output_dir,
+                    state_dict=state_dict,
+                    safe_serialization=self.args.save_safetensors,
+                    save_embedding_layers=True,
                 )
         if self.tokenizer is not None:
             self.tokenizer.save_pretrained(output_dir)


### PR DESCRIPTION
I was having trouble tying the embeddings to the lm_head in LoRA models where the embeddings were actually targeted layers, not just unfrozen, because the embeddings become a specific `lora_embedding` module, whereas the lm_head is treated normally, and the two aren't quite compatible. I didn't spend a ton of time on it because I know we mostly want to fully train the embeddings, so if we ever want to target the embeddings and keep them tied together, there is some more work to be done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/372)
<!-- Reviewable:end -->
