### PR TITLE
Remove spurious iso code for French

### DIFF
--- a/silnlp/common/iso_info.py
+++ b/silnlp/common/iso_info.py
@@ -715,7 +715,6 @@ data = [
     ("fij", "fj"),
     ("fin", "fi"),
     ("fra", "fr"),
-    ("fre", "fr"),
     ("fry", "fy"),
     ("ful", "ff"),
     ("geo", "ka"),


### PR DESCRIPTION
Removed fre which isn't a code for french.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/509)
<!-- Reviewable:end -->
