### PR TITLE
Automatically run poetry install and set python interpreter on devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,6 +36,7 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
+				"python.defaultInterpreterPath": "/workspaces/silnlp/.venv/bin/python",
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.codeActionsOnSave": {
@@ -63,7 +64,8 @@
 				"donjayamanne.githistory"
 			]
 		}
-	}
+	},
+	"postStartCommand": "poetry install"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }


### PR DESCRIPTION
This PR address #586 . It automatically runs poetry install after the devcontainer starts up, and it sets the default python interpreter to the python installed in the poetry environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/587)
<!-- Reviewable:end -->
