### PR TITLE
Issue 494: Add repair logic for split lines to extract_xri script

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -105,21 +105,108 @@ def load_sentence_pairs(input_file_path: str) -> List[SentencePair]:
     source_column_index = get_column_index("source")
     target_column_index = get_column_index("target")
     split_column_index = get_column_index("split")
+    logger.debug(
+        f"Column indexes: id={id_column_index} source={source_column_index} target={target_column_index} split={split_column_index}"
+    )
 
-    def parse_and_log_id(row: List[str]) -> int:
-        id = int(row[id_column_index])
-        logger.debug(f"Processing row with id: {id}")
-        return id
+    logger.debug("Checking all rows contain 4 cells")
+    all_rows_contain_four_cells = all(len(row) == 4 for row in data_rows)
+    if not all_rows_contain_four_cells:
+        # Potential causes:
+        # - missing entries
+        # - newlines embedded in source or target sentences that are splitting them
+        # - trailing tab characters added causing extra rows
+        logger.warning("Not all rows contain 4 cells")
+
+    repaired = repair_if_necessary(id_column_index, data_rows)
+
+    def parse_and_log_id(row_index: int, row: List[str]) -> int:
+        logger.debug(f"Loading row {row_index} into sentence pair structure: {row}")
+        return int(row[id_column_index])
 
     return [
         SentencePair(
-            id=parse_and_log_id(row),
+            id=parse_and_log_id(row_index, row),
             source=row[source_column_index],
             target=row[target_column_index],
             split=Split[row[split_column_index]],
         )
-        for row in data_rows
+        for row_index, row in enumerate(repaired)
     ]
+
+
+def repair_if_necessary(id_column_index: int, rows: List[List[str]]) -> List[List[str]]:
+    """
+    Searches for rows that have been broken over 2 lines, and repairs them into a single line.
+    This can happen sometimes due to newlines being inserted into the source or target sentences.
+    """
+    repair_logger = logging.getLogger("repair")
+    repair_logger.info("Repair starting")
+    # If newlines were in the original tsv, then the row structure would be split up, e.g.
+    #     [ID0, source0, target0, split0]
+    #     [ID1, source1, tar]        | target1 broken over 2 lines
+    #     [get1, split1]             |
+    #     [ID2, source2, target2, split2]
+    #     [ID3, so        |
+    #     [urc]           | source3 broken over 3 lines
+    #     [e3, targ]      |      | target3 broken over 2 lines
+    #     [et3, split3]          |
+    # It would repair to:
+    #     [ID0, source0, target0, split0]
+    #     [ID1, source1, target1, split1]
+    #     [ID2, source2, target2, split2]
+    #     [ID3, source3, target3, split3]
+    #
+    # The mechanism for detecting splits is to look for lines that don't have a numerical id in the position expected.
+    # It's assumed that those lines should be joined up onto the lines prior.
+    # NOTE: If a source/target string happened to end with a newline followed by a number,
+    # then the number would split to the next line and be mistaken for an id.
+    # This is very unlikely and solving it increases complexity so we don't repair that case.
+
+    def try_extract_id(row: List[str]) -> Optional[int]:
+        """Tries to find a numerical id in the row passed at the expected position"""
+        if id_column_index >= len(row):
+            repair_logger.debug("Short row")
+            return None
+        else:
+            id_str = row[id_column_index]
+            if id_str.isdigit():
+                return int(id_str)
+            else:
+                repair_logger.debug(f"Can't parse id cell: '{id_str}' - assuming row is broken")
+                return None
+
+    repaired: List[List[str]] = []
+    # Represents the accumulated row data that is gradually populated when a sentence pair is split across many lines
+    current_row: List[str] = []
+    for row_index, next_row in enumerate(rows):
+        # Ignore empty lines
+        if not next_row:
+            repair_logger.debug(f"Empty line detected at row index={row_index}")
+            continue
+        id_opt = try_extract_id(next_row)
+        repair_logger.debug(f"Examining row index={row_index} id={id_opt}: {next_row}")
+        if id_opt is not None:
+            # We are starting a new row
+            # Commit the previously accumulated row (except in the special case of the first row)
+            if len(current_row) > 0:
+                repair_logger.debug(f"New row starting at index={row_index}, committing previous row {current_row}")
+                repaired.append(current_row)
+            current_row = next_row
+        else:
+            # Merge the current row with the next row
+            # The last cell of the previous row combines with the first cell of this row
+            repair_logger.debug(f"Merging row {row_index} with data from previous row(s)")
+            last_cell = current_row[-1]
+            first_cell = next_row[0]
+            current_row[-1] = last_cell + first_cell
+            current_row.extend(next_row[1:])
+
+    # The very last row needs to be committed as it doesn't have a following row
+    repaired.append(current_row)
+
+    repair_logger.info("Repair complete")
+    return repaired
 
 
 def write_output_file(filepath: Path, sentences: List[str]) -> None:
@@ -135,6 +222,7 @@ def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]
         logger.info("No output directory specified, defaulting to SIL_NLP_ENV.mt_corpora_dir")
         unique_dir = f"{cli_input.source_iso}-{cli_input.target_iso}-{cli_input.dataset_descriptor}-{time.strftime('%Y%m%d-%H%M%S')}"
         from ..common.environment import SIL_NLP_ENV
+
         output_dir = SIL_NLP_ENV.mt_corpora_dir / unique_dir
     else:
         logger.info("Using specified output directory")


### PR DESCRIPTION
This PR relates to Michael's request on issue https://github.com/sillsdev/silnlp/issues/494 for split lines:

> Filtering or correcting split sentences
> - Discard sentence pairs that don't follow the expected format
> - Stretch goal would be to re-assemble and retain sentence pairs that are split over 2 lines because of an embedded newline

The PR addresses the stretch goal part in that it repairs split lines, for example if the input tsv was this mess:

```tsv
id	source	target	split

0	source0	tar
get0	train
1	sour
ce1	tar
ge

t1	train
2	source2	target2	train
```

then it will process it as if it was this tsv:

```
id	source	target	split
0	source0	target0	train
1	source1	target1	train
2	source2	target2	train
```

The first request about discarding records that can't be processed hasn't been implemented. Currently the script would just crash in situations where it can't parse something rather than gracefully ignoring it. An example situation would be if there were less than 4 cells in a row. But I have at added a simple warning that would detect some of these cases.

The logic is a bit complex, you'll want to have had your morning coffee before reviewing. Basically it's like a fold that works its way through the rows accumulating the first line with any broken lines that follow. When it gets to a new line, it commits what it's accumulated so far and starts again.

Like usual, this PR is built off the back of another one that is waiting to merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/515)
<!-- Reviewable:end -->
