### PR TITLE
Revised translation options for USFM markers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5174,13 +5174,13 @@ type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12
 
 [[package]]
 name = "sil-machine"
-version = "1.6.1"
+version = "1.6.2"
 description = "A natural language processing library that is focused on providing tools for resource-poor languages."
 optional = false
 python-versions = "<3.13,>=3.9"
 files = [
-    {file = "sil_machine-1.6.1-py3-none-any.whl", hash = "sha256:38b81f1fc5508e05fe8702c8d0e1a2d5e86e511aa2ce4f30d480744b6a8c8214"},
-    {file = "sil_machine-1.6.1.tar.gz", hash = "sha256:9a4103b5aaaa916f14337b39a1135f5fc40ecff2d46568ed098ac6e99ad07f52"},
+    {file = "sil_machine-1.6.2-py3-none-any.whl", hash = "sha256:89ab7cfe53856c474a1dfb705e90cd3eec6da399b77237005bb16139f43ec353"},
+    {file = "sil_machine-1.6.2.tar.gz", hash = "sha256:25f1818a8a14a4b26e1eacda2f527fbe7ffadba7cdeaa98d450ef5ae6313cc7c"},
 ]
 
 [package.dependencies]
@@ -6217,4 +6217,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "1060ce63116411c4c71f57b346a6d2ad59f08f9b2142abc5f000b95b37e14aca"
+content-hash = "8b1efa077c6a39ee15a1f3276f40478d9ce3f1753f956e1d601d7ba6cf6d11de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ s3path = "0.3.4"
 sacrebleu = "^2.3.1"
 ctranslate2 = "^3.5.1"
 libclang = "14.0.6"
-sil-machine = {extras = ["thot"], version = "^1.6.1"}
+sil-machine = {extras = ["thot"], version = "^1.6.2"}
 datasets = "^2.7.1"
 torch = {version = "^2.4", source = "torch"}
 sacremoses = "^0.0.53"

--- a/silnlp/common/usfm_preservation.py
+++ b/silnlp/common/usfm_preservation.py
@@ -25,51 +25,92 @@ class UsfmPreserver:
 
     # (sent_idx, start idx in text_only_sent, is_paragraph_marker, tok (inc. \ and spaces))
     _markers: List[Tuple[int, int, str]]
-    # (vref, embed)
-    _embeds: List[Tuple[ScriptureRef, str]]
+    # (sent_idx, embed)
+    _char_embeds: List[Tuple[int, str]]
+    # (sent_idx, ref, embed contents)
+    _para_embeds: List[Tuple[int, ScriptureRef, str]]
 
     def __init__(
-        self, src_sents: List[str], vrefs: List[ScriptureRef], stylesheet: UsfmStylesheet, include_embeds: bool = False
+        self,
+        src_sents: List[str],
+        vrefs: List[ScriptureRef],
+        stylesheet: UsfmStylesheet,
+        include_paragraph_markers: bool = False,
+        include_style_markers: bool = False,
+        include_embeds: bool = False,
     ):
+        # Remove sentences that are paragraph-type embeds
+        # NOTE: when only dealing with inserting back into the same USFM structure, i.e. translate_usfm's trg_project is None,
+        # paragraph-type embeds can be handled more simply with the updater's preserve_paragraph_styles argument,
+        # but because this approach is necessary when updating a project different from the source, we use it for both cases
+        src_sents, self._vrefs = self._remove_para_embeds(src_sents, vrefs, include_embeds)
+
         usfm_tokenizer = UsfmTokenizer(stylesheet)
         sentence_toks = []
         for sent in src_sents:
             sentence_toks.append(usfm_tokenizer.tokenize(sent))
-        self._vrefs = vrefs
 
-        self._src_sents = self._extract_markers(sentence_toks, include_embeds)
+        # Take markers and character-type embeds out of sentences
+        self._src_sents = self._extract_markers(
+            sentence_toks, include_paragraph_markers, include_style_markers, include_embeds
+        )
         self._src_tok_ranges = self._tokenize_sents(self._src_sents)
 
-    # Source sentences without USFM markers, to be used as input to an MT model
+    # Source sentences without USFM markers or embeds, to be used as input to an MT model
     @property
     def src_sents(self) -> List[str]:
         return self._src_sents
 
