### PR TITLE
Update for Issue #623 

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -58,13 +58,16 @@ class SILExperiment:
         if not config_file.exists():
             raise RuntimeError(f"ERROR: Config file does not exist in experiment folder {exp_dir}.")
         SIL_NLP_ENV.copy_experiment_from_bucket(self.name)
+        if self.config.has_parent:
+            SIL_NLP_ENV.copy_experiment_from_bucket(self.config.data["parent"])
         self.config.preprocess(self.make_stats, self.force_align)
         SIL_NLP_ENV.copy_experiment_to_bucket(self.name, overwrite=self.force_align)
 
     def train(self):
         os.system("nvidia-smi")
         SIL_NLP_ENV.copy_experiment_from_bucket(self.name)
-
+        if self.config.has_parent:
+            SIL_NLP_ENV.copy_experiment_from_bucket(self.config.data["parent"])
         model = self.config.create_model(self.mixed_precision, self.num_devices)
         model.save_effective_config(self.config.exp_dir / f"effective-config-{self.rev_hash}.yml")
         SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=f"effective-config-{self.rev_hash}.yml")

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -194,14 +194,9 @@ def load_parent_exp(parent_exp: str) -> Tuple[str, str]:
     if not parent_model_dir.is_dir():
         LOGGER.error("The parent experiment does not contain a checkpoint.")
         raise ValueError(f"Invalid path {parent_model_dir}")
-
-    trainer_state_path = parent_model_dir / "trainer_state.json"
-    with open(trainer_state_path, "r") as file:
-        trainer_state = json.load(file)
-    parent_model_path = trainer_state.get("best_model_checkpoint", None)
-    parent_model_name = os.path.basename(parent_model_path)
-    parent_model = parent_model_dir / parent_model_name
-
+    parent_model = get_last_checkpoint(parent_model_dir)
+    if has_best_checkpoint(parent_model_dir):
+        parent_model = get_best_checkpoint(parent_model_dir)
     parent_model_files = os.listdir(parent_model)
     valid_model_files = [f for f in parent_model_files if f.endswith(".safetensors")]
     if not valid_model_files:
@@ -209,10 +204,8 @@ def load_parent_exp(parent_exp: str) -> Tuple[str, str]:
         raise ValueError(f"Incomplete folder {parent_model}")
 
     LOGGER.info("Using parent model. This might be different from the model specified in config.")
-
     with (parent_dir / "config.yml").open("r", encoding="utf-8") as file:
         parent_configs = yaml.safe_load(file)
-
     parent_base_model = parent_configs.get("model")
     parent_model_prefix = get_model_prefix(parent_base_model)
 


### PR DESCRIPTION
Update the `hugging_face_config.py`:

- Load the model from the parent experiment if a parent is specified in the config. 
- The tokenizer will be the same as the parent experiment unless it is specified in the config.
- An optional parameter is added in `SilSeq2SeqTrainer` to store the model prefix (when the model is from a parent experiment, the model name will be a path, so we can't get directly a prefix).

This modification has been tested on:

- [x] Training without parent or LoRA.
- [x] Training without parent but with LoRA.
- [x] Training with parent and LoRA.
- [x] Training with parent but without LoRA.

The remaining potential issues:

- Model name becomes a path when the parent is specified, so it is not safe to directly use it anymore (such as in methods that need to get a prefix from the model name). That is why I edited the trainer class. I'm not sure if there are other methods that will be influenced, but I went over the related methods and think it's all good now.

- If the parent model prefix is different from the model specified in the config, it will throw an exception. Based on my intuition, since we are supposed to use the parent model, the model specified in the config should be ignored? It feels weird that it is specified, so I see it as a way to double check something like "This is the model I want! It should be an NLLB instead of T5". 


Please let me know if there is any further update or modification needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/628)
<!-- Reviewable:end -->
