### PR TITLE
Issue 494: Add normalization to shrink consecutive whitespace to a single space

### DIFF
--- a/silnlp/common/normalize_extracts.py
+++ b/silnlp/common/normalize_extracts.py
@@ -39,6 +39,7 @@ You can change the logging level with the optional `--log-level LOG_LEVEL` which
 import argparse
 import logging
 import os
+import re
 
 from dataclasses import dataclass
 
@@ -89,12 +90,12 @@ def normalized_path(output_dir: Path, input_path: Path) -> Path:
     return output_dir / output_filename
 
 
+consecutive_spaces = re.compile("\\s+")
 def normalize(extract_sentence: str) -> str:
     """
     Returns a normalized version of the input string.
     """
-    # TODO
-    return extract_sentence
+    return re.sub(consecutive_spaces, " ", extract_sentence)
 
 
 def load_extract_file(path: Path) -> List[str]:


### PR DESCRIPTION
This PR adds very basic normalization for extract strings to shrink consecutive whitespace characters to a single space, e.g. `"a      b    \t\t     c"` -> `"a b c"`.

It addresses this requirement from Michael: (see https://github.com/sillsdev/silnlp/issues/494#issuecomment-2345328525):

> Convert multiple consecutive spaces to a single space

Note this goes a little further and will pick up _any_ whitespace (tabs, carriage returns, bells) and convert it to a regular space character. I haven't seen cases of this yet - just being cautious.

The only remaining requirement for issue 494 will be:

> Correct inconsistent spacing around punctuation

then issue 494 can be closed. Future requirements would go onto a different issue. I am waiting for a definition of what is considered "punctuation" before implementing this one.

Note this PR is built off https://github.com/sillsdev/silnlp/pull/549 and will need to be rebased once 549 is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/550)
<!-- Reviewable:end -->
