### PR TITLE
Handle edge case caused by non-standard USFM

### DIFF
--- a/silnlp/common/corpus.py
+++ b/silnlp/common/corpus.py
@@ -59,11 +59,11 @@ def get_scripture_parallel_corpus(
             trg_line = trg_line.strip()
             vref = VerseRef.from_string(vref_line, ORIGINAL_VERSIFICATION)
             if src_line == "<range>" and trg_line == "<range>":
-                if vref.chapter_num == vrefs[-1].chapter_num:
+                if vref.book_num == vrefs[-1].book_num and vref.chapter_num == vrefs[-1].chapter_num:
                     vrefs[-1].simplify()
                     vrefs[-1] = VerseRef.from_range(vrefs[-1], vref)
             elif src_line == "<range>":
-                if vref.chapter_num == vrefs[-1].chapter_num:
+                if vref.book_num == vrefs[-1].book_num and vref.chapter_num == vrefs[-1].chapter_num:
                     vrefs[-1].simplify()
                     vrefs[-1] = VerseRef.from_range(vrefs[-1], vref)
                 if len(trg_line) > 0:
@@ -71,7 +71,7 @@ def get_scripture_parallel_corpus(
                         trg_sentences[-1] += " "
                     trg_sentences[-1] += trg_line
             elif trg_line == "<range>":
-                if vref.chapter_num == vrefs[-1].chapter_num:
+                if vref.book_num == vrefs[-1].book_num and vref.chapter_num == vrefs[-1].chapter_num:
                     vrefs[-1].simplify()
                     vrefs[-1] = VerseRef.from_range(vrefs[-1], vref)
                 if len(src_line) > 0:


### PR DESCRIPTION
TL;DR: A project with non-standard USFM was causing `get_scripture_parallel_corpus` to try to create illegal vref ranges. I don't think this particular scenario could happen with normal USFM, but the change won't affect standard use at all.

This error came about from a project with very non-standard USFM (the files are `.PTW`, but if that is another standard, I can't imagine that these files followed that either). In the files I looked at, there were lots of missing verse markers, chapter markers, etc.. This resulted in an extracted corpus with lots of `<range>` markers. In one case, a whole book was entirely `<range>` markers, so `get_scripture_parallel_corpus` was trying to create invalid cross-book VerseRef ranges, and it only got caught when the chapter number looped back around to that of the first vref.

Closes #520

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/522)
<!-- Reviewable:end -->
