### PR TITLE
Add folder_name prefix to output files.

### DIFF
--- a/silnlp/common/combine_scores.py
+++ b/silnlp/common/combine_scores.py
@@ -52,7 +52,6 @@ def aggregate_csv(folder_path):
 
 
 def write_to_csv(data_by_header, folder, output_filename):
-
     output_file = folder / f"{output_filename}.csv"
     with open(output_file, "w", newline="") as f:
         writer = csv.writer(f)

--- a/silnlp/common/combine_scores.py
+++ b/silnlp/common/combine_scores.py
@@ -52,6 +52,7 @@ def aggregate_csv(folder_path):
 
 
 def write_to_csv(data_by_header, folder, output_filename):
+
     output_file = folder / f"{output_filename}.csv"
     with open(output_file, "w", newline="") as f:
         writer = csv.writer(f)
@@ -91,24 +92,22 @@ def main():
     args = parser.parse_args()
 
     folder = Path(args.folder)
-
-    csv_filename = f"{folder}_{args.output_filename}"
-    excel_filename = f"{folder}_{args.output_filename}"
+    base_filename = f"{folder.name}_{args.output_filename}"
 
     if not folder.is_dir():
         folder = Path(SIL_NLP_ENV.mt_experiments_dir) / args.folder
 
     # Check for lock files and ask the user to close them.
-    check_for_lock_file(folder, csv_filename, "csv")
-    check_for_lock_file(folder, excel_filename, "xlsx")
+    check_for_lock_file(folder, base_filename, "csv")
+    check_for_lock_file(folder, base_filename, "xlsx")
 
     data = aggregate_csv(folder)
 
     # Write the aggregated data to a new CSV file
-    write_to_csv(data, folder, csv_filename)
+    write_to_csv(data, folder, base_filename)
 
     # Write the aggregated data to an Excel file
-    write_to_excel(data, folder, excel_filename)
+    write_to_excel(data, folder, base_filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix a bug where the filenames were being created that included '/' characters.
Only prefix the output file names with the final folder name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/683)
<!-- Reviewable:end -->
