### PR TITLE
Issue 546: use unix line endings for extract files in all cases

### DIFF
--- a/silnlp/common/extract_xri.py
+++ b/silnlp/common/extract_xri.py
@@ -379,7 +379,8 @@ def write_output_file(filepath: Path, sentences: List[str]) -> None:
     logger.debug(f"Writing {len(sentences)} sentences to file: {filepath}")
     with open(filepath, "w", encoding="utf-8") as f:
         for sentence in sentences:
-            f.write(f"{sentence}{os.linesep}")
+            # For choice of line ending, see discussion: https://github.com/sillsdev/silnlp/issues/546#issuecomment-2391314524
+            f.write(f"{sentence}\n")
 
 
 def create_extract_files(cli_input: CliInput, sentence_pairs: List[SentencePair]) -> None:


### PR DESCRIPTION
This PR addresses Michael's feedback from this comment: https://github.com/sillsdev/silnlp/issues/546#issuecomment-2391314524 by switching the extract file to always use unix line endings (`\n`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/548)
<!-- Reviewable:end -->
