### PR TITLE
Auto gradient accumulation

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1,4 +1,5 @@
 import csv
+import gc
 import json
 import logging
 import os
@@ -17,6 +18,7 @@ import pandas as pd
 import torch
 import transformers.utils.logging as transformers_logging
 import yaml
+from accelerate.utils.memory import should_reduce_batch_size
 from datasets import Dataset
 from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef
 from sacremoses import MosesPunctNormalizer
@@ -279,6 +281,7 @@ class HuggingFaceConfig(Config):
                     "save_strategy": "steps",
                     "save_total_limit": 2,
                     "gradient_accumulation_steps": 4,
+                    "auto_grad_acc": False,
                     "max_steps": 100000,
                     "group_by_length": True,
                     "output_dir": str(exp_dir / "run"),
@@ -326,6 +329,10 @@ class HuggingFaceConfig(Config):
             config["eval"]["load_best_model_at_end"] = False
             config["eval"]["early_stopping"] = None
             config["eval"]["metric_for_best_model"] = None
+
+        if config["train"]["auto_grad_acc"]:
+            config["train"]["per_device_train_batch_size"] = 64
+            config["train"]["gradient_accumulation_steps"] = 1
 
     @property
     def model_dir(self) -> Path:
@@ -896,6 +903,7 @@ class HuggingFaceNMTModel(NMTModel):
             compute_metrics=compute_metrics,
             sequential_sampling=self._config.train.get("sequential_sampling", False),
             better_transformer=self._config.train.get("better_transformer", False),
+            auto_grad_acc=self._config.train.get("auto_grad_acc", False),
         )
         early_stopping: Optional[dict] = self._config.eval["early_stopping"]
         if early_stopping:
@@ -1426,6 +1434,7 @@ class SilSeq2SeqTrainer(Seq2SeqTrainer):
         preprocess_logits_for_metrics: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
         sequential_sampling: bool = False,
         better_transformer: bool = False,
+        auto_grad_acc: bool = False,
     ):
         super().__init__(
             model,
@@ -1442,11 +1451,32 @@ class SilSeq2SeqTrainer(Seq2SeqTrainer):
         )
         self._sequential_sampling = sequential_sampling
         self._better_transformer = better_transformer
+        self._auto_grac_acc = auto_grad_acc
 
     def _get_train_sampler(self) -> Optional[Sampler]:
         if self._sequential_sampling:
             return None
         return super()._get_train_sampler()
+
+    def _inner_training_loop(
+        self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
+    ):
+        if self._auto_grac_acc:
+            inner_training_loop = find_executable_batch_size(super()._inner_training_loop, batch_size, self.accelerator)
+            return inner_training_loop(
+                args=args,
+                resume_from_checkpoint=resume_from_checkpoint,
+                trial=trial,
+                ignore_keys_for_eval=ignore_keys_for_eval,
+            )
+        else:
+            super()._inner_training_loop(
+                batch_size=batch_size,
+                args=args,
+                resume_from_checkpoint=resume_from_checkpoint,
+                trial=trial,
+                ignore_keys_for_eval=ignore_keys_for_eval,
+            )
 
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
@@ -1493,3 +1523,29 @@ class SilSeq2SeqTrainer(Seq2SeqTrainer):
 
         # Good practice: save your training arguments together with the trained model
         torch.save(self.args, os.path.join(output_dir, TRAINING_ARGS_NAME))
+
+
+def find_executable_batch_size(function: callable = None, starting_batch_size: int = 64, accelerator=None):
+    batch_size = starting_batch_size
+
+    def decorator(*args, **kwargs):
+        nonlocal batch_size
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        while True:
+            if batch_size == 0:
+                raise RuntimeError("No executable batch size found, reached zero.")
+            try:
+                return function(batch_size, *args, **kwargs)
+            except Exception as e:
+                if should_reduce_batch_size(e):
+                    gc.collect()
+                    torch.cuda.empty_cache()
+                    batch_size //= 2
+                    accelerator.gradient_accumulation_steps = accelerator.gradient_accumulation_steps * 2
+                    kwargs["args"].gradient_accumulation_steps = accelerator.gradient_accumulation_steps
+                else:
+                    raise
+
+    return decorator

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1470,7 +1470,7 @@ class SilSeq2SeqTrainer(Seq2SeqTrainer):
                 ignore_keys_for_eval=ignore_keys_for_eval,
             )
         else:
-            super()._inner_training_loop(
+            return super()._inner_training_loop(
                 batch_size=batch_size,
                 args=args,
                 resume_from_checkpoint=resume_from_checkpoint,


### PR DESCRIPTION
Adds option to find and use the highest batch size with the corresponding number of gradient accumulation steps. 

The new code mostly mirrors `accelerate` and the base Trainer's implementation of the `auto_find_batch_size` option, but adjusting the number of gradient accumulation steps needs to happen at the same time as adjusting the batch size as far as I can tell, so I wasn't able to just use the `auto_find_batch_size` option and adjust the grad. acc. steps after the fact.

Closes #371

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/424)
<!-- Reviewable:end -->
