### PR TITLE
Small updates missed in MinIO support added

### DIFF
--- a/bucket_setup.md
+++ b/bucket_setup.md
@@ -17,6 +17,7 @@ Backblaze B2 is only used as a backup storage option when the MinIO bucket is un
 The following will mount /silnlp on your B drive or /nlp-research on your M drive and allow you to explore, read and write.
 * Install WinFsp: http://www.secfs.net/winfsp/rel/  (Click the button to "Download WinFsp Installer" not the "SSHFS-Win (x64)" installer)
 * Download rclone from: https://rclone.org/downloads/
+* If you already have rclone installed, make sure it is updated to at least version 1.43 to support Backblaze
 * Unzip to your desktop (or some convient location). 
 * Add the folder that contains rclone.exe to your PATH environment variable.
 * Take the `scripts/rclone/rclone.conf` file from this SILNLP repo and copy it to `~\AppData\Roaming\rclone` (creating folders if necessary)

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -163,7 +163,7 @@ class SilNlpEnv:
             endpoint_url=endpoint_url,
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
-            config=Config(read_timeout=600),
+            config=generate_s3_config(),
             # Verify is false if endpoint_url is an IP address. Aqua/Cheetah connecting to MinIO need this disabled for now.
             verify=False if re.match(r"https://\d+\.\d+\.\d+\.\d+", endpoint_url) else True,
         )
@@ -180,7 +180,7 @@ class SilNlpEnv:
             LOGGER.warning("Support for AWS S3 will soon be removed. Please set up MinIO and/or B2 credentials.")
             resource = boto3.resource(
                 service_name="s3",
-                config=Config(read_timeout=600),
+                config=generate_s3_config(),
             )
             bucket = resource.Bucket("silnlp")
             register_configuration_parameter(PureS3Path("/"), resource=resource)


### PR DESCRIPTION
- Note in bucket_setup for minimum rclone version needed
- use generate_s3_config whenever a s3 config is needed

This is a very small PR adding some things missed in this [PR](https://github.com/sillsdev/silnlp/pull/620)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/675)
<!-- Reviewable:end -->
