### PR TITLE
Made bucket_service required for SILClearML

### DIFF
--- a/silnlp/nmt/analyze_project_pairs.py
+++ b/silnlp/nmt/analyze_project_pairs.py
@@ -475,7 +475,7 @@ def main() -> None:
     if args.clearml_queue is not None and "cpu" not in args.clearml_queue:
         LOGGER.warning("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")
         exit()
-    clearml = SILClearML(exp_name, args.clearml_queue)
+    clearml = SILClearML(exp_name, args.clearml_queue, bucket_service=SIL_NLP_ENV.bucket_service)
 
     SIL_NLP_ENV.copy_experiment_from_bucket(exp_name)
 

--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -21,7 +21,7 @@ class SILClearML:
     experiment_suffix: str = ""
     clearml_project_folder: str = ""
     commit: Optional[str] = None
-    bucket_service: Optional[str] = None
+    bucket_service: str = ""
 
     def __post_init__(self) -> None:
         self.name = self.name.replace("\\", "/")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -262,6 +262,7 @@ class TranslationTask:
             project_suffix="_infer",
             experiment_suffix=experiment_suffix,
             commit=self.commit,
+            bucket_service=SIL_NLP_ENV.bucket_service,
         )
         self.name = clearml.name
 


### PR DESCRIPTION
- Fixed an oversight with running translate and analyse_project_pairs not passing in bucket_service to SILClearML

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/680)
<!-- Reviewable:end -->
