### PR TITLE
#285 multigpu

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -274,7 +274,7 @@ class HuggingFaceConfig(Config):
                     "max_source_length": 200,
                     "max_target_length": 200,
                     "gradient_checkpointing": True,
-                    "gradient_checkpointing_kwargs": {"use_reentrant": False},
+                    "gradient_checkpointing_kwargs": {"use_reentrant": True},
                     "save_steps": 1000,
                     "per_device_train_batch_size": 16,
                     "save_strategy": "steps",


### PR DESCRIPTION
This PR adds support for splitting a model across two GPUs during training. There was already a num_devices argument in experiment.py that defaulted to 1, but it wasn't being used by any other part of the code, so I repurposed the argument. Now when the user specifies num_devices = 2 for an NLLB model, the model is loaded using the custom device map splitting it across two GPUs during the training phase.

I tested on 3 languages comparing 1 to 2 GPUs, and the BLEU scores were all within one point, with the 2 GPUs actually having a marginally higher BLEU score. These tests were conducted with the 40GB GPUs on the AQuA Server using the 1.3B NLLB model. I also started another set of 3 languages with the 2 GPU setup running on ORU, and although I confirmed that 2 24GB GPUs are now able to train the 1.3B NLLB when they couldn't before, the ORU server went down toward the end of training so I haven't been able to get BLEU scores yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/612)
<!-- Reviewable:end -->
