### PR TITLE
migrate to new silnlp bucket

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,6 +44,6 @@ ENV SIL_NLP_CACHE_EXPERIMENT_DIR=/root/.cache/silnlp/experiments
 ENV SIL_NLP_CACHE_PROJECT_DIR=/root/.cache/silnlp/projects
 # Set environment variables
 ENV CLEARML_API_HOST="https://api.sil.hosted.allegro.ai"
-ENV SIL_NLP_DATA_PATH=/aqua-ml-data
+ENV SIL_NLP_DATA_PATH=/silnlp
 ENV EFLOMAL_PATH=/workspaces/silnlp/.venv/lib/python3.8/site-packages/eflomal/bin
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ These are the main requirements for the SILNLP code to run on a local machine. S
    AWS_REGION="us-east-1"
    AWS_ACCESS_KEY_ID=xxxxx
    AWS_SECRET_ACCESS_KEY=xxxxx
-   SIL_NLP_DATA_PATH="/aqua-ml-data"
+   SIL_NLP_DATA_PATH="/silnlp"
    ```
    * If you do not intend to use SILNLP with ClearML and/or AWS, you can leave out the respective variables. If you need to generate ClearML credentials, see [ClearML setup](clear_ml_setup.md).
    * Note that this does not give you direct access to an AWS S3 bucket from within the Docker container, it only allows you to run scripts referencing files in the bucket.

--- a/manual_setup.md
+++ b/manual_setup.md
@@ -89,7 +89,7 @@ See [ClearML setup](clear_ml_setup.md).
 
 ### Additional Environment Variables
 * Set the following environment variables with your respective credentials: CLEARML_API_ACCESS_KEY, CLEARML_API_SECRET_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY.
-* Set SIL_NLP_DATA_PATH to "/aqua-ml-data" and CLEARML_API_HOST to "https://api.sil.hosted.allegro.ai".
+* Set SIL_NLP_DATA_PATH to "/silnlp" and CLEARML_API_HOST to "https://api.sil.hosted.allegro.ai".
 
 ### Setting Up and Running Experiments
 

--- a/s3_bucket_setup.md
+++ b/s3_bucket_setup.md
@@ -12,7 +12,7 @@ We use Amazon S3 storage for storing our experiment data. Here is some workspace
 
 **Windows**
 
-The following will mount /aqua-ml-data on your S drive and allow you to explore, read and write.
+The following will mount /silnlp on your S drive and allow you to explore, read and write.
 * Install WinFsp: http://www.secfs.net/winfsp/rel/  (Click the button to "Download WinFsp Installer" not the "SSHFS-Win (x64)" installer)
 * Download rclone from: https://rclone.org/downloads/
 * Unzip to your desktop (or some convient location). 
@@ -22,13 +22,13 @@ The following will mount /aqua-ml-data on your S drive and allow you to explore,
 * Take the `scripts/rclone/mount_to_s.bat` file from this SILNLP repo and copy it to the folder that contains the unzipped rclone.
 * Double-click the bat file. A command window should open and remain open. You should see something like:
 ```
-C:\Users\David\Software\rclone>call rclone mount --vfs-cache-mode full --use-server-modtime s3aqua:aqua-ml-data S:
+C:\Users\David\Software\rclone>call rclone mount --vfs-cache-mode full --use-server-modtime s3silnlp:silnlp S:
 The service rclone has been started.
 ```
 
 **Linux / macOS**
 
-The following will mount /aqua-ml-data to an S folder in your home directory and allow you to explore, read and write.
+The following will mount /silnlp to an S folder in your home directory and allow you to explore, read and write.
 * For macOS, first download and install macFUSE: https://osxfuse.github.io/
 * Download rclone from: https://rclone.org/install/
 * Take the `scripts/rclone/rclone.conf` file from this SILNLP repo and copy it to `~/.config/rclone/rclone.conf` (creating folders if necessary)
@@ -36,7 +36,7 @@ The following will mount /aqua-ml-data to an S folder in your home directory and
 * Create a folder called "S" in your user directory 
 * Run the following command:
    ```
