### PR TITLE
Issue 473: change xri script to run as a module and rename

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -3,10 +3,10 @@ Transforms tsv files in the XRI format to extract files suitable for training SI
 
 Example:
 
-    $ python xri_etl.py   data.tsv   swa     ngq     XRI-2024-08-14
-                             ^        ^       ^           ^
-                           input   source    target     dataset
-                           file    iso code  iso code   descriptor
+    $ python -m silnlp.common.extract_xri   data.tsv   swa     ngq     XRI-2024-08-14
+                                               ^        ^       ^           ^
+                                             input   source    target     dataset
+                                             file    iso code  iso code   descriptor
 
 Each execution puts the extract files into a unique directory in `out` with name generated from script inputs and the current time:
 
@@ -20,6 +20,7 @@ Each execution puts the extract files into a unique directory in `out` with name
         ├── ngq-XRI-2024-08-14.dev.txt     ┛
         ├── swa-XRI-2024-08-14.test.txt    ┓ extract files filtered to test data
         └── ngq-XRI-2024-08-14.test.txt    ┛
+    (Note that a subsequent PR is going to rework the output location to follow SIL team conventions)
 
 Run with --help for more details.
 


### PR DESCRIPTION
This PR addresses 2 of the points raised in the code review feedback from Damien from this comment:

https://github.com/sillsdev/silnlp/pull/491#pullrequestreview-2261754354

- change the invocation method to run the script as a module
- move the file into `silnlp/common`
- rename the file to `extract_xri.py` to follow existing naming conventions

I will address the other point about output location in a follow up PR to make review easier. (I didn't want to rename a file and also change the code, but it looks like github's diff view actually does a good job of teasing those things apart)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/506)
<!-- Reviewable:end -->