-    def _extract_markers(self, sentence_toks: List[List[UsfmToken]], include_embeds: bool) -> List[str]:
+    @property
+    def vrefs(self) -> List[ScriptureRef]:
+        return self._vrefs
+
+    def _remove_para_embeds(
+        self, sents: List[str], vrefs: List[ScriptureRef], include_embeds: bool
+    ) -> List[ScriptureRef]:
+        para_embeds = []
+        for i, (sent, ref) in reversed(list(enumerate(zip(sents, vrefs)))):
+            if (ref.path[-1].name if len(ref.path) > 0 else "") in PARAGRAPH_TYPE_EMBEDS:
+                para_embeds.append((i, ref, sent if include_embeds else ""))
+                sents.pop(i)
+                vrefs.pop(i)
+
+        self._para_embeds = reversed(para_embeds)
+        return sents, vrefs
+
+    def _extract_markers(
+        self,
+        sentence_toks: List[List[UsfmToken]],
+        include_paragraph_markers: bool,
+        include_style_markers: bool,
+        include_embeds: bool,
+    ) -> List[str]:
         markers = []
-        embeds = []
+        char_embeds = []
         text_only_sents = ["" for _ in sentence_toks]
-        for i, (toks, ref) in enumerate(zip(sentence_toks, self._vrefs)):
-            embed_text = ""
+        for i, toks in enumerate(sentence_toks):
+            embed_usfm = ""
             curr_embed = None
             for tok in toks:
                 if curr_embed is not None:
-                    embed_text += tok.to_usfm()
+                    embed_usfm += tok.to_usfm()
                     if tok.type == UsfmTokenType.END and tok.marker[:-1] == curr_embed.marker:
                         if include_embeds:
-                            embeds.append((ref, embed_text))
-                        embed_text = ""
+                            char_embeds.append((i, embed_usfm))
+                        embed_usfm = ""
                         curr_embed = None
                 elif tok.type == UsfmTokenType.NOTE or tok.marker in CHARACTER_TYPE_EMBEDS:
-                    embed_text += tok.to_usfm()
+                    embed_usfm += tok.to_usfm()
                     curr_embed = tok
-                elif tok.type in [UsfmTokenType.PARAGRAPH, UsfmTokenType.CHARACTER, UsfmTokenType.END]:
-                    markers.append((i, len(text_only_sents[i]), tok.type == UsfmTokenType.PARAGRAPH, tok.to_usfm()))
+                elif tok.type == UsfmTokenType.PARAGRAPH and include_paragraph_markers:
+                    markers.append((i, len(text_only_sents[i]), True, tok.to_usfm()))
+                elif tok.type in [UsfmTokenType.CHARACTER, UsfmTokenType.END] and include_style_markers:
+                    markers.append((i, len(text_only_sents[i]), False, tok.to_usfm()))
                 elif tok.type == UsfmTokenType.TEXT:
                     text_only_sents[i] += tok.text
 
         self._markers = markers
-        self._embeds = embeds
+        self._char_embeds = char_embeds
         return text_only_sents
 
     def construct_rows(self, translations: List[str]) -> List[Tuple[List[ScriptureRef], str]]:
@@ -105,10 +146,10 @@ class UsfmPreserver:
         # Construct rows for the USFM file
         embed_idx = 0
         rows = []
-        for ref, translation, inserts in zip(self._vrefs, translations, to_insert):
+        for i, (ref, translation, inserts) in enumerate(zip(self._vrefs, translations, to_insert)):
             row_text = translation[: inserts[0][0]] if len(inserts) > 0 else translation
 
-            for i, (insert_idx, is_para_marker, marker) in enumerate(inserts):
+            for j, (insert_idx, is_para_marker, marker) in enumerate(inserts):
                 if is_para_marker:
                     row_text += "\n"
 
@@ -120,21 +161,25 @@ class UsfmPreserver:
                         else ""
                     )
                     + (
-                        translation[insert_idx : inserts[i + 1][0]]
-                        if i + 1 < len(inserts)
+                        translation[insert_idx : inserts[j + 1][0]]
+                        if j + 1 < len(inserts)
                         else translation[insert_idx:]
                     )
                 )
                 # Prevent spaces before end markers
-                if i + 1 < len(inserts) and "*" in inserts[i + 1][2] and len(row_text) > 0 and row_text[-1] == " ":
+                if j + 1 < len(inserts) and "*" in inserts[j + 1][2] and len(row_text) > 0 and row_text[-1] == " ":
                     row_text = row_text[:-1]
 
             # Append any transferred embeds that match the current ScriptureRef
