### PR TITLE
Added an option for a book filter for KBTs

### DIFF
--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -12,7 +12,7 @@ from statistics import mean, median, stdev
 from typing import Any, Dict, Iterable, List, Optional, Set, TextIO, Tuple, Union, cast
 
 import pandas as pd
-from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef, get_chapters
+from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef, get_books, get_chapters
 from machine.tokenization import LatinWordTokenizer
 from tqdm import tqdm
 
@@ -1037,7 +1037,7 @@ class Config(ABC):
     ) -> int:
 
         try:
-            filter_books = get_chapters(self.data["terms"]["filter_books"]).keys()
+            filter_books = get_books(self.data["terms"]["filter_books"])
         except KeyError:
             filter_books = None
 

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -1035,7 +1035,13 @@ class Config(ABC):
         src_terms_files: List[Tuple[DataFile, str]],
         trg_terms_files: List[Tuple[DataFile, str]],
     ) -> int:
-        terms = self._collect_terms(src_terms_files, trg_terms_files)
+
+        try:
+            filter_books = get_chapters(self.data["terms"]["filter_books"]).keys()
+        except KeyError:
+            filter_books = None
+
+        terms = self._collect_terms(src_terms_files, trg_terms_files, filter_books)
 
         if terms is None:
             return 0


### PR DESCRIPTION
-In the config file, under the terms section, a new option was added: filter_books.
-filter_books uses the same syntax as corpus_books, except chapter selections will be ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/531)
<!-- Reviewable:end -->
