### PR TITLE
Normalize experiment paths consistently

### DIFF
--- a/silnlp/nmt/analyze_project_pairs.py
+++ b/silnlp/nmt/analyze_project_pairs.py
@@ -469,7 +469,8 @@ def main() -> None:
 
     get_git_revision_hash()
 
-    exp_name = args.experiment
+    # Experiment path relative to MT/experiments
+    exp_name = args.experiment.replace("\\", "/")
 
     if args.clearml_queue is not None and "cpu" not in args.clearml_queue:
         LOGGER.warning("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")


### PR DESCRIPTION
When `analyze_project_pairs` was run on Windows and the experiment argument used backslashes, no calls to copy files to/from the S3 bucket were successful because the path was not normalized to only use forward slashes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/663)
<!-- Reviewable:end -->
