### PR TITLE
only match with checkpoint folder name not full path

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -88,7 +88,7 @@ class SILExperiment:
         )
 
     def translate(self):
-        SIL_NLP_ENV.copy_experiment_from_bucket(self.name)
+        SIL_NLP_ENV.copy_experiment_from_bucket(self.name, patterns="*.yml")
         with (self.config.exp_dir / "translate_config.yml").open("r", encoding="utf-8") as file:
             translate_configs = yaml.safe_load(file)
 
@@ -183,10 +183,10 @@ def main() -> None:
     if args.memory_growth:
         enable_memory_growth()
 
-    if not (args.preprocess or args.train or args.test):
-        args.preprocess = True
-        args.train = True
-        args.test = True
+    # if not (args.preprocess or args.train or args.test):
+    #    args.preprocess = True
+    #    args.train = True
+    #    args.test = True
 
     exp = SILExperiment(
         name=args.experiment,

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -183,10 +183,10 @@ def main() -> None:
     if args.memory_growth:
         enable_memory_growth()
 
-    # if not (args.preprocess or args.train or args.test):
-    #    args.preprocess = True
-    #    args.train = True
-    #    args.test = True
+    if not (args.preprocess or args.train or args.test):
+        args.preprocess = True
+        args.train = True
+        args.test = True
 
     exp = SILExperiment(
         name=args.experiment,

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -266,9 +266,7 @@ class TranslationTask:
         translator = NMTTranslator(model, self.checkpoint)
         if clearml.config.model_dir.exists():
             checkpoint_path, step = model.get_checkpoint_path(self.checkpoint)
-            SIL_NLP_ENV.copy_experiment_from_bucket(
-                self.name, patterns=SIL_NLP_ENV.get_source_experiment_path(checkpoint_path) + "/*.*"
-            )
+            SIL_NLP_ENV.copy_experiment_from_bucket(self.name, patterns=checkpoint_path.name + "/*.*")
             step_str = "avg" if step == -1 else str(step)
         else:
             step_str = "last"


### PR DESCRIPTION
This fixes the issue in #464 by only matching with the checkpoint folder name rather than the whole path, so that there are no potential issues with characters in the experiment name that could interfere with regex matching. I also modified experiment.py so that it doesn't copy over all the contents in the experiment folder when the translate option is used. It now just downloads .yml files so that the program will have access to the configs, and any other downloads will occur when the program execution gets to _init_translation_task() in translate.py.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/465)
<!-- Reviewable:end -->
