### PR TITLE
Issue 494: Add basic filtering and cleaning to extract_xri script

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -53,6 +53,7 @@ from typing import List, Optional
 
 
 logger = logging.getLogger(__package__ + ".extract_xri")
+repair_logger = logging.getLogger(logger.name + ".repair")
 
 
 class Split(Enum):
@@ -140,7 +141,6 @@ def repair_if_necessary(id_column_index: int, rows: List[List[str]]) -> List[Lis
     Searches for rows that have been broken over 2 lines, and repairs them into a single line.
     This can happen sometimes due to newlines being inserted into the source or target sentences.
     """
-    repair_logger = logging.getLogger("repair")
     repair_logger.info("Repair starting")
     # If newlines were in the original tsv, then the row structure would be split up, e.g.
     #     [ID0, source0, target0, split0]
@@ -266,6 +266,7 @@ def run(cli_input: CliInput) -> None:
     if cli_input.log_level is not None:
         log_level = getattr(logging, cli_input.log_level.upper())
         logger.setLevel(log_level)
+        repair_logger.setLevel(log_level)
     logger.info("Starting script")
     sentence_pairs = load_sentence_pairs(cli_input.input_file_path)
     create_extract_files(cli_input, sentence_pairs)


### PR DESCRIPTION
This PR implemented some requirements from this comment https://github.com/sillsdev/silnlp/issues/494#issuecomment-2345328525:

- Discard sentence pairs that don't follow the expected format
- Removal of Missing translations (indicated by `!`)
- Removal of leading/trailing whitespace on the sentence pairs

This is implemented with a big imperative loop that iterates over the original rows and on each iteration of the loop it will `continue` if it hits anything it wants to filter out. At the end of the iteration it adds the cleaned up sentence pair into its return list.

Once this is merged, the only outstanding data cleaning requirement for the extract_xri script will be dealing with duplicate source sentences.

I also added some additional tweaks related to the split cell:

- Split is case insensitive, e.g. they can pass "TRAIN" or "train"
- Extra whitespace around the split is allowed and gets trimmed off
- When the split can't be parsed, instead of failing, we assign it to "train"

There's a report logged out at the end of the filter/cleaning stage, e.g.

```
2024-09-13 15:24:46,654 - silnlp.common.extract_xri.clean - INFO - Finished filtering and cleaning stage. 3942 rows ingested. 3942 survived. 0 removed. 0 survivors were transformed in some way.
```

---

Some notes on this one:

> Discard sentence pairs that don't follow the expected format

I interpreted "the expected format" as meaning that all cells were present for the 4 fields (including id). So for example a row with only id and source cells would be considered invalid and skipped.

Previously the script just assumed every row had sufficient fields and would crash angrily with an index out of bounds error if some fields were missing. Now the script will pre-emptively check for this and skip rows it knows it can't process.

This creates some inconsistency I wanted to raise:

```
# This will get rejected
id0 source0 target0

# This will get accepted and fixed
id1 source1 target1 brain
```

The second example has all 4 cells, but there is a typo in the split cell, so it gets defaulted to using "train". If we are willing to do that, then we could consider making the first example pass as well and default to "train". Or make them both get skipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/517)
<!-- Reviewable:end -->
