### PR TITLE
Issue 647 - add link to floating point documentation

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1227,6 +1227,7 @@ class HuggingFaceNMTModel(NMTModel):
             for param in params:
                 if param in section_config:
                     args[param] = section_config[param]
+        # For context on floating point precision, see https://github.com/sillsdev/silnlp/issues/647
         merge_dict(
             args,
             {


### PR DESCRIPTION
The issue provides some background info about floating point formats and later might contain some notes from investigations, so I thought it would be useful to link to it from the code that sets the floating point precision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/648)
<!-- Reviewable:end -->
