### PR TITLE
#513 multiple diverse drafts

### DIFF
--- a/silnlp/common/translate_google.py
+++ b/silnlp/common/translate_google.py
@@ -6,7 +6,7 @@ from machine.scripture import VerseRef, book_id_to_number
 
 from ..common.environment import SIL_NLP_ENV
 from .paratext import book_file_name_digits
-from .translator import Translator
+from .translator import TranslationSet, Translator
 from .utils import get_git_revision_hash, get_mt_exp_dir
 
 
@@ -15,8 +15,13 @@ class GoogleTranslator(Translator):
         self._translate_client = translate.Client()
 
     def translate(
-        self, sentences: Iterable[str], src_iso: str, trg_iso: str, vrefs: Optional[Iterable[VerseRef]] = None
-    ) -> Iterable[str]:
+        self,
+        sentences: Iterable[str],
+        src_iso: str,
+        trg_iso: str,
+        produce_multiple_translations: bool = False,
+        vrefs: Optional[Iterable[VerseRef]] = None,
+    ) -> Iterable[TranslationSet]:
         for sentence in sentences:
             if len(sentence) == 0:
                 yield ""
@@ -25,7 +30,7 @@ class GoogleTranslator(Translator):
                     sentence, source_language=src_iso, target_language=trg_iso, format_="text"
                 )
                 translation = results["translatedText"]
-                yield translation
+                yield TranslationSet([translation])
 
 
 def main() -> None:

--- a/silnlp/common/translate_google.py
+++ b/silnlp/common/translate_google.py
@@ -36,7 +36,7 @@ class GoogleTranslator(Translator):
                     sentence, source_language=src_iso, target_language=trg_iso, format_="text"
                 )
                 translation = results["translatedText"]
-                yield TranslationGroup([translation])
+                yield [translation]
 
 
 def main() -> None:

--- a/silnlp/common/translate_google.py
+++ b/silnlp/common/translate_google.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from typing import Iterable, Optional
 
 from google.cloud import translate_v2 as translate
@@ -6,8 +7,10 @@ from machine.scripture import VerseRef, book_id_to_number
 
 from ..common.environment import SIL_NLP_ENV
 from .paratext import book_file_name_digits
-from .translator import TranslationSet, Translator
+from .translator import TranslationGroup, Translator
 from .utils import get_git_revision_hash, get_mt_exp_dir
+
+LOGGER = logging.getLogger(__package__ + ".translate")
 
 
 class GoogleTranslator(Translator):
@@ -21,7 +24,10 @@ class GoogleTranslator(Translator):
         trg_iso: str,
         produce_multiple_translations: bool = False,
         vrefs: Optional[Iterable[VerseRef]] = None,
-    ) -> Iterable[TranslationSet]:
+    ) -> Iterable[TranslationGroup]:
+        if produce_multiple_translations:
+            LOGGER.warning("Google Translator does not support --multiple-translations")
+
         for sentence in sentences:
             if len(sentence) == 0:
                 yield ""
@@ -30,7 +36,7 @@ class GoogleTranslator(Translator):
                     sentence, source_language=src_iso, target_language=trg_iso, format_="text"
                 )
                 translation = results["translatedText"]
-                yield TranslationSet([translation])
+                yield TranslationGroup([translation])
 
 
 def main() -> None:

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -76,10 +76,10 @@ class DraftSet:
         self.initial_translation_set: TranslationSet = next(self.translation_sets)
         self.num_drafts: int = self.initial_translation_set.num_translations()
 
-    def get_drafts(self) -> list[TranslatedDraft]:
+    def get_drafts(self) -> List[TranslatedDraft]:
         # for a single draft, don't consume the generator
         if self.num_drafts == 1:
-            return [TranslationSet(self.create_draft_sentence_generator(0))]
+            return [TranslatedDraft(self.create_draft_sentence_generator(0))]
         else:
             return self.create_draft_sentence_lists()
 
@@ -87,7 +87,7 @@ class DraftSet:
         yield self.initial_translation_set.translations[draft_index]
         yield from [ts.translations[draft_index] for ts in self.translation_sets]
 
-    def create_draft_sentence_lists(self) -> list[TranslatedDraft]:
+    def create_draft_sentence_lists(self) -> List[TranslatedDraft]:
         translated_draft_sentences = [
             [self.initial_translation_set.translations[draft_index]] for draft_index in range(self.num_drafts)
         ]
@@ -96,7 +96,7 @@ class DraftSet:
             for draft_index in range(self.num_drafts):
                 translated_draft_sentences[draft_index].append(translation_set.translations[draft_index])
 
