### PR TITLE
remove extra brackets

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1371,7 +1371,7 @@ class HuggingFaceNMTModel(NMTModel):
 
         else:
             yield from [
-                OutputGroup([translated_sentence])
+                OutputGroup(translated_sentence)
                 for translated_sentence in self._translate_with_beam_search(
                     pipeline,
                     sentences,


### PR DESCRIPTION
Removed the extra brackets in `_translate_sentence_helper` in `hugging_face_config.py` and tested that experiment.py now runs without error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/541)
<!-- Reviewable:end -->
