### PR TITLE
Log the full path and file name of the parsed file.

### DIFF
--- a/silnlp/common/check_books.py
+++ b/silnlp/common/check_books.py
@@ -69,9 +69,9 @@ def parse_book(project_dir: str, book: str):
         errors.append(e)
 
     if not errors:
-        LOGGER.info(f"{book} in project {project_dir} parsed correctly and contains {file_text.count()} verses.")
+        LOGGER.info(f"{book} in file {book_path} parsed correctly and contains {file_text.count()} verses.")
     else:
-        LOGGER.info(f"The following error occured while parsing {book} in project {project_dir}")
+        LOGGER.info(f"The following error occured while parsing {book} from file {book_path}.")
         for error in errors:
             error_str = " ".join([str(s) for s in error.args])
             LOGGER.info(error_str)
@@ -121,7 +121,7 @@ def main() -> None:
     LOGGER.info(f"Found these books in the project_directory: {' '.join(grouped_result)}")
 
     if not sfm_files:
-        LOGGER.info(f"No sfm or SFM files found in project folder: {project_dir}")
+        LOGGER.info(f"No sfm files found in project folder: {project_dir}")
     else:
         books = args.books
         canons_to_add = [canon for canon in books if canon in valid_canons]


### PR DESCRIPTION
Logging the full path to the SFM file is useful since there are some projects (e.g. NASB) with duplicate SFM files with different names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/561)
<!-- Reviewable:end -->
