### PR TITLE
Issue 333: Fixed bug with dupe key terms during preprocessing

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -1036,10 +1036,10 @@ class Config(ABC):
         trg_terms_files: List[Tuple[DataFile, str]],
     ) -> int:
         terms = self._collect_terms(src_terms_files, trg_terms_files)
-        terms = terms.drop_duplicates(subset=["source", "target"])
 
         if terms is None:
             return 0
+        terms = terms.drop_duplicates(subset=["source", "target"])
 
         train_count = 0
         with ExitStack() as stack:

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -1089,12 +1089,12 @@ class Config(ABC):
         categories_set: Optional[Set[str]] = None if categories is None else set(categories)
 
         all_src_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-        for src_terms_file in src_terms_files:
-            all_src_terms.append((src_terms_file[0], get_terms(src_terms_file[0].path), src_terms_file[1]))
+        for src_terms_file, tags_str in src_terms_files:
+            all_src_terms.append((src_terms_file, get_terms(src_terms_file.path), tags_str))
 
         all_trg_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-        for trg_terms_file in trg_terms_files:
-            all_trg_terms.append((trg_terms_file[0], get_terms(trg_terms_file[0].path), trg_terms_file[1]))
+        for trg_terms_file, tags_str in trg_terms_files:
+            all_trg_terms.append((trg_terms_file, get_terms(trg_terms_file.path), tags_str))
 
         for src_terms_file, src_terms, tags_str in all_src_terms:
             for trg_terms_file, trg_terms in all_trg_terms:

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 from ..alignment.config import get_aligner_name
 from ..alignment.utils import add_alignment_scores
 from ..common.corpus import (
+    Term,
     exclude_chapters,
     filter_parallel_corpus,
     get_mt_corpus_path,
@@ -85,6 +86,9 @@ class DataFile:
         self.project = (
             parts[1] if str(self.path.parent).startswith(str(SIL_NLP_ENV.mt_scripture_dir)) else BASIC_DATA_PROJECT
         )
+    
+    def __hash__(self) -> int:
+        return hash(self.path)
 
     @property
     def is_scripture(self) -> bool:
@@ -529,12 +533,32 @@ class Config(ABC):
         self._delete_files("dict.*.txt")
 
         train_count = 0
+        terms_config = self.data["terms"]
+        src_terms_files: Dict[DataFile, str] = {}
+        trg_terms_files: Dict[DataFile, str] = {}
         for pair in self.corpus_pairs:
             if pair.is_scripture:
                 train_count += self._write_scripture_data_sets(tokenizer, pair, force_align)
             else:
                 train_count += self._write_basic_data_sets(tokenizer, pair)
+            
+            if terms_config["dictionary"] or terms_config["train"]:
+                for file in pair.src_terms_files:
+                    src_terms_files[file] = self._get_tags_str(pair.tags)
+                for file in pair.trg_terms_files:
+                    trg_terms_files[file] = self._get_tags_str(pair.tags)
+        
+        terms_train_count = 0
+        if terms_config["train"]:
+            terms_train_count = self._write_terms(tokenizer, src_terms_files, trg_terms_files)
+            LOGGER.info(f"terms train size: {terms_train_count}")
+        train_count += terms_train_count
 
+        dict_count = 0
+        if terms_config["dictionary"]:
+            dict_count = self._write_dictionary(tokenizer, src_terms_files, trg_terms_files)
+            LOGGER.info(f"dictionary size: {dict_count}")
+        
         if stats:
             self._calculate_tokenization_stats()
 
@@ -812,16 +836,6 @@ class Config(ABC):
                 tokenizer, train, pair.mapping == DataFileMapping.MIXED_SRC, project_isos, pair.augmentations
             )
 
-        terms_config = self.data["terms"]
-        terms_train_count = 0
-        if terms_config["train"]:
-            terms_train_count = self._write_terms(tokenizer, pair, tags_str)
-        train_count += terms_train_count
-
-        dict_count = 0
-        if terms_config["dictionary"]:
-            dict_count = self._write_dictionary(tokenizer, pair)
-
         val_count = 0
         if len(val) > 0:
             for (src_iso, trg_iso), pair_val in val.items():
@@ -863,8 +877,6 @@ class Config(ABC):
             f"train size: {train_count},"
             f" val size: {val_count},"
             f" test size: {test_count},"
-            f" dict size: {dict_count},"
-            f" terms train size: {terms_train_count}"
         )
         return train_count
 
@@ -1024,8 +1036,11 @@ class Config(ABC):
                     train_count += 1
         return train_count
 
