### PR TITLE
set use_reentrant to true

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -102,6 +102,7 @@ TRAINING_ARGS_CONFIG_MAPPING = {
     "train": {
         "gradient_accumulation_steps",
         "gradient_checkpointing",
+        "gradient_checkpointing_kwargs",
         "group_by_length",
         "log_level",
         "logging_dir",
@@ -272,6 +273,7 @@ class HuggingFaceConfig(Config):
                     "max_source_length": 200,
                     "max_target_length": 200,
                     "gradient_checkpointing": True,
+                    "gradient_checkpointing_kwargs": {"use_reentrant": True},
                     "save_steps": 1000,
                     "per_device_train_batch_size": 16,
                     "save_strategy": "steps",


### PR DESCRIPTION
Per the discussion in issue #387, I'm setting use_reentrant to True by default to fix the warning, since it seems to perform slightly better than the False setting and is also the setting that we have been using, just not explicitly. If we run into any issues with freezing layers, the default can be overridden in the experiment's config.yml. When this pull request is approved, I'll go ahead and update the wiki with that info for the config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/403)
<!-- Reviewable:end -->