-        return [TranslationSet(sentence_list) for sentence_list in translated_draft_sentences]
+        return [TranslatedDraft(sentence_list) for sentence_list in translated_draft_sentences]
 
     def get_drafts_with_indices(self):
         return zip(self.get_drafts(), range(1, self.num_drafts + 1))
@@ -122,7 +122,6 @@ class Translator(ABC):
         trg_iso: str,
         produce_multiple_translations: bool = False,
     ) -> None:
-
         draft_set: DraftSet = DraftSet(
             self.translate(load_corpus(src_file_path), src_iso, trg_iso, produce_multiple_translations)
         )

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -38,7 +38,7 @@ from ..common.corpus import (
 )
 from ..common.environment import SIL_NLP_ENV
 from ..common.script_utils import get_script, is_represented
-from ..common.translator import TranslationSet
+from ..common.translator import TranslationGroup
 from ..common.utils import NoiseMethod, Side, create_noise_methods, get_mt_exp_dir, is_set, set_seed
 from .augment import AugmentMethod, create_augment_methods
 from .tokenizer import Tokenizer
@@ -334,7 +334,7 @@ class NMTModel(ABC):
         trg_iso: str,
         vrefs: Optional[Iterable[VerseRef]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
-    ) -> Iterable[TranslationSet]: ...
+    ) -> Iterable[TranslationGroup]: ...
 
     @abstractmethod
     def get_checkpoint_path(self, ckpt: Union[CheckpointType, str, int]) -> Tuple[Path, int]: ...

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -38,6 +38,7 @@ from ..common.corpus import (
 )
 from ..common.environment import SIL_NLP_ENV
 from ..common.script_utils import get_script, is_represented
+from ..common.translator import TranslationSet
 from ..common.utils import NoiseMethod, Side, create_noise_methods, get_mt_exp_dir, is_set, set_seed
 from .augment import AugmentMethod, create_augment_methods
 from .tokenizer import Tokenizer
@@ -320,6 +321,7 @@ class NMTModel(ABC):
         self,
         input_paths: List[Path],
         translation_paths: List[Path],
+        produce_multiple_translations: bool = False,
         vref_paths: Optional[List[Path]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
     ) -> None: ...
@@ -332,7 +334,7 @@ class NMTModel(ABC):
         trg_iso: str,
         vrefs: Optional[Iterable[VerseRef]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
-    ) -> Iterable[str]: ...
+    ) -> Iterable[TranslationSet]: ...
 
     @abstractmethod
     def get_checkpoint_path(self, ckpt: Union[CheckpointType, str, int]) -> Tuple[Path, int]: ...

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -28,6 +28,7 @@ class SILExperiment:
     run_train: bool = False
     run_test: bool = False
     run_translate: bool = False
+    produce_multiple_translations: bool = False
     scorers: Set[str] = field(default_factory=set)
     score_by_book: bool = False
     commit: Optional[str] = None
@@ -105,6 +106,7 @@ class SILExperiment:
                     config.get("src_project"),
                     config.get("trg_project"),
                     config.get("trg_iso"),
+                    self.produce_multiple_translations,
                     config.get("include_inline_elements", False),
                 )
             elif config.get("src_prefix"):
@@ -115,6 +117,7 @@ class SILExperiment:
                     config.get("end_seq"),
                     config.get("src_iso"),
                     config.get("trg_iso"),
+                    self.produce_multiple_translations,
                 )
             elif config.get("src"):
                 translator.translate_files(
@@ -122,6 +125,7 @@ class SILExperiment:
                     config.get("trg"),
                     config.get("src_iso"),
                     config.get("trg_iso"),
+                    self.produce_multiple_translations,
                     config.get("include_inline_elements", False),
                 )
             else:
@@ -150,6 +154,12 @@ def main() -> None:
     parser.add_argument("--train", default=False, action="store_true", help="Run the train step.")
     parser.add_argument("--test", default=False, action="store_true", help="Run the test step.")
     parser.add_argument("--translate", default=False, action="store_true", help="Create drafts.")
+    parser.add_argument(
+        "--multiple-translations",
+        default=False,
+        action="store_true",
+        help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
+    )
     parser.add_argument("--score-by-book", default=False, action="store_true", help="Score individual books")
     parser.add_argument("--mt-dir", default=None, type=str, help="The machine translation directory.")
     parser.add_argument(
@@ -199,6 +209,7 @@ def main() -> None:
         run_train=args.train,
         run_test=args.test,
         run_translate=args.translate,
+        produce_multiple_translations=args.multiple_translations,
         scorers=set(s.lower() for s in args.scorers),
         score_by_book=args.score_by_book,
         commit=args.commit,

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -306,7 +306,7 @@ class HuggingFaceConfig(Config):
                 },
                 "infer": {
                     "infer_batch_size": 16,
-                    "num_beams": 5,
+                    "num_beams": 2,
                     "num_drafts": 3,
                     "multiple_translations_method": "hybrid",
                     "temperature": 0.75,
@@ -1067,7 +1067,7 @@ class HuggingFaceNMTModel(NMTModel):
         ):
             if isinstance(outputs, OutputGroup):
                 outputs = [outputs]
