### PR TITLE
Upgrade 'packaging' to be compatible with the latest version of clearml-session

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2876,17 +2876,14 @@ six = ">=1.8.0"
 
 [[package]]
 name = "packaging"
-version = "21.3"
+version = "22.0"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
-    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+    {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
+    {file = "packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
 ]
-
-[package.dependencies]
-pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
@@ -5702,4 +5699,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.9"
-content-hash = "997f3c1157f0aa69198f304393a9c23bd518a486603218aaaeed8e75bab78371"
+content-hash = "a6db0be62da76ae8d3985b78c69115794641592cf988ef8dcb02d7a8b42ed597"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ attrs = "^22.2.0"
 jsonschema = "^4.18.0"
 requests = "^2.31"
 openpyxl = "^3.1.2"
+packaging = "^22.0"
 
 [tool.poetry.group.dev.dependencies]
 types-pyyaml = "^6.0.12.12"


### PR DESCRIPTION
clearml-session uses jupyter-server 2.14.2, which has a dependency on packaging>=22.0. This was preventing some other pip packages from being installed, in my case poetry and protobuf.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/529)
<!-- Reviewable:end -->
