### PR TITLE
Upgrade eflomal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder /src/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
 
 # Set eflomal path
-ENV EFLOMAL_PATH=/workspaces/silnlp/.venv/lib/python3.8/site-packages/eflomal/bin
+ENV EFLOMAL_PATH=/usr/local/lib/python3.8/dist-packages/eflomal/bin
 
 # Install fast_align
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install --no-install-recommends -y \
     git \
     python$PYTHON_VERSION \
     python3-pip \
+    python3-dev \
     wget \
     build-essential \
     gdb \
@@ -59,12 +60,8 @@ RUN ln -sfn /usr/bin/python${PYTHON_VERSION} /usr/bin/python3  & \
 COPY --from=builder /src/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
 
-# Install eflomal
-RUN git clone https://github.com/robertostling/eflomal.git
-RUN make -C eflomal/src
-RUN make -C eflomal/src install
-RUN rm -rf eflomal
-ENV EFLOMAL_PATH=/usr/local/bin
+# Set eflomal path
+ENV EFLOMAL_PATH=/workspaces/silnlp/.venv/lib/python3.8/site-packages/eflomal/bin
 
 # Install fast_align
 RUN apt-get update && \

--- a/poetry.lock
+++ b/poetry.lock
@@ -808,19 +808,20 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "eflomal"
-version = "0.1"
+version = "2.0.0"
 description = "pip installable eflomal"
 optional = true
 python-versions = "*"
 files = [
-    {file = "eflomal-0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:192115fa23f29790e17d8857a6fb9dd34d98e065357bac0588e3d459dad9f6fc"},
-    {file = "eflomal-0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:886899e3cc67d0620f2f9a63a508069453fd6c8a69dd4a0b5befd3e55f4012dc"},
-    {file = "eflomal-0.1.tar.gz", hash = "sha256:529a5fbbca7539a2534900447717d70cf6cfdeec4528645eb028bb5ae878adcd"},
+    {file = "eflomal-2.0.0.tar.gz", hash = "sha256:b71183dcf85bf4f59f44ef7a59f5268df1c17c0c8d8093f77b220025ffdba100"},
 ]
 
 [package.dependencies]
 Cython = "*"
 numpy = "*"
+
+[package.extras]
+test = ["pytest"]
 
 [[package]]
 name = "entrypoints"
@@ -5691,4 +5692,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.9"
-content-hash = "5422d3afdbe96d87dc4d601ca1e0f17aef09e0d8b00ab1f7a182b8576f7f6a5b"
+content-hash = "b38124c25f1f384b0fc90537ea3cb55964023ec5888272ed25bb0b0f685744c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sacremoses = "^0.0.53"
 evaluate = "^0.3.0"
 python-docx = "^0.8.11"
 iso639-lang = "^2.1.0"
-eflomal = { version = "^0.1", optional = true }
+eflomal = { version = "^2.0.0", optional = true }
 accelerate = "^0.23.0"
 transformers = "^4.36.2"
 optimum = "^1.16.0"

--- a/silnlp/alignment/config.py
+++ b/silnlp/alignment/config.py
@@ -67,9 +67,10 @@ ALIGNERS: Dict[str, Tuple[Type[Aligner], str]] = {
     "clear3_fa": (ClearAligner, "Clear-3-FA"),
     "clear3_hmm": (ClearAligner, "Clear-3-HMM"),
     "clab_fast_align": (FastAlign, "clab-FastAlign"),
-    "eflomal": (EflomalAligner, "Eflomal"),
 }
 
+if is_eflomal_available():
+    ALIGNERS["eflomal"] = (EflomalAligner, "Eflomal")
 
 STEMMERS: Dict[str, Type[Stemmer]] = {
     "snowball": SnowballStemmer,

--- a/silnlp/alignment/config.py
+++ b/silnlp/alignment/config.py
@@ -67,10 +67,9 @@ ALIGNERS: Dict[str, Tuple[Type[Aligner], str]] = {
     "clear3_fa": (ClearAligner, "Clear-3-FA"),
     "clear3_hmm": (ClearAligner, "Clear-3-HMM"),
     "clab_fast_align": (FastAlign, "clab-FastAlign"),
+    "eflomal": (EflomalAligner, "Eflomal"),
 }
 
-if is_eflomal_available():
-    ALIGNERS["eflomal"] = (EflomalAligner, "Eflomal")
 
 STEMMERS: Dict[str, Type[Stemmer]] = {
     "snowball": SnowballStemmer,


### PR DESCRIPTION
This PR updates eflomal from 0.1 to 2.0.0 to fix #431, modifies the Dockerfile to use the pip installation of eflomal, and adds eflomal to the `ALIGNERS` dictionary in `silnlp/alignment/config.py` permanently instead of only when eflomal is installed so that the error message will be `eflomal is not installed` rather than `invalid aligner`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/433)
<!-- Reviewable:end -->
