### PR TITLE
Issue 473: change how output directory is generated for extract_xri script

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -40,7 +40,6 @@ import csv
 import os
 import time
 
-from ..common.environment import SIL_NLP_ENV
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -113,6 +112,7 @@ def write_output_file(filepath: Path, sentences: List[str]) -> None:
 def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]) -> None:
     if cli_input.output is None:
         unique_dir = f"{cli_input.source_iso}-{cli_input.target_iso}-{cli_input.dataset_descriptor}-{time.strftime('%Y%m%d-%H%M%S')}"
+        from ..common.environment import SIL_NLP_ENV
         output_dir = SIL_NLP_ENV.mt_corpora_dir / unique_dir
     else:
         output_dir = Path(cli_input.output)

--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -161,7 +161,9 @@ def main() -> None:
     parser.add_argument("source_iso", help="The ISO 693-3 code for the source/LWC language", type=str)
     parser.add_argument("target_iso", help="The ISO 693-3 code for the target/vernacular language", type=str)
     parser.add_argument("dataset", help="A descriptor of the dataset to be used in the output filename", type=str)
-    parser.add_argument("-output", help="Optional path to the output directory where extract files are generated", type=str)
+    parser.add_argument(
+        "-output", help="Optional path to the output directory where extract files are generated", type=str
+    )
     args = parser.parse_args()
 
     cli_input = CliInput(

--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -104,8 +104,8 @@ def load_sentence_pairs(input_file_path: str) -> List[SentencePair]:
     ]
 
 
-def write_output_file(filename: str, sentences: List[str]) -> None:
-    with open(filename, "w", encoding="utf-8") as f:
+def write_output_file(filepath: Path, sentences: List[str]) -> None:
+    with open(filepath, "w", encoding="utf-8") as f:
         for sentence in sentences:
             f.write(f"{sentence}{os.linesep}")
 
@@ -113,7 +113,7 @@ def write_output_file(filename: str, sentences: List[str]) -> None:
 def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]) -> None:
     if cli_input.output is None:
         unique_dir = f"{cli_input.source_iso}-{cli_input.target_iso}-{cli_input.dataset_descriptor}-{time.strftime('%Y%m%d-%H%M%S')}"
-        output_dir = Path(os.path.join(SIL_NLP_ENV.mt_corpora_dir, unique_dir))
+        output_dir = SIL_NLP_ENV.mt_corpora_dir / unique_dir
     else:
         output_dir = Path(cli_input.output)
 
@@ -121,8 +121,8 @@ def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]
     output_dir.mkdir(parents=True, exist_ok=True)
 
     def create_source_target_files(sub_sentence_pairs: List[SentencePair], suffix: str) -> None:
-        def build_output_path(iso: str) -> str:
-            return os.path.join(output_dir, f"{iso}-{cli_input.dataset_descriptor}.{suffix}.txt")
+        def build_output_path(iso: str) -> Path:
+            return output_dir / f"{iso}-{cli_input.dataset_descriptor}.{suffix}.txt"
 
         source_filename = build_output_path(iso=cli_input.source_iso)
         source_sentences = [sentence.source for sentence in sub_sentence_pairs]


### PR DESCRIPTION
This PR addresses one point raised in the code review feedback from Damien from this comment:

https://github.com/sillsdev/silnlp/pull/491#pullrequestreview-2261754354

> I would make the output directory an optional command-line argument. By default, you should extract files to `SIL_NLP_ENV.mt_corpora_dir`. This should point to the MT/corpora folder in the S3 bucket, which is where we would store this kind of corpus.

I wasn't clear on the directory structure to use within the corpora dir, so I kept the existing logic of generating a unique folder based on the cli inputs + timestamp.

Note that this PR is built off the back of https://github.com/sillsdev/silnlp/pull/506. When that one is merged I'll rebase this one and have it target `master`.

Once this PR is merged, all code review comments from #491 are addressed and balance is returned to the force.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/507)
<!-- Reviewable:end -->
