### PR TITLE
Issue 546: Tighten filtering logic for single character sentences

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -282,8 +282,11 @@ def filter_and_clean(
         source = trim(row[column_schema.source_column_index], "source")
         target = trim(row[column_schema.target_column_index], "target")
 
-        if target == "!":
-            clean_logger.debug("Target sentence is '!' indicating it is not translated. Ignoring.")
+        # See discussion: https://github.com/sillsdev/silnlp/issues/546#issuecomment-2391335853
+        if len(source) <= 1 or len(target) <= 1:
+            clean_logger.debug("Ignoring sentence pair as it has only one non-whitespace character in either source or target")
+            if target == "!":
+                clean_logger.debug("Target sentence is '!' indicating it is not translated.")
             continue
 
         split_text = trim(row[column_schema.split_column_index], "split").lower()

--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -379,7 +379,8 @@ def write_output_file(filepath: Path, sentences: List[str]) -> None:
     logger.debug(f"Writing {len(sentences)} sentences to file: {filepath}")
     with open(filepath, "w", encoding="utf-8") as f:
         for sentence in sentences:
-            f.write(f"{sentence}{os.linesep}")
+            # For choice of line ending, see discussion: https://github.com/sillsdev/silnlp/issues/546#issuecomment-2391314524
+            f.write(f"{sentence}\n")
 
 
 def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]) -> None:


### PR DESCRIPTION
This PR addresses this feedback from Michael: https://github.com/sillsdev/silnlp/issues/546#issuecomment-2391335853

Any sentence pair where the source/target has only 1 character after trimming is filtered out.

---

Example input file:

```
id	source	target	split
0	s0 	 t0	train
1	s 	long	train
2	long	t	train
3	   s   	  t  	train
4	 source   	  !  	train
```

Only id=0 survives filtering as both source and target have 2 characters.

Example run showing just the cleaning logs:

```
python -m silnlp.common.extract_xri hackery/simple.tsv swa ngq hackery --output hackery/out --log-level DEBUG 2>&1 | grep clean

2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - INFO - Starting filtering and cleaning stage
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Required number of columns for each stage is 4
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Processing row index=0: ['0', 's0 ', ' t0', 'train']
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'source' field. Number of trimmed chars: 1
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'target' field. Number of trimmed chars: 1
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Successfully parsed and cleaned row index=0 id=0. Transformations applied? True
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Processing row index=1: ['1', 's ', 'long', 'train']
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'source' field. Number of trimmed chars: 1
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Ignoring sentence pair as it has only one non-whitespace character in either source or target
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Processing row index=2: ['2', 'long', 't', 'train']
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Ignoring sentence pair as it has only one non-whitespace character in either source or target
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Processing row index=3: ['3', '   s   ', '  t  ', 'train']
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'source' field. Number of trimmed chars: 6
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'target' field. Number of trimmed chars: 4
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Ignoring sentence pair as it has only one non-whitespace character in either source or target
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Processing row index=4: ['4', ' source   ', '  !  ', 'train']
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'source' field. Number of trimmed chars: 4
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Boundary whitespace trimmed off 'target' field. Number of trimmed chars: 4
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Ignoring sentence pair as it has only one non-whitespace character in either source or target
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - DEBUG - Target sentence is '!' indicating it is not translated.
2024-10-03 23:17:03,148 - silnlp.common.extract_xri.clean - INFO - Finished filtering and cleaning stage. 5 rows ingested. 1 survived. 4 removed. 1 survivors were transformed in some way.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/547)
<!-- Reviewable:end -->