-            while embed_idx < len(self._embeds) and self._embeds[embed_idx][0] == ref:
-                row_text += self._embeds[embed_idx][1]
+            while embed_idx < len(self._char_embeds) and self._char_embeds[embed_idx][0] == i:
+                row_text += self._char_embeds[embed_idx][1]
                 embed_idx += 1
 
             rows.append(([ref], row_text))
+
+        # Add transferred paragraph-type embeds
+        for sent_idx, ref, sent in self._para_embeds:
+            rows.insert(sent_idx, ([ref], sent))
 
         return rows
 
@@ -228,9 +273,20 @@ class UsfmPreserver:
 
 
 class StatisticalUsfmPreserver(UsfmPreserver):
-    def __init__(self, src_sentences, vrefs, stylesheet, include_embeds, aligner="eflomal"):
+    def __init__(
+        self,
+        src_sentences,
+        vrefs,
+        stylesheet,
+        include_paragraph_markers,
+        include_style_markers,
+        include_embeds,
+        aligner="eflomal",
+    ):
         self._aligner = aligner
-        super().__init__(src_sentences, vrefs, stylesheet, include_embeds)
+        super().__init__(
+            src_sentences, vrefs, stylesheet, include_paragraph_markers, include_style_markers, include_embeds
+        )
 
     def _tokenize_sents(self, sents: List[str]) -> List[List[Range[int]]]:
         tokenizer = LatinWordTokenizer()
@@ -256,7 +312,7 @@ Necessary changes to use AttentionUsfmPreserver:
 
 
 class AttentionUsfmPreserver(UsfmPreserver):
-    def __init__(self, src_sents, vrefs, stylesheet, include_embeds):
+    def __init__(self, src_sents, vrefs, stylesheet, include_paragraph_markers, include_style_markers, include_embeds):
         raise NotImplementedError(
             "AttentionUsfmPreserver is not a supported class. See class definition for more information about the work needed to use."
         )

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -112,8 +112,9 @@ class SILExperiment:
                     config.get("trg_project"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
-                    config.get("include_inline_elements", False),
-                    config.get("preserve_usfm_markers", False),
+                    config.get("include_paragraph_markers", False),
+                    config.get("include_style_markers", False),
+                    config.get("include_embeds", False),
                 )
             elif config.get("src_prefix"):
                 translator.translate_text_files(
@@ -132,8 +133,9 @@ class SILExperiment:
                     config.get("src_iso"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
-                    config.get("include_inline_elements", False),
-                    config.get("preserve_usfm_markers", False),
+                    config.get("include_paragraph_markers", False),
+                    config.get("include_style_markers", False),
+                    config.get("include_embeds", False),
                 )
             else:
                 raise RuntimeError("A Scripture book, file, or file prefix must be specified for translation.")

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -112,9 +112,9 @@ class SILExperiment:
                     config.get("trg_project"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
-                    config.get("include_paragraph_markers", False),
-                    config.get("include_style_markers", False),
-                    config.get("include_embeds", False),
+                    config.get("include_paragraph_markers", False) or config.get("preserve_usfm_markers", False),
+                    config.get("include_style_markers", False) or config.get("preserve_usfm_markers", False),
+                    config.get("include_embeds", False) or config.get("include_inline_elements", False),
                 )
             elif config.get("src_prefix"):
                 translator.translate_text_files(
@@ -133,9 +133,9 @@ class SILExperiment:
                     config.get("src_iso"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
-                    config.get("include_paragraph_markers", False),
-                    config.get("include_style_markers", False),
-                    config.get("include_embeds", False),
+                    config.get("include_paragraph_markers", False) or config.get("preserve_usfm_markers", False),
+                    config.get("include_style_markers", False) or config.get("preserve_usfm_markers", False),
+                    config.get("include_embeds", False) or config.get("include_inline_elements", False),
                 )
             else:
                 raise RuntimeError("A Scripture book, file, or file prefix must be specified for translation.")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -338,6 +338,18 @@ def main() -> None:
         help="For files in USFM format, carry over embeds from the source project to the output without translating them",
     )
     parser.add_argument(
+        "--include-inline-elements",
+        default=False,
+        action="store_true",
+        help="Deprecated argument, equivalent to --include-embeds",
+    )
+    parser.add_argument(
+        "--preserve-usfm-markers",
+        default=False,
+        action="store_true",
+        help="Deprecated argument, equivalent to --include-paragraph-markers AND --include-style-markers",
+    )
+    parser.add_argument(
         "--clearml-queue",
         default=None,
         type=str,
@@ -361,6 +373,13 @@ def main() -> None:
     translator = TranslationTask(
         name=args.experiment, checkpoint=args.checkpoint, clearml_queue=args.clearml_queue, commit=args.commit
     )
+
+    # For backwards compatibility
+    if args.preserve_usfm_markers:
+        args.include_paragraph_markers = True
+        args.include_style_markers = True
+    if args.include_inline_elements:
+        args.include_embeds = True
 
     if len(args.books) > 0:
         if args.debug:

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -54,8 +54,9 @@ class TranslationTask:
         trg_project: Optional[str],
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
-        include_inline_elements: bool = False,
-        preserve_usfm_markers: bool = False,
+        include_paragraph_markers: bool = False,
+        include_style_markers: bool = False,
+        include_embeds: bool = False,
     ):
         book_nums = get_chapters(books)
         translator, config, step_str = self._init_translation_task(
@@ -114,8 +115,9 @@ class TranslationTask:
                     produce_multiple_translations,
                     chapters,
                     trg_project,
-                    include_inline_elements,
-                    preserve_usfm_markers,
+                    include_paragraph_markers,
+                    include_style_markers,
+                    include_embeds,
                     experiment_ckpt_str,
                 )
             except Exception as e:
@@ -175,8 +177,9 @@ class TranslationTask:
         src_iso: Optional[str],
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
-        include_inline_elements: bool = False,
-        preserve_usfm_markers: bool = False,
+        include_paragraph_markers: bool = False,
+        include_style_markers: bool = False,
+        include_embeds: bool = False,
     ) -> None:
         translator, config, step_str = self._init_translation_task(
             experiment_suffix=f"_{self.checkpoint}_{os.path.basename(src)}"
@@ -249,8 +252,9 @@ class TranslationTask:
                     src_iso,
                     trg_iso,
                     produce_multiple_translations,
-                    include_inline_elements=include_inline_elements,
-                    preserve_usfm_markers=preserve_usfm_markers,
+                    include_paragraph_markers=include_paragraph_markers,
+                    include_style_markers=include_style_markers,
+                    include_embeds=include_embeds,
                     experiment_ckpt_str=experiment_ckpt_str,
                 )
         SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
