### PR TITLE
Fixed an issue with interactive sessions

### DIFF
--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -137,9 +137,9 @@ class SilNlpEnv:
                 LOGGER.info(f"Using workspace: {sil_nlp_data_path} as per environment variable SIL_NLP_DATA_PATH.")
                 return Path(sil_nlp_data_path)
             else:
-                raise Exception(
+                LOGGER.warning(
                     f"The path defined by environment variable SIL_NLP_DATA_PATH ({sil_nlp_data_path}) is not a "
-                    + "real directory."
+                    + "local directory."
                 )
 
         gutenberg_path = Path("G:/Shared drives/Gutenberg")


### PR DESCRIPTION
There was an issue found with interactive sessions that caused them to never try to connect to an S3 bucket since `SIL_NLP_DATA_PATH=/silnlp` is included in the clearml.conf files and `BUCKET_SERVICE` is not set. There are three potential fixes to this issue:

1. Demote from an exception to warning when a local directory from `SIL_NLP_DATA_PATH` is not found.
2. Remove the environment variable `SIL_NLP_DATA_PATH` from each of the clearml agents. 
3. Add a different value for `BUCKET_SERVICE`, such as `any` to each of the clearml agents to force the use of an S3 bucket.

I chose this PR as the best option to not have to restart every agent, and this will allow `SIL_NL_DATA_PATH` to be set and tried first, with S3 as a fallback as long as `BUCKET_SERVICE=""` or is not set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/678)
<!-- Reviewable:end -->
