### PR TITLE
Translation script arguments relative to experiment directory

### DIFF
--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,11 +255,8 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        if type(name) is Path and name.is_absolute():
-            experiments_path = str(name)
-        else:
-            name = str(name)
-            experiments_path = str(self.mt_dir.relative_to(self.data_dir) / "experiments") + "/"
+        name = str(name)
+        experiments_path = str(self.mt_dir.relative_to(self.data_dir) / "experiments") + "/"
         name = name.split(experiments_path)[-1]
         if len(name) == 0:
             raise Exception(
@@ -324,13 +321,11 @@ class SilNlpEnv:
             source_path = source_path[1:]
         return source_path
 
-    def download_if_s3_paths(self, paths: Iterable[S3Path] | Iterable[Path]) -> List[Path]:
+    def download_if_s3_paths(self, paths: Iterable[S3Path]) -> List[Path]:
         return_paths = []
         s3_setup = False
 
         for path in paths:
-            if type(path) is Path:
-                path = S3Path(path)
             if type(path) is not S3Path:
                 return_paths.append(path)
             else:
@@ -340,7 +335,6 @@ class SilNlpEnv:
                     self.set_s3_bucket()
                     s3_setup = True
                 temp_path = temp_root / path.name
-                LOGGER.info("Downloading " + path.key)
                 try_n_times(lambda: self.bucket.download_file(path.key, str(temp_path)))
                 return_paths.append(temp_path)
         return return_paths

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,7 +255,7 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        if type(name) is Path and name.is_absolute():
+        if os.path.isabs(name):
             experiments_path = str(name)
         else:
             name = str(name)
@@ -324,13 +324,11 @@ class SilNlpEnv:
             source_path = source_path[1:]
         return source_path
 
-    def download_if_s3_paths(self, paths: Iterable[S3Path] | Iterable[Path]) -> List[Path]:
+    def download_if_s3_paths(self, paths: Iterable[S3Path]) -> List[Path]:
         return_paths = []
         s3_setup = False
 
         for path in paths:
-            if type(path) is Path:
-                path = S3Path(path)
             if type(path) is not S3Path:
                 return_paths.append(path)
             else:

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,7 +255,7 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        if os.path.isabs(name):
+        if type(name) is Path and name.is_absolute():
             experiments_path = str(name)
         else:
             name = str(name)
@@ -324,11 +324,13 @@ class SilNlpEnv:
             source_path = source_path[1:]
         return source_path
 
-    def download_if_s3_paths(self, paths: Iterable[S3Path]) -> List[Path]:
+    def download_if_s3_paths(self, paths: Iterable[S3Path] | Iterable[Path]) -> List[Path]:
         return_paths = []
         s3_setup = False
 
         for path in paths:
+            if type(path) is Path:
+                path = S3Path(path)
             if type(path) is not S3Path:
                 return_paths.append(path)
             else:

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,8 +255,11 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        name = str(name)
-        experiments_path = str(self.mt_dir.relative_to(self.data_dir) / "experiments") + "/"
+        if type(name) is Path and name.is_absolute():
+            experiments_path = str(name)
+        else:
+            name = str(name)
+            experiments_path = str(self.mt_dir.relative_to(self.data_dir) / "experiments") + "/"
         name = name.split(experiments_path)[-1]
         if len(name) == 0:
             raise Exception(
@@ -321,11 +324,13 @@ class SilNlpEnv:
             source_path = source_path[1:]
         return source_path
 
-    def download_if_s3_paths(self, paths: Iterable[S3Path]) -> List[Path]:
+    def download_if_s3_paths(self, paths: Iterable[S3Path] | Iterable[Path]) -> List[Path]:
         return_paths = []
         s3_setup = False
 
         for path in paths:
+            if type(path) is Path:
+                path = S3Path(path)
             if type(path) is not S3Path:
                 return_paths.append(path)
             else:
@@ -335,6 +340,7 @@ class SilNlpEnv:
                     self.set_s3_bucket()
                     s3_setup = True
                 temp_path = temp_root / path.name
+                LOGGER.info("Downloading " + path.key)
                 try_n_times(lambda: self.bucket.download_file(path.key, str(temp_path)))
                 return_paths.append(temp_path)
         return return_paths

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,7 +255,7 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        if os.path.isabs(name):
+        if type(name) is Path and name.is_absolute():
             experiments_path = str(name)
         else:
             name = str(name)

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -255,7 +255,7 @@ class SilNlpEnv:
     def copy_experiment_from_bucket(self, name: Union[str, Path], patterns: Union[str, Sequence[str]] = []):
         if not self.is_bucket:
             return
-        if type(name) is Path and name.is_absolute():
+        if os.path.isabs(name):
             experiments_path = str(name)
         else:
             name = str(name)

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -42,6 +42,7 @@ class TranslationTask:
     checkpoint: Union[str, int] = "last"
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
+    files: Optional[List[str]] = None
     data_dirs: Optional[List[str]] = None
 
     def __post_init__(self) -> None:

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -122,7 +122,7 @@ class TranslationTask:
                 translation_failed.append(book)
                 LOGGER.exception(f"Was not able to translate {book}.")
 
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM", "*infer*"), overwrite=True)
 
         if len(translation_failed) > 0:
             raise RuntimeError(f"Some books failed to translate: {' '.join(translation_failed)}")
@@ -180,7 +180,7 @@ class TranslationTask:
                 translator.translate_text(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
                 end = time.time()
                 print(f"Translated {src_file_path.name} to {trg_file_path.name} in {((end-start)/60):.2f} minutes")
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM*", "*.txt*"), overwrite=True)
 
     def translate_files(
         self,
@@ -272,7 +272,7 @@ class TranslationTask:
                     preserve_usfm_markers=preserve_usfm_markers,
                     experiment_ckpt_str=experiment_ckpt_str,
                 )
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM", f"*{trg}*"), overwrite=True)
 
     def _init_translation_task(
         self, experiment_suffix: str, patterns: Optional[List[str]]
@@ -327,10 +327,30 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Translates text using an NMT model")
     parser.add_argument("experiment", help="Experiment name")
     parser.add_argument("--checkpoint", type=str, help="Checkpoint to use (last, best, avg, or checkpoint #)")
-    parser.add_argument("--src", default=None, type=str, help="Source file")
-    parser.add_argument("--trg", default=None, type=str, help="Target file")
-    parser.add_argument("--src-prefix", default=None, type=str, help="Source file prefix (e.g., de-news2019-)")
-    parser.add_argument("--trg-prefix", default=None, type=str, help="Target file prefix (e.g., en-news2019-)")
+    parser.add_argument(
+        "--src",
+        default=None,
+        type=str,
+        help="Source file name, can be relative to the data directory or experiment directory",
+    )
+    parser.add_argument(
+        "--trg",
+        default=None,
+        type=str,
+        help="Target file name, can be relative to the data directory or experiment directory",
+    )
+    parser.add_argument(
+        "--src-prefix",
+        default=None,
+        type=str,
+        help="Source file prefix (e.g., de-news2019-), can be relative to the data directory or experiment directory",
+    )
+    parser.add_argument(
+        "--trg-prefix",
+        default=None,
+        type=str,
+        help="Target file prefix (e.g., en-news2019-), can be relative to the data directory or experiment directory",
+    )
     parser.add_argument("--start-seq", default=None, type=int, help="Starting file sequence #")
     parser.add_argument("--end-seq", default=None, type=int, help="Ending file sequence #")
     parser.add_argument("--src-project", default=None, type=str, help="The source project to translate")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -4,7 +4,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 from machine.scripture import VerseRef, book_number_to_id, get_chapters
 
@@ -42,6 +42,8 @@ class TranslationTask:
     checkpoint: Union[str, int] = "last"
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
+    files: Optional[List[str]] = None
+    data_dirs: Optional[List[str]] = None
 
     def __post_init__(self) -> None:
         if self.checkpoint is None:
@@ -137,7 +139,13 @@ class TranslationTask:
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
     ) -> None:
-        translator, config, _ = self._init_translation_task(experiment_suffix=f"_{self.checkpoint}_{src_prefix}")
+        translator, config, _ = self._init_translation_task(
+            experiment_suffix=f"_{self.checkpoint}_{src_prefix}",
+            exts=[".txt"],
+            prefixes=[src_prefix, trg_prefix],
+            start_seq=start_seq,
+            end_seq=end_seq,
+        )
         if trg_prefix is None:
             raise RuntimeError("A target file prefix must be specified.")
         if start_seq is None or end_seq is None:
@@ -166,7 +174,9 @@ class TranslationTask:
                 translator.translate_text(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
                 end = time.time()
                 print(f"Translated {src_file_path.name} to {trg_file_path.name} in {((end-start)/60):.2f} minutes")
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(
+            self.name, patterns=("*.SFM", f"*{trg_file_path.suffix}", f"*{src_file_path.suffix}"), overwrite=True
+        )
 
     def translate_files(
         self,
@@ -179,7 +189,9 @@ class TranslationTask:
         preserve_usfm_markers: bool = False,
     ) -> None:
         translator, config, step_str = self._init_translation_task(
-            experiment_suffix=f"_{self.checkpoint}_{os.path.basename(src)}"
+            experiment_suffix=f"_{self.checkpoint}_{os.path.basename(src)}",
+            exts=[Path(src).suffix, Path(trg).suffix],
+            paths=[src, trg],
         )
 
         if src_iso is None:
@@ -198,6 +210,15 @@ class TranslationTask:
         src_path = Path(src)
         if not src_path.exists() and not src_path.is_absolute():
             src_path = SIL_NLP_ENV.data_dir / src
+            if not src_path.exists():
+                src_path = SIL_NLP_ENV.mt_dir / src
+            if not src_path.exists():
+                src_path = SIL_NLP_ENV.mt_experiments_dir / self.name / src
+            if not src_path.exists():
+                for data_dir in self.data_dirs:
+                    src_path = Path(data_dir / src)
+                    if src_path.exists():
+                        break
         if not src_path.exists():
             raise FileNotFoundError("Cannot find source: " + src)
 
@@ -205,6 +226,15 @@ class TranslationTask:
             trg_path = Path(trg)
             if not trg_path.exists() and not trg_path.is_absolute():
                 trg_path = SIL_NLP_ENV.data_dir / trg
+                if not trg_path.exists():
+                    trg_path = SIL_NLP_ENV.mt_dir / trg
+                if not trg_path.exists():
+                    trg_path = SIL_NLP_ENV.mt_experiments_dir / self.name / trg
+                if not trg_path.exists():
+                    for data_dir in self.data_dirs:
+                        trg_path = Path(data_dir / trg)
+                        if trg_path.exists():
+                            break
             if not trg_path.exists() and ((src_path.is_file() and not trg_path.parent.is_dir()) or src_path.is_dir()):
                 raise FileNotFoundError("Cannot find target: " + trg)
 
@@ -253,9 +283,18 @@ class TranslationTask:
                     preserve_usfm_markers=preserve_usfm_markers,
                     experiment_ckpt_str=experiment_ckpt_str,
                 )
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
 
-    def _init_translation_task(self, experiment_suffix: str) -> Tuple[Translator, Config, str]:
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM", f"*{ext}"), overwrite=True)
+
+    def _init_translation_task(
+        self,
+        experiment_suffix: str,
+        exts: Optional[List[str]] = [],
+        paths: Optional[List[str]] = None,
+        prefixes: Optional[List[str]] = None,
+        start_seq: Optional[int] = None,
+        end_seq: Optional[int] = None,
+    ) -> Tuple[Translator, Config, str]:
         clearml = SILClearML(
             self.name,
             self.clearml_queue,
@@ -265,10 +304,39 @@ class TranslationTask:
             bucket_service=SIL_NLP_ENV.bucket_service,
         )
         self.name = clearml.name
-
+        LOGGER.info(exts)
         SIL_NLP_ENV.copy_experiment_from_bucket(
-            self.name, patterns=("*.vocab", "*.model", "*.yml", "dict.*.txt", "*.json", "checkpoint", "ckpt*.index")
+            self.name,
+            patterns=(
+                "*.vocab",
+                "*.model",
+                "*.yml",
+                "dict.*.txt",
+                "*.json",
+                "checkpoint",
+                "ckpt*.index",
+                *[f"*{ext}" for ext in exts],
+            ),
         )
+
+        if self.data_dirs is not None:
+            patterns = []
+            if paths:
+                patterns.extend(paths)
+            if prefixes:
+                patterns.extend(f"{prefix}*" for prefix in prefixes)
+            if start_seq is not None and end_seq is not None:
+                patterns.extend(f"{i:04d}*" for i in range(start_seq, end_seq + 1))
+            for data_dir in self.data_dirs:
+                SIL_NLP_ENV.copy_experiment_from_bucket(data_dir, patterns=patterns)
+        elif paths is not None:
+            download_paths = []
+            for path in paths:
+                if Path(path).is_absolute():
+                    download_paths.append(path)
+                else:
+                    download_paths.append(SIL_NLP_ENV.mt_dir / path)
+            SIL_NLP_ENV.download_if_s3_paths(download_paths)
 
         clearml.config.set_seed()
 
@@ -287,12 +355,42 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Translates text using an NMT model")
     parser.add_argument("experiment", help="Experiment name")
     parser.add_argument("--checkpoint", type=str, help="Checkpoint to use (last, best, avg, or checkpoint #)")
-    parser.add_argument("--src", default=None, type=str, help="Source file")
-    parser.add_argument("--trg", default=None, type=str, help="Target file")
-    parser.add_argument("--src-prefix", default=None, type=str, help="Source file prefix (e.g., de-news2019-)")
-    parser.add_argument("--trg-prefix", default=None, type=str, help="Target file prefix (e.g., en-news2019-)")
-    parser.add_argument("--start-seq", default=None, type=int, help="Starting file sequence #")
-    parser.add_argument("--end-seq", default=None, type=int, help="Ending file sequence #")
+    parser.add_argument(
+        "--src",
+        default=None,
+        type=str,
+        help="Source file path. Can be a relative path from the experiment, data, or MT directories; or an absolute path.",
+    )
+    parser.add_argument(
+        "--trg",
+        default=None,
+        type=str,
+        help="Target file. Can be a relative path from the experiment, data, or MT directories; or an absolute path.",
+    )
+    parser.add_argument(
+        "--src-prefix",
+        default=None,
+        type=str,
+        help="Source file prefix (e.g., de-news2019-), must be in the experiment or data directories",
+    )
+    parser.add_argument(
+        "--trg-prefix",
+        default=None,
+        type=str,
+        help="Target file prefix (e.g., en-news2019-), must be in the experiment or data directories",
+    )
+    parser.add_argument(
+        "--start-seq",
+        default=None,
+        type=int,
+        help="Starting file sequence #, must be in the experiment or data directories",
+    )
+    parser.add_argument(
+        "--end-seq",
+        default=None,
+        type=int,
+        help="Ending file sequence #, must be in the experiment or data directories",
+    )
     parser.add_argument("--src-project", default=None, type=str, help="The source project to translate")
     parser.add_argument(
         "--trg-project",
@@ -344,12 +442,23 @@ def main() -> None:
         "--commit", type=str, default=None, help="The silnlp git commit id with which to run a remote job"
     )
 
+    parser.add_argument(
+        "--data-dirs",
+        nargs="+",
+        default=[],
+        help="The absolute path to the data directories needed for the translation task.  Default: None - use only the experiment directory.",
+    )
+
     args = parser.parse_args()
 
     get_git_revision_hash()
 
     translator = TranslationTask(
-        name=args.experiment, checkpoint=args.checkpoint, clearml_queue=args.clearml_queue, commit=args.commit
+        name=args.experiment,
+        checkpoint=args.checkpoint,
+        clearml_queue=args.clearml_queue,
+        commit=args.commit,
+        data_dirs=args.data_dirs,
     )
 
     if len(args.books) > 0:

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, Union
 
 from machine.scripture import VerseRef, book_number_to_id, get_chapters
-from s3path import S3Path
 
 from ..common.environment import SIL_NLP_ENV
 from ..common.paratext import book_file_name_digits, get_project_dir
@@ -43,6 +42,7 @@ class TranslationTask:
     checkpoint: Union[str, int] = "last"
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
+    files: Optional[List[str]] = None
     data_dirs: Optional[List[str]] = None
 
     def __post_init__(self) -> None:
@@ -333,9 +333,9 @@ class TranslationTask:
             download_paths = []
             for path in paths:
                 if Path(path).is_absolute():
-                    download_paths.append(S3Path(path))
+                    download_paths.append(path)
                 else:
-                    download_paths.append(S3Path(SIL_NLP_ENV.mt_dir / path))
+                    download_paths.append(SIL_NLP_ENV.mt_dir / path)
             SIL_NLP_ENV.download_if_s3_paths(download_paths)
 
         clearml.config.set_seed()

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -42,7 +42,6 @@ class TranslationTask:
     checkpoint: Union[str, int] = "last"
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
-    files: Optional[List[str]] = None
     data_dirs: Optional[List[str]] = None
 
     def __post_init__(self) -> None:

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, Union
 
 from machine.scripture import VerseRef, book_number_to_id, get_chapters
+from s3path import S3Path
 
 from ..common.environment import SIL_NLP_ENV
 from ..common.paratext import book_file_name_digits, get_project_dir
@@ -42,7 +43,6 @@ class TranslationTask:
     checkpoint: Union[str, int] = "last"
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
-    files: Optional[List[str]] = None
     data_dirs: Optional[List[str]] = None
 
     def __post_init__(self) -> None:
@@ -333,9 +333,9 @@ class TranslationTask:
             download_paths = []
             for path in paths:
                 if Path(path).is_absolute():
-                    download_paths.append(path)
+                    download_paths.append(S3Path(path))
                 else:
-                    download_paths.append(SIL_NLP_ENV.mt_dir / path)
+                    download_paths.append(S3Path(SIL_NLP_ENV.mt_dir / path))
             SIL_NLP_ENV.download_if_s3_paths(download_paths)
 
         clearml.config.set_seed()


### PR DESCRIPTION
This PR introduces the following improvements to the `silnlp/nmt/translate.py` command line arguments:
1. A new flag named `--data-dirs` was added that can be set to a list of absolute paths to any directories needed for translation
2. `--src` and `--trg` can now be absolute paths, or a relative path from any of the following directories: the ones listed in `--data-dirs`, `experiment` (not `MT/experiments`, but the experiment name folder), or `MT`. 
3. `--src-prefix`, `--trg-prefix`, `--start-seq`, and `--end-seq` will now check the `experiment` directory and any directories listed in `--data-dirs`

Results will always be stored in the `experiment` folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/689)
<!-- Reviewable:end -->