-    def _write_terms(self, tokenizer: Tokenizer, pair: CorpusPair, tags_str: str) -> int:
-        terms = self._collect_terms(pair, tags_str)
+    def _write_terms(self, tokenizer: Tokenizer, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str]) -> int:
+        terms = self._collect_terms(src_terms_files, trg_terms_files)
+        terms = terms.drop_duplicates(subset=["source"])
+        terms = terms.drop_duplicates(subset=["target"])
+        
         if terms is None:
             return 0
 
@@ -1062,7 +1077,7 @@ class Config(ABC):
         return train_count
 
     def _collect_terms(
-        self, pair: CorpusPair, tags_str: str = "", filter_books: Optional[Set[int]] = None
+        self, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str],  filter_books: Optional[Set[int]] = None
     ) -> Optional[pd.DataFrame]:
         terms_config = self.data["terms"]
         terms: Optional[pd.DataFrame] = None
@@ -1072,9 +1087,16 @@ class Config(ABC):
         if categories is not None and len(categories) == 0:
             return None
         categories_set: Optional[Set[str]] = None if categories is None else set(categories)
-        all_src_terms = [(src_terms_file, get_terms(src_terms_file.path)) for src_terms_file in pair.src_terms_files]
-        all_trg_terms = [(trg_terms_file, get_terms(trg_terms_file.path)) for trg_terms_file in pair.trg_terms_files]
-        for src_terms_file, src_terms in all_src_terms:
+        
+        all_src_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
+        for src_terms_file, tags_str in src_terms_files.items():
+            all_src_terms.append((src_terms_file, get_terms(src_terms_file.path), tags_str))
+            
+        all_trg_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
+        for trg_terms_file, tags_str in trg_terms_files.items():
+            all_trg_terms.append((trg_terms_file, get_terms(trg_terms_file.path), tags_str))
+        
+        for src_terms_file, src_terms, tags_str in all_src_terms:
             for trg_terms_file, trg_terms in all_trg_terms:
                 if src_terms_file.iso == trg_terms_file.iso:
                     continue
@@ -1085,14 +1107,14 @@ class Config(ABC):
         if terms_config["include_glosses"]:
             for gloss_iso in ["en", "fr", "id"]:
                 if gloss_iso in self.trg_isos:
-                    for src_terms_file, src_terms in all_src_terms:
+                    for src_terms_file, src_terms, tags_str in all_src_terms:
                         cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
                         cur_terms = cur_terms.rename(columns={"rendering": "source", "gloss": "target"})
                         cur_terms["source_lang"] = src_terms_file.iso
                         cur_terms["target_lang"] = gloss_iso
                         terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
                 if gloss_iso in self.src_isos:
-                    for trg_terms_file, trg_terms in all_trg_terms:
+                    for trg_terms_file, trg_terms, tags_str in all_trg_terms:
                         cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
                         cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})
                         cur_terms["source_lang"] = gloss_iso
@@ -1438,4 +1460,4 @@ class Config(ABC):
     def _build_vocabs(self, stats: bool = False) -> None: ...
 
     @abstractmethod
-    def _write_dictionary(self, tokenizer: Tokenizer, pair: CorpusPair) -> int: ...
+    def _write_dictionary(self, tokenizer: Tokenizer, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str]) -> int: ...

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -604,7 +604,12 @@ class HuggingFaceConfig(Config):
             self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
         return self._tokenizer
 
-    def _write_dictionary(self, tokenizer: Tokenizer, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str]) -> int:
+    def _write_dictionary(
+        self,
+        tokenizer: Tokenizer,
+        src_terms_files: List[Tuple[DataFile, str]],
+        trg_terms_files: List[Tuple[DataFile, str]],
+    ) -> int:
         terms_config = self.data["terms"]
         dict_count = 0
         with ExitStack() as stack:
@@ -619,8 +624,8 @@ class HuggingFaceConfig(Config):
             categories_set: Optional[Set[str]] = None if categories is None else set(categories)
 
             all_trg_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-            for trg_terms_file, tags_str in trg_terms_files.items():
-                all_trg_terms.append((trg_terms_file, get_terms(trg_terms_file.path), tags_str))
+            for trg_terms_file in trg_terms_files:
+                all_trg_terms.append((trg_terms_file[0], get_terms(trg_terms_file[0].path), trg_terms_file[1]))
             for trg_terms_file, trg_terms, tags_str in all_trg_terms:
                 tokenizer.set_trg_lang(trg_terms_file.iso)
                 for trg_term in trg_terms.values():
@@ -643,8 +648,8 @@ class HuggingFaceConfig(Config):
 
             if terms_config["include_glosses"] and "en" in self.trg_isos:
                 all_src_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-                for src_terms_file, tags_str in src_terms_files.items():
