### PR TITLE
Save LoRA models as full merged models rather than adapters

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1102,8 +1102,8 @@ class HuggingFaceNMTModel(NMTModel):
         )
 
         if self._config.model_prefix == "facebook/nllb-200":
-            model.base_model.encoder.embed_tokens = encoder_embeddings
-            model.base_model.decoder.embed_tokens = decoder_embeddings
+            model.model.encoder.embed_tokens = encoder_embeddings
+            model.model.decoder.embed_tokens = decoder_embeddings
             model.tie_weights()
         elif self._config.model_prefix == "google/madlad400":
             model.encoder.embed_tokens = encoder_embeddings
@@ -1252,7 +1252,7 @@ class HuggingFaceNMTModel(NMTModel):
         dtype = torch.bfloat16 if self._is_t5 else torch.float16
         if (
             self._config.train["use_lora"]
-            and self._config.model_prefix == "google/madlad400"
+            and self._config.model_prefix != "facebook/nllb-200"
             and model_name != self._config.model
         ):
             base_model = AutoModelForSeq2SeqLM.from_pretrained(


### PR DESCRIPTION
The only changed code that should be run before the first `_save` call is the `create_tied_embedding_weights` function, which got moved outside of the `HuggingFaceNMTModel` class, and when that function is called, now after the `lora_config` is loaded, and I did verify that the model was set up the same way it was before, i.e. that all the right weights were tied in the right ways. Previously, the losses, eval BLEU scores, and test scores were identical between reruns of the same experiment, so I'm not sure what could be causing this additional non-determinism.
<br>
A couple other pieces of information I didn't mention earlier that may or may not be useful:
* Most of the (identically configured) experiments I ran with these changes had the same best/last checkpoints (7k/11k), but a couple were different (one was 6k/10k, another was 8k/9k).
* While all of the test scores have been within a point of the scores of the original LoRA experiment, they have all been lower. It's possible that this is just a coincidence, but I did run the same experiment 5 times.
* When I've experimented with how LoRA models have been saved in the past, the test scores were always either all 0/very low, or the same scores as the original LoRA model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/383)
<!-- Reviewable:end -->