-   rclone mount --vfs-cache-mode full --use-server-modtime s3aqua:aqua-ml-data ~/S
+   rclone mount --vfs-cache-mode full --use-server-modtime s3silnlp:silnlp ~/S
    ```
 ### To start S: drive on start up
 
@@ -50,7 +50,7 @@ Now your AWS S3 bucket should be mounted as S: drive when you start Windows.
 
 **Linux / macOS**
 * Run `crontab -e`
-* Paste `@reboot rclone mount --vfs-cache-mode full --use-server-modtime s3aqua:aqua-ml-data ~/S` into the file, save and exit
+* Paste `@reboot rclone mount --vfs-cache-mode full --use-server-modtime s3silnlp:silnlp ~/S` into the file, save and exit
 * Reboot Linux / macOS
 
 Now your AWS S3 bucket should be mounted as ~/S when you start Linux / macOS.

--- a/scripts/clean_s3.py
+++ b/scripts/clean_s3.py
@@ -17,7 +17,7 @@ def clean_s3(dry_run: bool) -> None:
     paginator = s3.get_paginator("list_objects_v2")
     total_deleted = 0
     storage_space_freed = 0
-    for page in paginator.paginate(Bucket="aqua-ml-data"):
+    for page in paginator.paginate(Bucket="silnlp"):
         for obj in page["Contents"]:
             if regex_to_delete.search(obj["Key"]) is None:
                 continue
@@ -28,7 +28,7 @@ def clean_s3(dry_run: bool) -> None:
             print(obj["Key"])
             print(f"{(now - last_modified) / MONTH_IN_SECONDS} months old")
             if not dry_run:
-                s3.delete_object(Bucket="aqua-ml-data", Key=obj["Key"])
+                s3.delete_object(Bucket="silnlp", Key=obj["Key"])
                 print("Deleted")
             total_deleted += 1
             storage_space_freed += obj["Size"]

--- a/scripts/clearml_agent/clearml.conf
+++ b/scripts/clearml_agent/clearml.conf
@@ -63,7 +63,7 @@ agent {
         type: poetry,
 
         # specify pip version to use (examples "<20", "==19.3.1", "", empty string will install the latest version)
-        pip_version: "<20.2",
+        pip_version: ["<20.2 ; python_version < '3.10'",  "<22.3 ; python_version >= '3.10'"],
 
         # virtual environment inheres packages from system
         system_site_packages: false,
@@ -146,7 +146,7 @@ agent {
     # these are local for this agent and will not be updated in the experiment's docker_cmd section
     # extra_docker_arguments: ["--ipc=host", ]
     extra_docker_arguments: [
-      "--env","SIL_NLP_DATA_PATH=/aqua-ml-data"
+      "--env","SIL_NLP_DATA_PATH=/silnlp"
       "--env","AWS_REGION=us-east-1",
       "--env","AWS_ACCESS_KEY_ID=",
       "--env","AWS_SECRET_ACCESS_KEY=",

--- a/scripts/rclone/mount_to_s.bat
+++ b/scripts/rclone/mount_to_s.bat
@@ -10,4 +10,4 @@ rem   copy your key and secret to rclone.conf
 
 rem run rclone - execute this file in the rclone folder
 
-call rclone mount --vfs-cache-mode full --use-server-modtime s3aqua:aqua-ml-data S: 
+call rclone mount --vfs-cache-mode full --use-server-modtime s3silnlp:silnlp S: 

--- a/scripts/rclone/rclone.conf
+++ b/scripts/rclone/rclone.conf
@@ -1,4 +1,4 @@
-[s3aqua]
+[s3silnlp]
 type = s3
 provider = AWS
 access_key_id = xxxxxxxxxxxxxxxxxx

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -175,7 +175,7 @@ class SilNlpEnv:
             )
         s3 = boto3.resource("s3")
         data_bucket = s3.Bucket(str(self.data_dir).strip("\\/"))
-        len_aqua_path = len(pt_projects_path)
+        len_silnlp_path = len(pt_projects_path)
         pt_projects_path = pt_projects_path + name
         objs = list(data_bucket.object_versions.filter(Prefix=pt_projects_path + "/"))
         if len(objs) == 0:
@@ -184,7 +184,7 @@ class SilNlpEnv:
         if isinstance(patterns, str):
             patterns = [patterns]
         for obj in objs:
-            rel_path = str(obj.object_key)[len_aqua_path:]
+            rel_path = str(obj.object_key)[len_silnlp_path:]
             pure_path = PurePath(rel_path)
             if len(patterns) == 0 or any(pure_path.match(pattern) for pattern in patterns):
                 # copy over project files and experiment files
@@ -208,7 +208,7 @@ class SilNlpEnv:
             )
         s3 = boto3.resource("s3")
         data_bucket = s3.Bucket(str(self.data_dir).strip("\\/"))
-        len_aqua_path = len(experiments_path)
+        len_silnlp_path = len(experiments_path)
         experiment_path = experiments_path + name
         objs = list(data_bucket.object_versions.filter(Prefix=experiment_path + "/"))
         if len(objs) == 0:
@@ -217,7 +217,7 @@ class SilNlpEnv:
         if isinstance(patterns, str):
             patterns = [patterns]
         for obj in objs:
-            rel_path = str(obj.object_key)[len_aqua_path:]
+            rel_path = str(obj.object_key)[len_silnlp_path:]
             pure_path = PurePath(rel_path)
             if len(patterns) == 0 or any(pure_path.match(pattern) for pattern in patterns):
                 # copy over project files and experiment files

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -152,7 +152,7 @@ class SilNlpEnv:
             )
             return gutenberg_path
 
-        s3root = S3Path("/aqua-ml-data")
+        s3root = S3Path("/silnlp")
         if s3root.is_dir():
             LOGGER.info(
                 f"Using s3 workspace workspace: {s3root}.  To change the workspace, set the environment variable "


### PR DESCRIPTION
This PR moves SILNLP from the aqua-ml-data S3 bucket to the new silnlp S3 bucket to address issue #468. I've tested that experiments are able to be successfully run with the new bucket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/471)
<!-- Reviewable:end -->
