### PR TITLE
Change default learning rate for LoRA models

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1056,7 +1056,7 @@ class HuggingFaceNMTModel(NMTModel):
                 "tf32": self._mixed_precision,
             },
         )
-        if self._is_t5 and "learning_rate" not in args.keys():
+        if self._config.train["use_lora"] and "learning_rate" not in args.keys():
             args["learning_rate"] = 3e-4
         return parser.parse_dict(args)[0]
 


### PR DESCRIPTION
Changing the conditional rather than the actual learning rate because I found that to be the best learning rate for NLLB models using LoRA as well. I will have to do another set of experiments once we start testing MADLAD without LoRA to see if it needs a different learning rate.

After running these experiments, it seems like the slowdown from using LoRA is a mix of taking more steps and taking longer to complete a step. With the new learning rate, experiments are completing in a similar amount of steps compared to the original models, whereas before they took about twice as many steps to hit early stopping. Now, the training time for LoRA experiments is closer to 1.5 times that of regular experiments for Catapult, and 1.25 times for Scripture, which makes sense given that they previously took around 3 times as long when taking twice as many steps.

The best learning rate for Catapult experiments using LoRA was around 2e-4 rather than 3e-4, but the results were still fine for 3e-4, and that was a pretty clear winner for the Scripture experiments.

Closes #394.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/417)
<!-- Reviewable:end -->
