### PR TITLE
Fix for a bug with empty verses in USFM

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -64,10 +64,16 @@ class DraftGroup:
         translated_draft_sentences = [[] for _ in range(self.num_drafts)]
 
         for translation_group in self.translation_groups:
+            if len(translation_group) == 0:
+                translation_group = self._createEmptyTranslationGroup()
+
             for draft_index in range(self.num_drafts):
                 translated_draft_sentences[draft_index].append(translation_group[draft_index])
 
         return translated_draft_sentences
+
+    def _createEmptyTranslationGroup(self):
+        return ["" for _ in range(self.num_drafts)]
 
 
 class Translator(ABC):

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -706,6 +706,12 @@ def main() -> None:
     parser.add_argument("--books", nargs="*", metavar="book", default=[], help="Books")
     parser.add_argument("--by-book", default=False, action="store_true", help="Score individual books")
     parser.add_argument(
+        "--multiple-translations",
+        default=False,
+        action="store_true",
+        help="Produce multiple translations of each verse.",
+    )
+    parser.add_argument(
         "--eager-execution",
         default=False,
         action="store_true",
@@ -737,6 +743,7 @@ def main() -> None:
         scorers=set(s.lower() for s in args.scorers),
         books=books,
         by_book=args.by_book,
+        produce_multiple_translations=args.multiple_translations,
     )
 
 


### PR DESCRIPTION
This PR addresses an issue that Isaac and Bethany found with empty verses in USFM.  I've also added the "--multiple-translations" option to test.py to match the behavior of experiment.py.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/552)
<!-- Reviewable:end -->