@@ -316,16 +320,22 @@ def main() -> None:
         help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
     )
     parser.add_argument(
-        "--include-inline-elements",
+        "--include-paragraph-markers",
         default=False,
         action="store_true",
-        help="Include inline elements for projects in USFM format",
+        help="For files in USFM format, attempt to place paragraph markers in translated verses based on the source project's markers",
     )
     parser.add_argument(
-        "--preserve-usfm-markers",
+        "--include-style-markers",
         default=False,
         action="store_true",
-        help="Insert UFSM markers from source text into translations",
+        help="For files in USFM format, attempt to place style markers in translated verses based on the source project's markers",
+    )
+    parser.add_argument(
+        "--include-embeds",
+        default=False,
+        action="store_true",
+        help="For files in USFM format, carry over embeds from the source project to the output without translating them",
     )
     parser.add_argument(
         "--clearml-queue",
@@ -362,8 +372,9 @@ def main() -> None:
             args.trg_project,
             args.trg_iso,
             args.multiple_translations,
-            args.include_inline_elements,
-            args.preserve_usfm_markers,
+            args.include_paragraph_markers,
+            args.include_style_markers,
+            args.include_embeds,
         )
     elif args.src_prefix is not None:
         if args.debug:
@@ -394,8 +405,9 @@ def main() -> None:
             args.src_iso,
             args.trg_iso,
             args.multiple_translations,
-            args.include_inline_elements,
-            args.preserve_usfm_markers,
+            args.include_paragraph_markers,
+            args.include_style_markers,
+            args.include_embeds,
         )
     else:
         raise RuntimeError("A Scripture book, file, or file prefix must be specified.")


### PR DESCRIPTION
* Added translation options to toggle placement of paragraph/style/embed markers
* Refactored to move all USFM marker-related work into UsfmPreserver and to always use UsfmPreserver for more consistency across possible configurations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/694)
<!-- Reviewable:end -->
