### PR TITLE
Add apt-get update command after apt-get clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,8 @@ RUN rm -rf eflomal
 ENV EFLOMAL_PATH=/usr/local/bin
 
 # Install fast_align
-RUN apt-get install --no-install-recommends -y libgoogle-perftools-dev libsparsehash-dev
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y libgoogle-perftools-dev libsparsehash-dev
 RUN git clone https://github.com/clab/fast_align.git
 RUN mkdir fast_align/build
 RUN cmake -S fast_align -B fast_align/build


### PR DESCRIPTION
Removing the .NET SDK install steps got rid of an `apt-get update` command that I believe is necessary because of the `apt-get clean` command run after the main batch of packages is installed.

I'm still not sure what the issues were with failing to download python packages, but since those would come up before this issue, I'm going to assume there were some connectivity issues on Github's end

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/381)
<!-- Reviewable:end -->