-            yield from [TranslationGroup(output_group.get_translated_text()) for output_group in outputs]
+            yield from [output_group.get_translated_text() for output_group in outputs]
 
     def get_checkpoint_path(self, ckpt: Union[CheckpointType, str, int]) -> Tuple[Path, int]:
         step: Optional[int] = None

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -413,6 +413,7 @@ def test_checkpoint(
         model.translate_test_files(
             source_paths,
             translation_paths,
+            False,
             vref_paths,
             step if checkpoint_type is CheckpointType.OTHER else checkpoint_type,
         )

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -413,9 +413,9 @@ def test_checkpoint(
         model.translate_test_files(
             source_paths,
             translation_paths,
-            False,
-            vref_paths,
-            step if checkpoint_type is CheckpointType.OTHER else checkpoint_type,
+            produce_multiple_translations=False,
+            vref_paths=vref_paths,
+            ckpt=step if checkpoint_type is CheckpointType.OTHER else checkpoint_type,
         )
 
     LOGGER.info(f"Scoring {checkpoint_name}")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -33,7 +33,7 @@ class NMTTranslator(Translator):
         vrefs: Optional[Iterable[VerseRef]] = None,
     ) -> Iterable[TranslationSet]:
         return self._model.translate(
-            sentences, src_iso, trg_iso, vrefs, produce_multiple_translations, self._checkpoint
+            sentences, src_iso, trg_iso, produce_multiple_translations, vrefs, self._checkpoint
         )
 
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -11,7 +11,7 @@ from machine.scripture import VerseRef, book_number_to_id, get_chapters
 from ..common.environment import SIL_NLP_ENV
 from ..common.paratext import book_file_name_digits, get_project_dir
 from ..common.tf_utils import enable_eager_execution, enable_memory_growth
-from ..common.translator import TranslationSet, Translator
+from ..common.translator import TranslationGroup, Translator
 from ..common.utils import get_git_revision_hash, show_attrs
 from .clearml_connection import SILClearML
 from .config import CheckpointType, Config, NMTModel
@@ -31,7 +31,7 @@ class NMTTranslator(Translator):
         trg_iso: str,
         produce_multiple_translations: bool = False,
         vrefs: Optional[Iterable[VerseRef]] = None,
-    ) -> Iterable[TranslationSet]:
+    ) -> Iterable[TranslationGroup]:
         return self._model.translate(
             sentences, src_iso, trg_iso, produce_multiple_translations, vrefs, self._checkpoint
         )
@@ -107,6 +107,7 @@ class TranslationTask:
                     book,
                     output_path,
                     trg_iso,
+                    produce_multiple_translations,
                     chapters,
                     trg_project,
                     include_inline_elements,
@@ -132,7 +133,6 @@ class TranslationTask:
         produce_multiple_translations: bool = False,
     ) -> None:
         translator, config, _ = self._init_translation_task(experiment_suffix=f"_{self.checkpoint}_{src_prefix}")
-
         if trg_prefix is None:
             raise RuntimeError("A target file prefix must be specified.")
         if start_seq is None or end_seq is None:
@@ -290,7 +290,7 @@ def main() -> None:
         "--multiple-translations",
         default=False,
         action="store_true",
-        help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1", ".2", etc.',
+        help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
     )
     parser.add_argument(
         "--include-inline-elements",


### PR DESCRIPTION
This adds the ability for SILNLP's translate functionality to produce multiple diverse drafts.  This ability is controlled by the --multiple-translations parameter on the command line (for both translate.py and experiment.py).  The other parameters, such as number of drafts and the method of creating multiple translations, are specified in the config file.

When multiple translations are requested, the output file name is given a different extension for each draft.  For example, if you specify "output.txt" as the output file and request 3 drafts, then three files will be created called "output.1.txt", "output.2.txt", and "output.3.txt".

The default method for producing multiple translations is called "hybrid" and uses a combination of beam search and sampling.  Other supported values are "sampling" which creates each draft with random sampling, "beam_search" which uses vanilla beam search (using the top-n hypotheses to populate the n drafts), and "diverse_beam_search" which uses the method in Vijayakumar, et al., 2016.  Other new parameters controlling the creation of multiple drafts are "temperature" and "diversity_penalty".  I will plan to document all of this in the wiki.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/533)
<!-- Reviewable:end -->
