### PR TITLE
Update hosts file in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,11 @@
 	"build": {
 		"context": "..",
 		// Path is relative to the devcontainer.json file.
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+            "MINIO_ENDPOINT_URL": "${localEnv:MINIO_ENDPOINT_URL}",
+			"MINIO_ENDPOINT_IP": "${localEnv:MINIO_ENDPOINT_IP}"
+        }
 	},
 	"runArgs": [
 		"--gpus",
@@ -19,6 +23,7 @@
 		"AWS_ACCESS_KEY_ID": "${localEnv:AWS_ACCESS_KEY_ID}",
 		"AWS_SECRET_ACCESS_KEY": "${localEnv:AWS_SECRET_ACCESS_KEY}",
 		"MINIO_ENDPOINT_URL": "${localEnv:MINIO_ENDPOINT_URL}",
+		"MINIO_ENDPOINT_IP": "${localEnv:MINIO_ENDPOINT_IP}",
 		"MINIO_ACCESS_KEY": "${localEnv:MINIO_ACCESS_KEY}",
 		"MINIO_SECRET_KEY": "${localEnv:MINIO_SECRET_KEY}",
 		"B2_ENDPOINT_URL": "${localEnv:B2_ENDPOINT_URL}",
@@ -69,7 +74,7 @@
 			]
 		}
 	},
-	"postStartCommand": "poetry install"
+	"postStartCommand": "poetry install && sh /workspaces/silnlp/.devcontainer/update_hosts.sh"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/update_hosts.sh
+++ b/.devcontainer/update_hosts.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+CLEANED_URL=$(echo "$MINIO_ENDPOINT_URL" | sed -E "s|^https://||" | sed -E "s|:[^:]*$||")
+if [ -n "$MINIO_ENDPOINT_IP" ] && [ -n "$CLEANED_URL" ]; then
+    echo "$MINIO_ENDPOINT_IP $CLEANED_URL" | tee -a /etc/hosts > /dev/null
+    echo "Updated /etc/hosts: $MINIO_ENDPOINT_IP $CLEANED_URL"
+else
+    echo "Skipping /etc/hosts update (Environment variables MINIO_ENDPOINT_IP and/or MINIO_ENDPOINT_URL are not set)"
+fi


### PR DESCRIPTION
This PR addresses issue #679. I added a startup script `update_hosts.sh` to the .devcontainers folder, which will be run post startup and adds a necessary line to the /etc/hosts file to allow the SonicWall NetExtender VPN to work. The user will need to know the IP address for the MinIO bucket and use it to set the environment variable MINIO_ENDPOINT_IP in order for the script to add the line to the hosts file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/681)
<!-- Reviewable:end -->
