### PR TITLE
Updated term glosses

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -380,8 +380,8 @@ class Config(ABC):
                 self.src_projects.update(sf.project for sf in corpus_pair.src_files)
                 self.trg_projects.update(sf.project for sf in corpus_pair.trg_files)
                 if terms_config["include_glosses"]:
-                    for gloss_iso in ["fr", "en", "id"]:
-                        if gloss_iso in pair_src_isos:
+                    for gloss_iso in ["fr", "en", "id", "es"]:
+                        if gloss_iso in pair_src_isos or gloss_iso == terms_config["include_glosses"]:
                             self.src_file_paths.update(get_terms_glosses_file_paths(corpus_pair.src_terms_files))
                         if gloss_iso in pair_trg_isos:
                             self.trg_file_paths.update(get_terms_glosses_file_paths(corpus_pair.trg_terms_files))
@@ -1105,7 +1105,7 @@ class Config(ABC):
                 cur_terms["target_lang"] = trg_terms_file.iso
                 terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
         if terms_config["include_glosses"]:
-            for gloss_iso in ["en", "fr", "id"]:
+            for gloss_iso in ["en", "fr", "id", "es"]:
                 if gloss_iso in self.trg_isos:
                     for src_terms_file, src_terms, tags_str in all_src_terms:
                         cur_terms = get_terms_data_frame(src_terms, categories_set, filter_books)
@@ -1113,7 +1113,7 @@ class Config(ABC):
                         cur_terms["source_lang"] = src_terms_file.iso
                         cur_terms["target_lang"] = gloss_iso
                         terms = self._add_to_terms_data_set(terms, cur_terms, tags_str)
-                if gloss_iso in self.src_isos:
+                if gloss_iso in self.src_isos or gloss_iso == terms_config["include_glosses"]:
                     for trg_terms_file, trg_terms, tags_str in all_trg_terms:
                         cur_terms = get_terms_data_frame(trg_terms, categories_set, filter_books)
                         cur_terms = cur_terms.rename(columns={"rendering": "target", "gloss": "source"})


### PR DESCRIPTION
-Added support for Spanish glosses
-Added an option to use one of the supported glosses (en, fr, id, es) even when the source language is not one of those four. -In the terms config, "include_glosses" can now be either true/false or one of the glosses language codes (en,fr,id,es) to indicate which gloss to use if the source is different.

NOTE: The wiki will need to be updated to reflect the "include_glosses" config change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/530)
<!-- Reviewable:end -->