-                    all_src_terms.append((src_terms_file, get_terms(src_terms_file.path), tags_str))
+                for src_terms_file in src_terms_files:
+                    all_src_terms.append((src_terms_file[0], get_terms(src_terms_file[0].path), src_terms_file[1]))
                 tokenizer.set_trg_lang("en")
                 for src_term_file, src_terms, tags_str in all_src_terms:
                     for src_term in src_terms.values():

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -624,8 +624,8 @@ class HuggingFaceConfig(Config):
             categories_set: Optional[Set[str]] = None if categories is None else set(categories)
 
             all_trg_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-            for trg_terms_file in trg_terms_files:
-                all_trg_terms.append((trg_terms_file[0], get_terms(trg_terms_file[0].path), trg_terms_file[1]))
+            for trg_terms_file, tags_str in trg_terms_files:
+                all_trg_terms.append((trg_terms_file, get_terms(trg_terms_file.path), tags_str))
             for trg_terms_file, trg_terms, tags_str in all_trg_terms:
                 tokenizer.set_trg_lang(trg_terms_file.iso)
                 for trg_term in trg_terms.values():
@@ -648,8 +648,8 @@ class HuggingFaceConfig(Config):
 
             if terms_config["include_glosses"] and "en" in self.trg_isos:
                 all_src_terms: List[Tuple[DataFile, Dict[str, Term], str]] = []
-                for src_terms_file in src_terms_files:
-                    all_src_terms.append((src_terms_file[0], get_terms(src_terms_file[0].path), src_terms_file[1]))
+                for src_terms_file, tags_str in src_terms_files:
+                    all_src_terms.append((src_terms_file, get_terms(src_terms_file.path), tags_str))
                 tokenizer.set_trg_lang("en")
                 for src_term_file, src_terms, tags_str in all_src_terms:
                     for src_term in src_terms.values():

--- a/silnlp/nmt/open_nmt_config.py
+++ b/silnlp/nmt/open_nmt_config.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from contextlib import ExitStack
 from pathlib import Path
-from typing import IO, Iterable, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import IO, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union, cast
 
 import numpy as np
 import sacrebleu
@@ -23,7 +23,7 @@ from ..common.corpus import load_corpus, split_corpus
 from ..common.environment import SIL_NLP_ENV, download_if_s3_paths
 from ..common.tf_utils import set_tf_log_level
 from ..common.utils import Side, get_mt_exp_dir, merge_dict
-from .config import CheckpointType, Config, CorpusPair, NMTModel
+from .config import CheckpointType, Config, DataFile, NMTModel
 from .opennmt.runner import create_runner
 from .sp_utils import decode_sp, decode_sp_lines
 from .tokenizer import NullTokenizer, Tokenizer
@@ -691,10 +691,10 @@ class OpenNMTConfig(Config):
             aligner.train(src_train_path, trg_train_path)
             aligner.force_align(src_align_path, trg_align_path, self.exp_dir / "train.alignments.txt")
 
-    def _write_dictionary(self, tokenizer: Tokenizer, pair: CorpusPair) -> int:
+    def _write_dictionary(self, tokenizer: Tokenizer, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str]) -> int:
         terms_config = self.data["terms"]
         dict_books = get_books(terms_config["dictionary_books"]) if "dictionary_books" in terms_config else None
-        terms = self._collect_terms(pair, filter_books=dict_books)
+        terms = self._collect_terms(src_terms_files, trg_terms_files, filter_books=dict_books)
 
         dict_count = 0
         with ExitStack() as stack:

--- a/silnlp/nmt/open_nmt_config.py
+++ b/silnlp/nmt/open_nmt_config.py
@@ -691,7 +691,7 @@ class OpenNMTConfig(Config):
             aligner.train(src_train_path, trg_train_path)
             aligner.force_align(src_align_path, trg_align_path, self.exp_dir / "train.alignments.txt")
 
-    def _write_dictionary(self, tokenizer: Tokenizer, src_terms_files: Dict[DataFile, str], trg_terms_files: Dict[DataFile, str]) -> int:
+    def _write_dictionary(self, tokenizer: Tokenizer, src_terms_files: List[Tuple[DataFile, str]], trg_terms_files: List[Tuple[DataFile, str]]) -> int:
         terms_config = self.data["terms"]
         dict_books = get_books(terms_config["dictionary_books"]) if "dictionary_books" in terms_config else None
         terms = self._collect_terms(src_terms_files, trg_terms_files, filter_books=dict_books)


### PR DESCRIPTION
-Key Terms are no longer collected per corpus pair, done once for the whole corpus
-Any remaining duplicates are removed (repeated proper names)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/503)
<!-- Reviewable:end -->
