### PR TITLE
Get rid of SettingWithCopyWarning

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -749,7 +749,7 @@ class Config(ABC):
             if pair.is_train and pair.score_threshold > 0:
                 unfiltered_count = len(cur_train)
                 cur_train = filter_parallel_corpus(cur_train, pair.score_threshold)
-                cur_train.drop("score", axis=1, inplace=True, errors="ignore")
+                cur_train = cur_train.drop("score", axis=1, errors="ignore")
                 LOGGER.info(
                     f"Filtered out {unfiltered_count - len(cur_train)} verses pairs with alignment below {pair.score_threshold}."
                 )


### PR DESCRIPTION
It seems like the issue was coming from how the dataset was being copied/passed around when it goes through `split_parallel_corpus` followed by `filter_parallel_corpus`. I couldn't figure out exactly which operations were triggering the warnings, but setting the dataset explicitly instead of using `inplace` after all of the problematic bits took care of it, and I double checked that nothing was actually changing about the data.

Fixes #484.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/486)
<!-- Reviewable:end -->
