### PR TITLE
check base versification of custom versification before throwing warning

### DIFF
--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -552,14 +552,18 @@ def check_versification(project_dir: str) -> Tuple[bool, List[VersificationType]
         return (matching, detected_versification)
 
     if settings.versification.type not in detected_versification:
-        LOGGER.warning(
-            f"Project versification setting {settings.versification.type} does not match detected versification(s) "
-            f"{', '.join([str(int(versification)) for versification in detected_versification])}. "
-            f"The detected versification(s) were based on {', '.join(key_verses)} "
-            f"being the last verse of {'their' if len(key_verses)>=2 else 'its'} "
-            f"respective chapter{'s' if len(key_verses)>=2 else ''}."
-        )
-        return (matching, detected_versification)
+        if not (
+            settings.versification.type == VersificationType.UNKNOWN
+            and settings.versification.base_versification.type in detected_versification
+        ):
+            LOGGER.warning(
+                f"Project versification setting {settings.versification.type} does not match detected versification(s) "
+                f"{', '.join([str(int(versification)) for versification in detected_versification])}. "
+                f"The detected versification(s) were based on {', '.join(key_verses)} "
+                f"being the last verse of {'their' if len(key_verses)>=2 else 'its'} "
+                f"respective chapter{'s' if len(key_verses)>=2 else ''}."
+            )
+            return (matching, detected_versification)
 
     matching = True
     return (matching, detected_versification)


### PR DESCRIPTION
This PR fixes #563 where, during the extract corpora process, the presence of a custom.vrs file would always cause the check_versification function to return a warning that the settings versification type does not match the detected versification type. Now, the function also checks whether the settings versification type is unknown, and if so, it compares the detected versification type against the settings *base* versification type and only raises a warning if those also don't match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/569)
<!-- Reviewable:end -->
