### PR TITLE
Clean up use of config.model

### DIFF
--- a/silnlp/nmt/analyze_project_pairs.py
+++ b/silnlp/nmt/analyze_project_pairs.py
@@ -106,12 +106,8 @@ def get_corpus_stats(config: Config, force_align: bool = False, deutero: bool = 
 
             src_script = predict_script_code("".join(corpus["source"][: min(len(corpus["source"]), 3000)]))
             trg_script = predict_script_code("".join(corpus["target"][: min(len(corpus["target"]), 3000)]))
-            try:
-                src_script_in_model = is_represented(src_script, config.model)
-                trg_script_in_model = is_represented(trg_script, config.model)
-            except:
-                src_script_in_model = None
-                trg_script_in_model = None
+            src_script_in_model = is_represented(src_script, config.model) if config.model is not None else None
+            trg_script_in_model = is_represented(trg_script, config.model) if config.model is not None else None
 
             stats_df.loc[project_pair, :] = [
                 pair_count,
@@ -210,12 +206,8 @@ def get_extra_alignments(config: Config, deutero: bool = False) -> List[str]:
             parallel_count = len(align_corpus.index)
             src_script = predict_script_code("".join(align_corpus["source"][: min(len(align_corpus["source"]), 3000)]))
             trg_script = predict_script_code("".join(align_corpus["target"][: min(len(align_corpus["target"]), 3000)]))
-            try:
-                src_script_in_model = is_represented(src_script, config.model)
-                trg_script_in_model = is_represented(trg_script, config.model)
-            except:
-                src_script_in_model = None
-                trg_script_in_model = None
+            src_script_in_model = is_represented(src_script, config.model) if config.model is not None else None
+            trg_script_in_model = is_represented(trg_script, config.model) if config.model is not None else None
 
             stats_df.loc[project_pair, :] = [
                 pair_count,

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -430,7 +430,7 @@ class Config(ABC):
 
     @property
     def model(self) -> str:
-        return self.root["model"]
+        return self.root.get("model")
 
     @property
     @abstractmethod

--- a/silnlp/nmt/config_utils.py
+++ b/silnlp/nmt/config_utils.py
@@ -18,5 +18,4 @@ def load_config(exp_name: str) -> Config:
 
 
 def create_config(exp_dir: Path, config: dict) -> Config:
-    model_name: Optional[str] = config.get("model")
     return HuggingFaceConfig(exp_dir, config)

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,6 +13,8 @@ from .clearml_connection import SILClearML
 from .config import Config, get_mt_exp_dir
 from .test import _SUPPORTED_SCORERS, test
 from .translate import TranslationTask
+
+LOGGER = logging.getLogger(__package__ + ".experiment")
 
 
 @dataclass
@@ -38,6 +41,9 @@ class SILExperiment:
         self.config: Config = self.clearml.config
         self.rev_hash = get_git_revision_hash()
         self.config.set_seed()
+
+        if self.config.model is None:
+            LOGGER.warning("Config file does not define a model to use.")
 
     def run(self):
         if self.run_prep:


### PR DESCRIPTION
The lack of a default value for config.model didn't end up affecting much, but I still altered it so I could clean up the code I previously changed.

I added a warning to experiment.py to help clarify errors coming from having a None model. I decided against a full-blown error because I think there are some situations where the name of the model technically isn't needed, i.e. when you already have a saved model + tokenizer. That being said, the average user will probably never have a trained model and an incomplete config file, so I can upgrade it to an error for simplicity if desired.

Closes #590