### PR TITLE
Use silnlp image, use system-site-packages

### DIFF
--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -48,7 +48,7 @@ class SILClearML:
             self._load_config()
 
             self.task.set_base_docker(
-                docker_image="ghcr.io/sillsdev/silnlp:0.1.14",
+                docker_image="ghcr.io/sillsdev/silnlp:latest",
                 docker_arguments=[
                     "--env TOKENIZERS_PARALLELISM='false'",
                 ],

--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -48,14 +48,20 @@ class SILClearML:
             self._load_config()
 
             self.task.set_base_docker(
-                # docker_image="ghcr.io/sillsdev/silnlp:1.01.4",
-                docker_image="nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu20.04",
-                docker_arguments="--env TOKENIZERS_PARALLELISM=false",
+                docker_image="ghcr.io/sillsdev/silnlp:0.1.14",
+                docker_arguments=[
+                    "--env TOKENIZERS_PARALLELISM='false'",
+                ],
                 docker_setup_bash_script=[
                     "apt install -y python3-venv",
                     "python3 -m pip install --user pipx",
                     "PATH=$PATH:/root/.local/bin",
                     "pipx install poetry==1.7.1",
+                    "poetry config virtualenvs.options.system-site-packages true",
+                    (
+                        "sed -i 's/include-system-site-packages = .*/include-system-site-packages = true/' "
+                        "/root/.local/share/pipx/venvs/poetry/pyvenv.cfg"
+                    ),
                 ],
             )
             if self.commit:

--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -57,6 +57,7 @@ class SILClearML:
                     "python3 -m pip install --user pipx",
                     "PATH=$PATH:/root/.local/bin",
                     "pipx install poetry==1.7.1",
+                    # update config.toml and pyvenv.cfg to give poetry environment access to system site packages
                     "poetry config virtualenvs.options.system-site-packages true",
                     (
                         "sed -i 's/include-system-site-packages = .*/include-system-site-packages = true/' "


### PR DESCRIPTION
This PR replaces the old nvidia/cuda image in `clearml_connection.py` with the SILNLP docker image. There are additions to the `docker_setup_bash_script` to allow Poetry to use system-site-packages. It now only takes ~6 seconds instead of ~1 minute for all the packages to be installed when running an experiment.

You'll see that it currently specifies an exact version of the SILNLP docker container rather than using `latest`. This is because currently the ClearML agents are set to not pull new versions of docker images, so `latest` doesn't work. If we'd like the ClearML agents to always check for the latest version of the SILNLP image, I can update that in the `clearml.conf`. And then once all the agents are restarted I can update this code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/542)
<!-- Reviewable:end -->
