### PR TITLE
Issue 508: compare translations script

### DIFF
--- a/silnlp/common/compare_translations.py
+++ b/silnlp/common/compare_translations.py
@@ -1,0 +1,109 @@
+import argparse
+import re
+from pathlib import Path
+from typing import Dict, List, Set
+
+import sacrebleu
+
+from silnlp.common.metrics import compute_wer_score
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare translations")
+    parser.add_argument("--dir-path", type=Path, required=True, help="Path to the directory")
+    parser.add_argument("--file-path-a", type=Path, required=True, help="Path to the first file from the directory")
+    parser.add_argument("--file-path-b", type=Path, required=True, help="Path to the second file from the directory")
+    parser.add_argument(
+        "--scorers",
+        nargs="*",
+        metavar="scorer",
+        default={"bleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "wer", "ter"},
+        help="Set of scorers",
+    )
+    args = parser.parse_args()
+
+    file_a = args.dir_path.joinpath(args.file_path_a)
+    file_b = args.dir_path.joinpath(args.file_path_b)
+    scores = compare_translations(file_a, file_b, args.scorers)
+
+    with open(f"{args.dir_path}/comparison_scores.txt", "w") as f:
+        f.write(f"Comparison of Translations in Files: {args.file_path_a} and {args.file_path_b}\n")
+        for key, value in scores.items():
+            f.write(f"{key}: {value}\n")
+
+
+def compare_translations(file_a: Path, file_b: Path, scorers: Set[str]) -> Dict[str, float]:
+    try:
+        with open(file_a, "r") as f:
+            a_lines = f.readlines()
+            # Remove usfm markers
+            if file_a.name.lower().endswith(".usfm") or file_a.name.lower().endswith(".sfm"):
+                print("Removing USFM markers")
+                a_lines = a_lines[8:]
+                a_lines = [re.sub(r"^\\\S+(\s[0-9]+)?", "", line) for line in a_lines]
+        with open(file_b, "r") as f:
+            b_lines = f.readlines()
+            # Remove usfm markers
+            if file_b.name.lower().endswith(".usfm") or file_b.name.lower().endswith(".sfm"):
+                print("Removing USFM markers")
+                b_lines = b_lines[8:]
+                b_lines = [re.sub(r"^\\\S+(\s[0-9]+)?", "", line) for line in b_lines]
+
+        return score_pair(a_lines, [b_lines], scorers)
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        return
+
+
+def score_pair(pair_sys: List[str], pair_refs: List[List[str]], scorers: Set[str]) -> Dict[str, float]:
+    scores: Dict[str, float] = {}
+
+    if "bleu" in scorers:
+        bleu_score = sacrebleu.corpus_bleu(
+            pair_sys,
+            pair_refs,
+            lowercase=True,
+        )
+        scores["BLEU"] = bleu_score.score
+
+    if "chrf3" in scorers:
+        chrf3_score = sacrebleu.corpus_chrf(pair_sys, pair_refs, char_order=6, beta=3, remove_whitespace=True)
+        scores["chrF3"] = chrf3_score.score
+
+    if "chrf3+" in scorers:
+        chrfp_score = sacrebleu.corpus_chrf(
+            pair_sys, pair_refs, char_order=6, beta=3, word_order=1, remove_whitespace=True, eps_smoothing=True
+        )
+        scores["chrF3+"] = chrfp_score.score
+
+    if "chrf3++" in scorers:
+        chrfpp_score = sacrebleu.corpus_chrf(
+            pair_sys, pair_refs, char_order=6, beta=3, word_order=2, remove_whitespace=True, eps_smoothing=True
+        )
+        scores["chrF3++"] = chrfpp_score.score
+
+    if "spbleu" in scorers:
+        spbleu_score = sacrebleu.corpus_bleu(
+            pair_sys,
+            pair_refs,
+            lowercase=True,
+            tokenize="flores200",
+        )
+        scores["spBLEU"] = spbleu_score.score
+
+    if "wer" in scorers:
+        wer_score = compute_wer_score(pair_sys, pair_refs)
+        if wer_score >= 0:
+            scores["WER"] = wer_score
+
+    if "ter" in scorers:
+        ter_score = sacrebleu.corpus_ter(pair_sys, pair_refs)
+        if ter_score.score >= 0:
+            scores["TER"] = ter_score.score
+
+    return scores
+
+
+if __name__ == "__main__":
+    main()

--- a/silnlp/common/compare_translations.py
+++ b/silnlp/common/compare_translations.py
@@ -11,10 +11,10 @@ from silnlp.common.metrics import compute_wer_score
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compare translations")
     parser.add_argument(
-        "--dir-paths", nargs=2, type=Path, required=True, help="Paths to the Paratext project directories"
+        "--projects", nargs=2, type=Path, required=True, help="Paths to the Paratext project directories"
     )
     parser.add_argument(
-        "--output-path", type=Path, required=True, help="Path to the directory to save the comparison scores"
+        "--output-file", type=Path, required=False, help="Path to the file to save the comparison scores"
     )
     parser.add_argument(
         "--scorers",
@@ -24,12 +24,18 @@ def main() -> None:
         help="Set of scorers",
     )
     args = parser.parse_args()
-    scores = compare_translations(args.dir_paths[0], args.dir_paths[1], args.scorers)
+    scores = compare_translations(args.projects[0], args.projects[1], args.scorers)
 
-    with open(f"{args.output_path}/comparison_scores.txt", "w") as f:
-        f.write(f"Comparison of Translations in Paratext Projects: {args.dir_paths[0]} and {args.dir_paths[1]}\n")
+    print(f"{args.projects[0]},{args.projects[1]}")
+    if args.output_file is not None:
+        with open(args.output_file, "w") as f:
+            f.write(f"{args.projects[0]},{args.projects[1]}\n")
+            for key, value in scores.items():
+                f.write(f"{key},{value}\n")
+                print(f"{key},{value}")
+    else:
         for key, value in scores.items():
-            f.write(f"{key}: {value}\n")
+            print(f"{key},{value}")
 
 
 def compare_translations(project1: Path, project2: Path, scorers: Set[str]) -> Dict[str, float]:

--- a/silnlp/common/compare_translations.py
+++ b/silnlp/common/compare_translations.py
@@ -11,8 +11,7 @@ from silnlp.common.metrics import compute_wer_score
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compare translations")
     parser.add_argument("--dir-path", type=Path, required=True, help="Path to the directory")
-    parser.add_argument("--file-path-a", type=Path, required=True, help="Path to the first file from the directory")
-    parser.add_argument("--file-path-b", type=Path, required=True, help="Path to the second file from the directory")
+    parser.add_argument("--file-paths", nargs=2, required=True, type=Path, help="Paths to the files from the directory")
     parser.add_argument(
         "--scorers",
         nargs="*",
@@ -22,12 +21,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    file_a = args.dir_path.joinpath(args.file_path_a)
-    file_b = args.dir_path.joinpath(args.file_path_b)
+    file_a = args.dir_path.joinpath(args.file_paths[0])
+    file_b = args.dir_path.joinpath(args.file_paths[1])
     scores = compare_translations(file_a, file_b, args.scorers)
 
     with open(f"{args.dir_path}/comparison_scores.txt", "w") as f:
-        f.write(f"Comparison of Translations in Files: {args.file_path_a} and {args.file_path_b}\n")
+        f.write(f"Comparison of Translations in Files: {args.file_paths[0]} and {args.file_paths[1]}\n")
         for key, value in scores.items():
             f.write(f"{key}: {value}\n")
 


### PR DESCRIPTION
- Created the compare_translations.py script and added it to silnlp/common
- The script takes 2 required arguments and 1 optional
     - dir-path - the path to the directory where the translations are found and where the comparison output will be stored
     - file-paths - the paths to each of the translation outputs that need to be compared, takes exactly 2 file paths
     - scorers - optional argument that contains the set of scorers to use for comparison, default is:
     {"bleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "wer", "ter"}
- The output of this script is stored in comparison_scores.txt at dir-path and contains the relevant filenames and each scorer and result used.

I did not add an S3 bucket connection yet, but this script can be extended later on to add that functionality if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/510)
<!-- Reviewable:end -->
