### PR TITLE
Issue 494: Add stubbed normalization script

### DIFF
--- a/silnlp/common/normalize_extracts.py
+++ b/silnlp/common/normalize_extracts.py
@@ -1,0 +1,174 @@
+"""
+This script is passed a directory containing extract files.
+It loads the extract files and normalizes them, then writes them to a new location.
+
+Normalization currently entails simple whitespace changes.
+See https://github.com/sillsdev/silnlp/issues/494 for more context.
+
+Example:
+
+    $ python -m silnlp.common.normalize_extracts input_dir --output output_dir
+
+Suppose the input dir had the files below. The output dir will contain the normalized equivalents of those
+files with `.norm` put before `.txt` in each filename.
+
+      input_dir                                    output_dir
+        ├── swa-extract.all.txt                      ├── swa-extract.all.norm.txt
+        ├── ngq-extract.all.txt                      ├── ngq-extract.all.norm.txt
+        ├── swa-extract.train.txt     normalize      ├── swa-extract.train.norm.txt
+        ├── ngq-extract.train.txt     -------->      ├── ngq-extract.train.norm.txt
+        ├── swa-extract.val.txt                      ├── swa-extract.val.norm.txt
+        ├── ngq-extract.val.txt                      ├── ngq-extract.val.norm.txt
+        ├── swa-extract.test.txt                     ├── swa-extract.test.norm.txt
+        └── ngq-extract.test.txt                     └── ngq-extract.test.norm.txt
+                                                                          ^^^^
+
+The output dir is optional. When not specified, the input_dir is used.
+
+Only files in the input_dir that have `.txt` extension (and don't end with `.norm.txt`) will be considered.
+An optional glob filter can be added to further reduce which input files are transformed, using `--filter GLOB`.
+
+If an output file already exists in the output directory, it won't be written over and an error will be logged.
+The optional `--overwrite` flag will bypass this.
+
+By default the script uses the logging configuration inherited from the parent packages (which should log at INFO level).
+You can change the logging level with the optional `--log_level LOG_LEVEL` which accepts values like:
+"DEBUG", "INFO", "WARNING/WARN", "ERROR" and "CRITICAL".
+"""
+
+import argparse
+import logging
+
+from dataclasses import dataclass
+
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__package__ + ".normalize_extracts")
+all_loggers = [logger]  # More to be added
+
+
+@dataclass(frozen=True)
+class CliInput:
+    input_dir: str
+    output_dir: Optional[str]
+    overwrite: bool
+    filter: Optional[str]
+    log_level: Optional[str]
+
+
+def get_files_to_normalize(input_dir: Path, filter: Optional[str]) -> List[Path]:
+    """
+    Searches the top level of the input directory for extract files
+    that aren't normalized.
+    If the filter is defined, then further filtering of those candidates is performed.
+    """
+    # TODO
+    return []
+
+
+def normalized_path(output_dir: Path, input_path: Path) -> Path:
+    """
+    Uses the input path to generate corresponding output path with "norm" in the name.
+    e.g. extract.all.txt -> extract.all.norm.txt
+    """
+    # TODO
+    return Path("TODO")
+
+
+def normalize(extract_sentence: str) -> str:
+    """
+    Returns a normalized version of the input string.
+    """
+    # TODO
+    return extract_sentence
+
+
+def load_extract_file(path: Path) -> List[str]:
+    # TODO
+    return []
+
+
+def write_extract_file(path: Path, lines: List[str]) -> None:
+    # TODO
+    return
+
+
+def run(cli_input: CliInput) -> None:
+    if cli_input.log_level is not None:
+        log_level = getattr(logging, cli_input.log_level.upper())
+        for log in all_loggers:
+            log.setLevel(log_level)
+
+    logger.info("Starting script")
+
+    input_dir = Path(cli_input.input_dir)
+
+    if cli_input.output_dir is not None:
+        output_dir = Path(cli_input.output_dir)
+    else:
+        output_dir = input_dir
+    logger.info(f"Output dir set to {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files_to_normalize: List[Path] = get_files_to_normalize(input_dir, cli_input.filter)
+    logger.info(f"Found {len(files_to_normalize)} files to normalize")
+
+    for input_path in files_to_normalize:
+        logger.debug(f"Processing file {input_path}")
+        output_path: Path = normalized_path(output_dir, input_path)
+        logger.debug(f"Outputting to {output_path}")
+        if output_path.is_file() and not cli_input.overwrite:
+            logger.error(
+                f"Outpath '{output_path}' already exists. Skipping input {input_path}. "
+                + "You can use the --overwrite flag to write over existing files."
+            )
+
+        input_lines: List[str] = load_extract_file(input_path)
+        normalized_lines: List[str] = [normalize(extract_sentence) for extract_sentence in input_lines]
+        write_extract_file(output_path, normalized_lines)
+        logger.debug(f"Finished processing {input_path}")
+
+    logger.info("Completed script")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Normalizes extract files")
+
+    parser.add_argument(
+        "input_dir", help="Path to the directory containing the extract files to be normalized", type=str
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Optional path to the output directory where the normalized extract files will be dumped. "
+        + "When not specified the input directory is used",
+        type=str,
+    )
+    parser.add_argument(
+        "--overwrite",
+        help="Optional parameter to make output files overwrite existing files of the same name",
+        type=bool,
+        default=False,
+    )
+    parser.add_argument(
+        "--filter",
+        help="Optional glob filter to narrow down the transformed files to only those those that satisfy the glob",
+        type=str,
+    )
+    parser.add_argument(
+        "--log-level", help="Optional parameter to override the default logging level for this script", type=str
+    )
+    args = parser.parse_args()
+
+    cli_input = CliInput(
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        overwrite=args.overwrite,
+        filter=args.filter,
+        log_level=args.log_level,
+    )
+    run(cli_input)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds an initial stubbed out script to normalize extract files.

It is the first step to implement the second half of this comment: https://github.com/sillsdev/silnlp/issues/494#issuecomment-2345328525

> # Normalization Script Responsibilities
>
> - Convert multiple consecutive spaces to a single space
> - Correct inconsistent spacing around punctuation

The main parts of the logic are stubbed out so when you run the script it doesn't do much:

```
$ python -m silnlp.common.normalize_extracts /tmp/xri --output hackery/normalized
2024-09-19 17:08:17,470 - silnlp.common.normalize_extracts - INFO - Starting script
2024-09-19 17:08:17,470 - silnlp.common.normalize_extracts - INFO - Output dir set to hackery/normalized
2024-09-19 17:08:17,470 - silnlp.common.normalize_extracts - INFO - Found 0 files to normalize
2024-09-19 17:08:17,470 - silnlp.common.normalize_extracts - INFO - Completed script
```

The aim of the PR is to get verification from Damien and Michael that the script interface and general approach makes sense as there hasn't been any discussions on those specific details. Once that is sorted, I'll fill in the other parts in follow up PR's, hence the stubbing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/527)
<!-- Reviewable:end -->
