### PR TITLE
Add ability to specify projects as back translations

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -177,7 +177,7 @@ def parse_corpus_pairs(corpus_pairs: List[dict]) -> List[CorpusPair]:
         if isinstance(trg, str):
             trg = trg.split(",")
         trg_files = [DataFile(get_mt_corpus_path(tp.strip())) for tp in trg]
-        back_translations: Union[str, List[str]] = pair.get("back_translations", [])
+        back_translations: Union[str, List[str]] = pair.get("mixed_src_BTs", [])
         if isinstance(back_translations, str):
             back_translations = back_translations.split(",")
         is_scripture = src_files[0].is_scripture

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -316,11 +316,6 @@ class HuggingFaceConfig(Config):
 
         super().__init__(exp_dir, config)
 
-        # Map back translation language codes to their base language
-        for src_iso in self.src_isos:
-            if src_iso.endswith("_BT"):
-                self.data["lang_codes"][src_iso] = self.data["lang_codes"].get(src_iso[:-3], src_iso[:-3])
-
         if self.model_prefix == "google/madlad400":
             self.train["max_source_length"] = 256
             self.train["max_target_length"] = 256

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -316,6 +316,11 @@ class HuggingFaceConfig(Config):
 
         super().__init__(exp_dir, config)
 
+        # Map back translation language codes to their base language
+        for src_iso in self.src_isos:
+            if src_iso.endswith("_BT"):
+                self.data["lang_codes"][src_iso] = self.data["lang_codes"].get(src_iso[:-3], src_iso[:-3])
+
         if self.model_prefix == "google/madlad400":
             self.train["max_source_length"] = 256
             self.train["max_target_length"] = 256


### PR DESCRIPTION
Adds an optional field called `back_translations` to corpus pairs whose value is a list of projects in the same format as `src` or `trg`. Projects in this list have "_BT" appended to their language code so that their test set is evaluated separately. The new language code is still mapped to the correct NLLB language code.

Closes #377.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/451)
<!-- Reviewable:end -->
