### PR TITLE
Generalize compute_alignment_scores

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get install --no-install-recommends -y \
     git \
     python$PYTHON_VERSION \
     python3-pip \
+    python3-dev \
     python$PYTHON_VERSION-venv \
     build-essential \
     gdb \
@@ -44,4 +45,5 @@ ENV SIL_NLP_CACHE_PROJECT_DIR=/root/.cache/silnlp/projects
 # Set environment variables
 ENV CLEARML_API_HOST="https://api.sil.hosted.allegro.ai"
 ENV SIL_NLP_DATA_PATH=/aqua-ml-data
+ENV EFLOMAL_PATH=/workspaces/silnlp/.venv/lib/python3.8/site-packages/eflomal/bin
 CMD ["bash"]

--- a/silnlp/alignment/eflomal.py
+++ b/silnlp/alignment/eflomal.py
@@ -28,6 +28,10 @@ class EflomalAligner(Aligner):
 
         super().__init__("eflomal", model_dir)
 
+    @property
+    def has_inverse_model(self) -> bool:
+        return False
+
     def train(self, src_file_path: Path, trg_file_path: Path) -> None:
         LOGGER.info("Generating alignments")
         self.model_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Changes to allow non-MachineAligner aligners and aligners without an inverse model.

Also adds dependency and environment variable to use eflomal in the dev container.

Closes #443.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/455)
<!-- Reviewable:end -->
