### PR TITLE
Fix format of empty sentences to remove DraftGroup num_drafts edge case

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -244,7 +244,7 @@ class Translator(ABC):
         # Prevents pre-existing text from showing up in the sections of translated text
         if not preserve_usfm_markers:
             for idx, vref in reversed(empty_sents):
-                translations.insert(idx, [])
+                translations.insert(idx, ["" for _ in range(len(translations[0]))])
                 vrefs.insert(idx, vref)
 
         draft_set: DraftGroup = DraftGroup(translations)


### PR DESCRIPTION
In the DraftGroup constructor, the number of translations of the first sentence is used to determine the number of drafts created. When the first sentence was empty, it was interpreted as the output having no drafts, which caused the whole output to be ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/633)
<!-- Reviewable:end -->
