### PR TITLE
Overwrite alignment files when realignment occurs

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Set
+
 import yaml
 
 from ..common.environment import SIL_NLP_ENV
@@ -10,7 +11,7 @@ from ..common.tf_utils import enable_memory_growth
 from ..common.utils import get_git_revision_hash, show_attrs
 from .clearml_connection import SILClearML
 from .config import Config, get_mt_exp_dir
-from .test import test, _SUPPORTED_SCORERS
+from .test import _SUPPORTED_SCORERS, test
 from .translate import TranslationTask
 
 
@@ -58,7 +59,7 @@ class SILExperiment:
             raise RuntimeError(f"ERROR: Config file does not exist in experiment folder {exp_dir}.")
         SIL_NLP_ENV.copy_experiment_from_bucket(self.name)
         self.config.preprocess(self.make_stats, self.force_align)
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name)
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, overwrite=self.force_align)
 
     def train(self):
         os.system("nvidia-smi")
@@ -89,13 +90,11 @@ class SILExperiment:
     def translate(self):
         SIL_NLP_ENV.copy_experiment_from_bucket(self.name)
         with (self.config.exp_dir / "translate_config.yml").open("r", encoding="utf-8") as file:
-                translate_configs = yaml.safe_load(file)
+            translate_configs = yaml.safe_load(file)
 
         for config in translate_configs.get("translate", []):
             translator = TranslationTask(
-            name=self.name,
-            checkpoint=config.get("checkpoint", "last"),
-            commit=self.commit
+                name=self.name, checkpoint=config.get("checkpoint", "last"), commit=self.commit
             )
 
             if len(config.get("books", [])) > 0:
@@ -111,19 +110,21 @@ class SILExperiment:
                 )
             elif config.get("src_prefix"):
                 translator.translate_text_files(
-                    config.get("src_prefix"), 
-                    config.get("trg_prefix"), 
-                    config.get("start_seq"), 
-                    config.get("end_seq"), 
-                    config.get("src_iso"), 
-                    config.get("trg_iso")
+                    config.get("src_prefix"),
+                    config.get("trg_prefix"),
+                    config.get("start_seq"),
+                    config.get("end_seq"),
+                    config.get("src_iso"),
+                    config.get("trg_iso"),
                 )
             elif config.get("src"):
-                translator.translate_files(config.get("src"), 
-                                        config.get("trg"), 
-                                        config.get("src_iso"), 
-                                        config.get("trg_iso"), 
-                                        config.get("include_inline_elements", False))
+                translator.translate_files(
+                    config.get("src"),
+                    config.get("trg"),
+                    config.get("src_iso"),
+                    config.get("trg_iso"),
+                    config.get("include_inline_elements", False),
+                )
             else:
                 raise RuntimeError("A Scripture book, file, or file prefix must be specified for translation.")
 
@@ -132,7 +133,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run experiment - preprocess, train, and test")
     parser.add_argument("experiment", help="Experiment name")
     parser.add_argument("--stats", default=False, action="store_true", help="Output corpus statistics")
-    parser.add_argument("--force-align", default=False, action="store_true", help="Force recalculation of all alignment scores")
+    parser.add_argument(
+        "--force-align", default=False, action="store_true", help="Force recalculation of all alignment scores"
+    )
     parser.add_argument("--disable-mixed-precision", default=False, action="store_true", help="Disable mixed precision")
     parser.add_argument("--memory-growth", default=False, action="store_true", help="Enable memory growth")
     parser.add_argument("--num-devices", type=int, default=1, help="Number of devices to train on")

--- a/silnlp/nmt/preprocess.py
+++ b/silnlp/nmt/preprocess.py
@@ -12,7 +12,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Preprocesses the parallel corpus for an NMT model")
     parser.add_argument("experiment", help="Experiment name")
     parser.add_argument("--stats", default=False, action="store_true", help="Output corpus statistics")
-    parser.add_argument("--force-align", default=False, action="store_true", help="Force recalculation of all alignment scores")
+    parser.add_argument(
+        "--force-align", default=False, action="store_true", help="Force recalculation of all alignment scores"
+    )
     args = parser.parse_args()
 
     get_git_revision_hash()
@@ -23,7 +25,7 @@ def main() -> None:
 
     config.set_seed()
     config.preprocess(args.stats, args.force_align)
-    SIL_NLP_ENV.copy_experiment_to_bucket(exp_name)
+    SIL_NLP_ENV.copy_experiment_to_bucket(exp_name, overwrite=args.force_align)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New alignments weren't getting copied to the S3 bucket when using the force_align option because the files would already exist in the experiment folder. We wouldn't typically expect large files like a saved model to be in the experiment folder at this point, but I can update the code to only overwrite for the alignment files if necessary.

Plus a bunch of auto formatting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/453)
<!-- Reviewable:end -->
