### PR TITLE
Add confidence scores as output for test.py, diff_predictions.py, translate.py

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -3,6 +3,7 @@ import re
 from abc import ABC, abstractmethod
 from datetime import date
 from itertools import groupby
+from math import exp
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -212,7 +213,9 @@ class Translator(ABC):
                 sentences.pop(i)
                 empty_sents.append((i, vrefs.pop(i)))
 
-        translations = list(self.translate(sentences, src_iso, trg_iso, produce_multiple_translations, vrefs))
+        output = list(self.translate(sentences, src_iso, trg_iso, produce_multiple_translations, vrefs))
+
+        translations = [translation for translation, _, _, _ in output]
 
         # Add empty sentences back in
         # Prevents pre-existing text from showing up in the sections of translated text
@@ -220,6 +223,7 @@ class Translator(ABC):
             sentences.insert(idx, "")
             translations.insert(idx, ["" for _ in range(len(translations[0]))])
             vrefs.insert(idx, vref)
+            output.insert(idx, [None, None, None, None])
 
         draft_set: DraftGroup = DraftGroup(translations)
         for draft_index, translated_draft in enumerate(draft_set.get_drafts(), 1):
@@ -273,14 +277,33 @@ class Translator(ABC):
             description = f"project {src_file_text.project}" if src_from_project else f"file {src_file_path.name}"
             usfm_out = insert_draft_remark(usfm_out, vrefs[0].book, description, experiment_ckpt_str)
             encoding = src_settings.encoding if src_from_project else "utf-8"
-
+            confidence_scores_suffix = ".confidences.tsv"
             if produce_multiple_translations:
                 trg_draft_file_path = trg_file_path.with_suffix(f".{draft_index}{trg_file_path.suffix}")
+                confidences_path = trg_file_path.with_suffix(
+                    f".{draft_index}{trg_file_path.suffix}{confidence_scores_suffix}"
+                )
             else:
                 trg_draft_file_path = trg_file_path
-
+                confidences_path = trg_file_path.with_suffix(f"{trg_file_path.suffix}{confidence_scores_suffix}")
             with trg_draft_file_path.open("w", encoding=encoding) as f:
                 f.write(usfm_out)
+            with confidences_path.open("w", encoding="utf-8", newline="\n") as confidences_file:
+                confidences_file.write("\t".join(["VRef"] + [f"Token {i}" for i in range(200)]) + "\n")
+                confidences_file.write("\t".join(["Sequence Score"] + [f"Token Score {i}" for i in range(200)]) + "\n")
+                for sentence_num, _ in enumerate(output):
+                    if output[sentence_num][0] is None:
+                        continue
+                    confidences_file.write(
+                        "\t".join([str(vrefs[sentence_num])] + output[sentence_num][1][draft_index - 1]) + "\n"
+                    )
+                    confidences_file.write(
+                        "\t".join(
+                            [str(exp(output[sentence_num][3][draft_index - 1]))]
+                            + [str(exp(token_score)) for token_score in output[sentence_num][2][draft_index - 1]]
+                        )
+                        + "\n"
+                    )
 
     def translate_docx(
         self,

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -433,9 +433,9 @@ def add_score_to_chap(df: pd.DataFrame):
         key = book_name + " " + str(chap_num)
         if key not in chapters_pred:
             chapters_pred[key] = []
-            chapters_trg[key] = []
-            chapters_pred[key].append(row[PREDICTION])
-            chapters_trg[key].append([row[TRG_SENTENCE]])
+            chapters_trg[key] = [[]]
+        chapters_pred[key].append(row[PREDICTION])
+        chapters_trg[key][0].append(row[TRG_SENTENCE])
 
     return chapters_pred, chapters_trg
 

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -16,6 +16,7 @@ from sacrebleu.metrics.bleu import BLEU, BLEUScore
 from tqdm import tqdm
 
 from ..common.corpus import load_corpus
+from ..common.environment import SIL_NLP_ENV
 from ..common.utils import get_git_revision_hash
 from .config import get_mt_exp_dir
 from .sp_utils import decode_sp, decode_sp_lines
@@ -75,6 +76,15 @@ def sentence_bleu(
         effective_order=use_effective_order,
     )
     return metric.sentence_score(hypothesis, references)
+
+
+def extract_chapter(chapter_num):
+    parts = chapter_num.split()
+    book_name = parts[0]
+    vref_num = parts[1]
+    chap_num, verse_num = vref_num.split(":")
+    order_num = verse_num.split("-")[0]
+    return book_name, int(chap_num), int(order_num)
 
 
 histogram_offset = 0
@@ -188,7 +198,7 @@ def adjust_column_widths(df: pd.DataFrame, sheet, col_width: int):
 # Add the em-dash
 all_punctuation = string.punctuation + "\u2014"
 # Add smart quotes
-all_punctuation = all_punctuation + "\u2018" + "\u2019" + "\u201C" + "\u201D"
+all_punctuation = all_punctuation + "\u2018" + "\u2019" + "\u201c" + "\u201d"
 # Add Danda (0964) and Double Danda (0965) for Devanagari scripts
 all_punctuation = all_punctuation + "\u0964" + "\u0965"
 
@@ -411,6 +421,78 @@ def add_digits_analysis(writer, df: pd.DataFrame, col_width: int):
     sheet.autofilter(0, 0, digits_df.shape[0], digits_df.shape[1] - 1)
 
 
+def add_score_to_chap(df: pd.DataFrame):
+    chapters_pred = {}
+    chapters_trg = {}
+    for _, row in tqdm(df.iterrows()):
+        cur_vref = row[VREF]
+        book_name, chap_num, _ = extract_chapter(cur_vref)
+        key = book_name + " " + str(chap_num)
+        if key not in chapters_pred:
+            chapters_pred[key] = []
+            chapters_trg[key] = []
+            chapters_pred[key].append(row[PREDICTION])
+            chapters_trg[key].append([row[TRG_SENTENCE]])
+
+    return chapters_pred, chapters_trg
+
+
+def add_chap_scores(df: pd.DataFrame, df_chap: pd.DataFrame, scorers: List[str], preserve_case: bool):
+    chapters_pred, chapters_trg = add_score_to_chap(df)
+    for scorer in scorers:
+        scorer = scorer.lower()
+        if scorer == BLEU_SCORE.lower():
+            print("Sentence BLEU is not provided for chapter scoring!")
+            continue
+        if scorer == SPBLEU_SCORE.lower():
+            df_chap[SPBLEU_SCORE] = None
+            print("Calculating spBLEU scores ...")
+            for chap, pred in chapters_pred.items():
+                spbleu_score = sacrebleu.corpus_bleu(
+                    pred, chapters_trg[chap], lowercase=not preserve_case, tokenize="flores200"
+                )
+                df_chap.loc[df_chap[VREF] == chap, SPBLEU_SCORE] = spbleu_score.score
+        elif scorer == CHRF3_SCORE.lower():
+            df_chap[CHRF3_SCORE] = None
+            print("Calculating chrF3 scores ...")
+            for chap, pred in chapters_pred.items():
+                chrf3_score = sacrebleu.corpus_chrf(
+                    pred, chapters_trg[chap], char_order=6, beta=3, remove_whitespace=True
+                )
+                df_chap.loc[df_chap[VREF] == chap, CHRF3_SCORE] = chrf3_score.score
+        elif scorer == CHRF3P_SCORE.lower():
+            print("Calculating chrF3+ scores ...")
+            for chap, pred in chapters_pred.items():
+                chrf3p_score = sacrebleu.corpus_chrf(
+                    pred,
+                    chapters_trg[chap],
+                    char_order=6,
+                    beta=3,
+                    word_order=1,
+                    remove_whitespace=True,
+                    eps_smoothing=True,
+                )
+                df_chap.loc[df_chap[VREF] == chap, CHRF3P_SCORE] = chrf3p_score.score
+        elif scorer == CHRF3PP_SCORE.lower():
+            print("Calculating chrF3++ scores ...")
+            for chap, pred in chapters_pred.items():
+                chrf3pp_score = sacrebleu.corpus_chrf(
+                    pred,
+                    chapters_trg[chap],
+                    char_order=6,
+                    beta=3,
+                    word_order=2,
+                    remove_whitespace=True,
+                    eps_smoothing=True,
+                )
+                df_chap.loc[df_chap[VREF] == chap, CHRF3PP_SCORE] = chrf3pp_score.score
+        elif scorer == TER_SCORE.lower():
+            print("Calculating TER scores ...")
+            for chap, pred in chapters_pred.items():
+                ter_score = sacrebleu.corpus_ter(pred, chapters_trg[chap])
+                df_chap.loc[df_chap[VREF] == chap, TER_SCORE] = ter_score.score if ter_score.score >= 0 else 0
+
+
 def add_scores(df: pd.DataFrame, scorers: List[str], preserve_case: bool, tokenize: bool):
     for scorer in scorers:
         scores: List[float] = []
@@ -507,6 +589,9 @@ def main() -> None:
         "--tokenize", type=str, default="13a", help="Sacrebleu tokenizer (none,13a,intl,zh,ja-mecab,char)"
     )
     parser.add_argument(
+        "--chapter-score", default=False, action="store_true", help="Show scores in chapters rather than in verses"
+    )
+    parser.add_argument(
         "--scorers",
         nargs="*",
         metavar="scorer",
@@ -523,6 +608,13 @@ def main() -> None:
 
     exp1_name = args.exp1
     exp1_dir = get_mt_exp_dir(exp1_name)
+
+    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.txt*")
+    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.csv")
+    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.yaml")
+
+    # exp1_type = "NMT"
+
     exp1_type = get_experiment_type(str(exp1_dir))
     if exp1_type != "SMT" and exp1_type != "NMT":
         print("Can't determine experiment type!")
@@ -534,6 +626,8 @@ def main() -> None:
         else get_last_checkpoint(str(exp1_dir)) if args.last else get_best_checkpoint(str(exp1_dir))
     )
     output_path = os.path.join(exp1_dir, f"diff_predictions.{exp1_step}.xlsx")
+    if args.chapter_score:
+        output_path = os.path.join(exp1_dir, f"diff_predictions.chapters.{exp1_step}.xlsx")
 
     # Set up to generate the Excel output
     writer: pd.ExcelWriter = pd.ExcelWriter(output_path, engine="xlsxwriter")
@@ -588,7 +682,21 @@ def main() -> None:
         df.insert(2, SRC_TOKENS, list(strip_lang_codes(load_corpus(Path(os.path.join(exp1_dir, "test.src.txt"))))))
         prediction_col = "E"
 
-    add_scores(df, args.scorers, args.preserve_case, args.tokenize)
+    if args.chapter_score:
+        df[["ChapName", "ChapNum", "SortNum"]] = df[VREF].apply(lambda x: pd.Series(extract_chapter(x)))
+        df = df.sort_values(by=["ChapName", "ChapNum", "SortNum"])
+
+        df_chap = (
+            df.groupby(["ChapName", "ChapNum"])
+            .agg({SRC_SENTENCE: " ".join, SRC_TOKENS: " ".join, TRG_SENTENCE: " ".join, PREDICTION: " ".join})
+            .reset_index()
+        )
+        df_chap[VREF] = df_chap["ChapName"] + " " + df_chap["ChapNum"].astype(str)
+        df_chap = df_chap[[VREF, SRC_SENTENCE, SRC_TOKENS, TRG_SENTENCE, PREDICTION]]
+        add_chap_scores(df, df_chap, args.scorers, args.preserve_case)
+        df = df_chap
+    else:
+        add_scores(df, args.scorers, args.preserve_case, args.tokenize)
 
     df.sort_values(VREF, inplace=True)
     df = df.reset_index(drop=True)
@@ -624,6 +732,8 @@ def main() -> None:
     writer.close()
     #    os.remove(exp1_graph)
     print(f"Output is in {output_path}")
+
+    # SIL_NLP_ENV.copy_experiment_to_bucket(exp1_name, patterns=("diff_predictions.*"), overwrite=True)
 
 
 if __name__ == "__main__":

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Iterable, List, Optional
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 import sacrebleu
 from sacrebleu.metrics.bleu import BLEU, BLEUScore

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -617,7 +617,7 @@ def main() -> None:
     stats_offset = 5
 
     exp1_name = args.exp1
-    SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name)
+    SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, no_checkpoints=True)
     exp1_dir = get_mt_exp_dir(exp1_name)
 
     # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.txt*")

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -677,7 +677,10 @@ def main() -> None:
     dictDf = load_dictionary(exp1_dir) if args.include_dict or args.show_dict else None
 
     # Create the initial data frame
-    df = pd.DataFrame(columns=[VREF, SRC_SENTENCE, TRG_SENTENCE, PREDICTION, CONFIDENCE])
+    df_columns = [VREF, SRC_SENTENCE, TRG_SENTENCE, PREDICTION]
+    if args.confidence:
+        df_columns.append(CONFIDENCE)
+    df = pd.DataFrame(columns=df_columns)
 
     # Load the datasets
     df[VREF] = list(load_corpus(Path(vref_file))) if vref_file is not None else ""

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -506,14 +506,14 @@ def add_scores(df: pd.DataFrame, scorers: List[str], preserve_case: bool, tokeni
         if scorer == BLEU_SCORE.lower():
             for index, row in tqdm(df.iterrows(), desc="Calculating BLEU scores ..."):
                 bleu = sentence_bleu(
-                    [row[PREDICTION]], [[row[TRG_SENTENCE]]], lowercase=not preserve_case, tokenize=tokenize
+                    row[PREDICTION], [row[TRG_SENTENCE]], lowercase=not preserve_case, tokenize=tokenize
                 )
                 scores.append(bleu.score)
             df[BLEU_SCORE] = scores
         elif scorer == SPBLEU_SCORE.lower():
             for index, row in tqdm(df.iterrows(), desc="Calculating spBLEU scores ..."):
                 spbleu_score = sacrebleu.corpus_bleu(
-                    row[PREDICTION], [row[TRG_SENTENCE]], lowercase=not preserve_case, tokenize="flores200"
+                    [row[PREDICTION]], [[row[TRG_SENTENCE]]], lowercase=not preserve_case, tokenize="flores200"
                 )
                 scores.append(spbleu_score.score)
             df[SPBLEU_SCORE] = scores

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -627,13 +627,6 @@ def main() -> None:
     exp1_name = args.exp1
     SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, no_checkpoints=True)
     exp1_dir = get_mt_exp_dir(exp1_name)
-
-    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.txt*")
-    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.csv")
-    # SIL_NLP_ENV.copy_experiment_from_bucket(exp1_name, patterns="*.yaml")
-
-    # exp1_type = "NMT"
-
     exp1_type = get_experiment_type(str(exp1_dir))
     if exp1_type != "SMT" and exp1_type != "NMT":
         print("Can't determine experiment type!")
@@ -717,17 +710,13 @@ def main() -> None:
             PREDICTION: " ".join,
         }
         if args.confidence:
-            agg_dict[CONFIDENCE] = [gmean, "mean", "median"]
-        agg_dict[BLEU_SCORE] = "mean"  # TODO: Remove when we no longer need to calculate mean scores
-        agg_dict[CHRF3_SCORE] = "mean"
-        agg_dict[CHRF3PP_SCORE] = "mean"
+            agg_dict[CONFIDENCE] = gmean
 
         df_chap = df.groupby(["ChapName", "ChapNum"]).agg(agg_dict).reset_index()
 
         columns = ["ChapName", "ChapNum", SRC_SENTENCE, SRC_TOKENS, TRG_SENTENCE, PREDICTION]
         if args.confidence:
-            columns += [CONFIDENCE, "Confidence AMean", "Confidence Median"]
-        columns += ["BLEU Mean Score", "chrF3 Mean Score", "chrF3++ Mean Score"]
+            columns += [CONFIDENCE]
 
         df_chap.columns = columns
 

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -182,7 +182,7 @@ def main() -> None:
         nargs="*",
         metavar="scorer",
         choices=_SUPPORTED_SCORERS,
-        default=["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu"],
+        default=["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "confidence"],
         help=f"List of scorers - {_SUPPORTED_SCORERS}",
     )
 

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -9,19 +9,7 @@ from copy import deepcopy
 from enum import Enum
 from itertools import repeat
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union, cast
 
 import datasets.utils.logging as datasets_logging
 import evaluate
@@ -36,10 +24,7 @@ from datasets import Dataset
 from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef
 from sacremoses import MosesPunctNormalizer
 from tokenizers import AddedToken, NormalizedString, Regex
-from tokenizers.implementations import (
-    SentencePieceBPETokenizer,
-    SentencePieceUnigramTokenizer,
-)
+from tokenizers.implementations import SentencePieceBPETokenizer, SentencePieceUnigramTokenizer
 from tokenizers.normalizers import Normalizer
 from torch import Tensor, TensorType, nn, optim
 from torch.utils.data import Sampler
@@ -71,6 +56,7 @@ from transformers import (
     set_seed,
 )
 from transformers.convert_slow_tokenizer import convert_slow_tokenizer
+from transformers.generation import BeamSearchEncoderDecoderOutput, GreedySearchEncoderDecoderOutput
 from transformers.modeling_utils import unwrap_model
 from transformers.tokenization_utils import BatchEncoding, TruncationStrategy
 from transformers.trainer import TRAINING_ARGS_NAME
@@ -88,14 +74,7 @@ from transformers.utils.logging import tqdm
 from ..common.corpus import Term, count_lines, get_terms
 from ..common.environment import SIL_NLP_ENV
 from ..common.translator import DraftGroup, TranslationGroup
-from ..common.utils import (
-    NoiseMethod,
-    ReplaceRandomToken,
-    Side,
-    create_noise_methods,
-    get_mt_exp_dir,
-    merge_dict,
-)
+from ..common.utils import NoiseMethod, ReplaceRandomToken, Side, create_noise_methods, get_mt_exp_dir, merge_dict
 from .config import CheckpointType, Config, DataFile, NMTModel
 from .tokenizer import NullTokenizer, Tokenizer
 
@@ -1870,6 +1849,127 @@ class PretokenizedTranslationPipeline(TranslationPipeline):
         tgt_lang_id = self.tokenizer.convert_tokens_to_ids(tgt_lang)
         model_inputs["forced_bos_token_id"] = tgt_lang_id
         return model_inputs
+
+    def _forward(self, model_inputs, **generate_kwargs):
+        in_b, input_length = model_inputs["input_ids"].shape
+
+        input_tokens = model_inputs["input_tokens"]
+        del model_inputs["input_tokens"]
+        if hasattr(self.model, "generation_config") and self.model.generation_config is not None:
+            config = self.model.generation_config
+        else:
+            config = self.model.config
+        generate_kwargs["min_length"] = generate_kwargs.get("min_length", config.min_length)
+        generate_kwargs["max_length"] = generate_kwargs.get("max_length", config.max_length)
+        self.check_inputs(input_length, generate_kwargs["min_length"], generate_kwargs["max_length"])
+        output = self.model.generate(
+            **model_inputs,
+            **generate_kwargs,
+            output_scores=True,
+            return_dict_in_generate=True,
+        )
+
+        if isinstance(output, BeamSearchEncoderDecoderOutput):
+            output_ids = output.sequences
+            beam_indices = output.beam_indices
+            scores = output.scores
+        elif isinstance(output, GreedySearchEncoderDecoderOutput):
+            output_ids = output.sequences
+            beam_indices = torch.zeros_like(output_ids)
+            assert output.scores is not None
+            scores = tuple(torch.nn.functional.log_softmax(logits, dim=-1) for logits in output.scores)
+        else:
+            raise RuntimeError("Cannot postprocess the output of the model.")
+
+        assert beam_indices is not None and scores is not None
+        out_b = output_ids.shape[0]
+        num_beams = scores[0].shape[0] // in_b
+        n_sequences = out_b // in_b
+        start_index = 0
+        if self.model.config.decoder_start_token_id is not None:
+            start_index = 1
+        indices = torch.stack(
+            (
+                torch.arange(output_ids.shape[1] - start_index, device=output_ids.device).expand(in_b, n_sequences, -1),
+                torch.reshape(beam_indices[:, start_index:] % num_beams, (in_b, n_sequences, -1)),
+                torch.reshape(output_ids[:, start_index:], (in_b, n_sequences, -1)),
+            ),
+            dim=3,
+        )
+        scores = torch.stack(scores, dim=0).reshape(len(scores), in_b, num_beams, -1).transpose(0, 1)
+        scores = torch_gather_nd(scores, indices, 1)
+        if self.model.config.decoder_start_token_id is not None:
+            scores = torch.cat((torch.zeros(scores.shape[0], scores.shape[1], 1, device=scores.device), scores), dim=2)
+        output_ids = output_ids.reshape(in_b, n_sequences, *output_ids.shape[1:])
+        return {
+            "output_ids": output_ids,
+            "scores": scores,
+        }
+
+    def postprocess(self, model_outputs, clean_up_tokenization_spaces=False):
+        if self.tokenizer is None:
+            raise RuntimeError("No tokenizer is specified.")
+        all_special_ids = set(self.tokenizer.all_special_ids)
+
+        records = []
+        output_ids: torch.Tensor
+        scores: torch.Tensor
+        for output_ids, scores in zip(
+            model_outputs["output_ids"][0],
+            model_outputs["scores"][0],
+        ):
+            output_tokens: List[str] = []
+            output_indices: List[int] = []
+            for i, output_id in enumerate(output_ids):
+                id = cast(int, output_id.item())
+                if id not in all_special_ids:
+                    output_tokens.append(self.tokenizer.convert_ids_to_tokens(id))
+                    output_indices.append(i)
+            scores = scores[output_indices]
+            records.append(
+                {
+                    "translation_tokens": output_tokens,
+                    "token_scores": scores,
+                    "translation_text": self.tokenizer.decode(
+                        output_ids,
+                        skip_special_tokens=True,
+                        clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+                    ),
+                }
+            )
+        return records
+
+
+def torch_gather_nd(params: torch.Tensor, indices: torch.Tensor, batch_dim: int = 0) -> torch.Tensor:
+    """
+    torch_gather_nd implements tf.gather_nd in PyTorch.
+
+    This supports multiple batch dimensions as well as multiple channel dimensions.
+    """
+    index_shape = indices.shape[:-1]
+    num_dim = indices.size(-1)
+    tail_sizes = params.shape[batch_dim + num_dim :]
+
+    # flatten extra dimensions
+    for s in tail_sizes:
+        row_indices = torch.arange(s, device=params.device)
+        indices = indices.unsqueeze(-2)
+        indices = indices.repeat(*[1 for _ in range(indices.dim() - 2)], s, 1)
+        row_indices = row_indices.expand(*indices.shape[:-2], -1).unsqueeze(-1)
+        indices = torch.cat((indices, row_indices), dim=-1)
+        num_dim += 1
+
+    # flatten indices and params to batch specific ones instead of channel specific
+    for i in range(num_dim):
+        size = prod(params.shape[batch_dim + i + 1 : batch_dim + num_dim])
+        indices[..., i] *= size
+
+    indices = indices.sum(dim=-1)
+    params = params.flatten(batch_dim, -1)
+    indices = indices.flatten(batch_dim, -1)
+
+    out = torch.gather(params, dim=batch_dim, index=indices)
+    return out.reshape(*index_shape, *tail_sizes)
 
 
 class DataCollatorForSeq2SeqNoising:

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -9,6 +9,7 @@ from typing import IO, Dict, List, Optional, Set, TextIO, Tuple
 import sacrebleu
 from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef, book_number_to_id, get_chapters
 from sacrebleu.metrics import BLEU, BLEUScore
+from scipy.stats import gmean
 
 from ..common.environment import SIL_NLP_ENV
 from ..common.metrics import compute_meteor_score
@@ -21,7 +22,7 @@ LOGGER = logging.getLogger(__package__ + ".test")
 
 logging.getLogger("sacrebleu").setLevel(logging.ERROR)
 
-_SUPPORTED_SCORERS = ["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "meteor", "ter"]
+_SUPPORTED_SCORERS = ["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "meteor", "ter", "confidence"]
 
 
 class PairScore:
@@ -83,6 +84,7 @@ def score_pair(
     src_iso: str,
     trg_iso: str,
     predictions_detok_file_name: str,
+    predictions_conf_file_name: str,
     scorers: Set[str],
     config: Config,
     ref_projects: Set[str],
@@ -142,6 +144,14 @@ def score_pair(
         if ter_score.score >= 0:
             other_scores["TER"] = ter_score.score
 
+    if "confidence" in scorers:
+        confidences = []
+        with open(config.exp_dir / predictions_conf_file_name, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+            for i in range(3, len(lines), 2):
+                confidences.append(float(lines[i].split("\t")[0]))
+        other_scores["confidence"] = gmean(confidences)
+
     return PairScore(book, src_iso, trg_iso, bleu_score, len(pair_sys), ref_projects, other_scores, draft_index)
 
 
@@ -150,6 +160,7 @@ def score_individual_books(
     src_iso: str,
     trg_iso: str,
     predictions_detok_file_name: str,
+    predictions_conf_file_name: str,
     scorers: Set[str],
     config: Config,
     ref_projects: Set[str],
@@ -163,7 +174,16 @@ def score_individual_books(
         overall_sys.extend(pair_sys)
         book_scores.append(
             score_pair(
-                pair_sys, pair_refs, book, src_iso, trg_iso, predictions_detok_file_name, scorers, config, ref_projects
+                pair_sys,
+                pair_refs,
+                book,
+                src_iso,
+                trg_iso,
+                predictions_detok_file_name,
+                predictions_conf_file_name,
+                scorers,
+                config,
+                ref_projects,
             )
         )
     return book_scores
@@ -369,6 +389,7 @@ def test_checkpoint(
     translation_file_names: List[str] = []
     refs_patterns: List[str] = []
     translation_detok_file_names: List[str] = []
+    translation_conf_file_names: List[str] = []
     suffix_str = "_".join(map(lambda n: book_number_to_id(n), sorted(books.keys())))
     if len(suffix_str) > 0:
         suffix_str += "-"
@@ -382,6 +403,7 @@ def test_checkpoint(
         translation_file_names.append(f"test.trg-predictions.txt.{suffix_str}")
         refs_patterns.append("test.trg.detok*.txt")
         translation_detok_file_names.append(f"test.trg-predictions.detok.txt.{suffix_str}")
+        translation_conf_file_names.append(f"test.trg-predictions.txt.{suffix_str}.confidences.tsv")
     else:
         # test data is split into separate files
         for src_iso in sorted(config.test_src_isos):
@@ -396,6 +418,7 @@ def test_checkpoint(
                     translation_file_names.append(f"{prefix}.trg-predictions.txt.{suffix_str}")
                     refs_patterns.append(f"{prefix}.trg.detok*.txt")
                     translation_detok_file_names.append(f"{prefix}.trg-predictions.detok.txt.{suffix_str}")
+                    translation_conf_file_names.append(f"{prefix}.trg-predictions.txt.{suffix_str}.confidences.tsv")
 
     checkpoint_name = "averaged checkpoint" if step == -1 else f"checkpoint {step}"
 
@@ -448,6 +471,7 @@ def test_checkpoint(
         predictions_file_name,
         refs_pattern,
         predictions_detok_file_name,
+        predictions_conf_file_name,
         draft_index,
     ) in zip(
         vref_file_names,
@@ -455,6 +479,7 @@ def test_checkpoint(
         translation_file_names,
         refs_patterns,
         translation_detok_file_names,
+        translation_conf_file_names,
         draft_indices,
     ):
         src_iso = config.default_test_src_iso
@@ -494,6 +519,7 @@ def test_checkpoint(
                 src_iso,
                 trg_iso,
                 predictions_detok_file_name,
+                predictions_conf_file_name,
                 scorers,
                 config,
                 ref_projects,
@@ -504,7 +530,14 @@ def test_checkpoint(
         if by_book:
             if len(book_dict) != 0:
                 book_scores = score_individual_books(
-                    book_dict, src_iso, trg_iso, predictions_detok_file_name, scorers, config, ref_projects
+                    book_dict,
+                    src_iso,
+                    trg_iso,
+                    predictions_detok_file_name,
+                    predictions_conf_file_name,
+                    scorers,
+                    config,
+                    ref_projects,
                 )
                 scores.extend(book_scores)
             else:

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -89,6 +89,7 @@ def score_pair(
     config: Config,
     ref_projects: Set[str],
     draft_index: int = 1,
+    pair_confs: Optional[List[float]] = None,
 ) -> PairScore:
     bleu_score = None
     if "bleu" in scorers:
@@ -145,11 +146,11 @@ def score_pair(
             other_scores["TER"] = ter_score.score
 
     if "confidence" in scorers:
-        confidences = []
-        with open(config.exp_dir / predictions_conf_file_name, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-            for i in range(3, len(lines), 2):
-                confidences.append(float(lines[i].split("\t")[0]))
+        if pair_confs is not None:
+            confidences = pair_confs
+        else:
+            with open(config.exp_dir / predictions_conf_file_name, "r", encoding="utf-8") as f:
+                confidences = [float(line.split("\t")[0]) for line in list(f)[3::2]]
         other_scores["confidence"] = gmean(confidences)
 
     return PairScore(book, src_iso, trg_iso, bleu_score, len(pair_sys), ref_projects, other_scores, draft_index)
@@ -171,6 +172,7 @@ def score_individual_books(
     for book, book_tuple in book_dict.items():
         pair_sys = book_tuple[0]
         pair_refs = book_tuple[1]
+        pair_confs = book_tuple[2]
         overall_sys.extend(pair_sys)
         book_scores.append(
             score_pair(
@@ -184,6 +186,7 @@ def score_individual_books(
                 scorers,
                 config,
                 ref_projects,
+                pair_confs=pair_confs,
             )
         )
     return book_scores
@@ -194,11 +197,12 @@ def process_individual_books(
     pred_file_path: Path,
     ref_file_paths: List[Path],
     vref_file_path: Path,
+    conf_file_path: Path,
     select_rand_ref_line: bool,
     books: Dict[int, List[int]],
 ) -> Dict[str, Tuple[List[str], List[List[str]]]]:
     # Output data structure
-    book_dict: Dict[str, Tuple[List[str], List[List[str]]]] = {}
+    book_dict: Dict[str, Tuple[List[str], List[List[str]], List[float]]] = {}
     with ExitStack() as stack:
         # Get all references
         ref_files: List[TextIO] = []
@@ -207,12 +211,15 @@ def process_individual_books(
 
         vref_file = stack.enter_context(vref_file_path.open("r", encoding="utf-8"))
         pred_file = stack.enter_context(pred_file_path.open("r", encoding="utf-8"))
+        conf_file = stack.enter_context(conf_file_path.open("r", encoding="utf-8"))
+        conf_list = [float(line.strip().split("\t")[0]) for line in list(conf_file)[3::2]]
 
-        for lines in zip(pred_file, vref_file, *ref_files):
+        for lines in zip(pred_file, vref_file, conf_list, *ref_files):
             # Get file lines
             pred_line = lines[0].strip()
             detok_pred = tokenizer.detokenize(pred_line)
             vref = lines[1].strip()
+            confidence = lines[2]
             # Get book
             if vref == "":
                 continue
@@ -222,24 +229,24 @@ def process_individual_books(
                 continue
             # If book not in dictionary add the book
             if vref.book not in book_dict:
-                book_dict[vref.book] = ([], [])
-            book_pred, book_refs = book_dict[vref.book]
+                book_dict[vref.book] = ([], [], [])
+            book_pred, book_refs, book_conf = book_dict[vref.book]
 
-            # Add detokenized prediction to nested dictionary
+            # Add detokenized prediction and confidence to nested dictionary
             book_pred.append(detok_pred)
-
+            book_conf.append(confidence)
             # Check if random ref line selected or not
             if select_rand_ref_line:
-                ref_lines: List[str] = [line.strip() for line in lines[2:] if len(line.strip()) > 0]
+                ref_lines: List[str] = [line.strip() for line in lines[3:] if len(line.strip()) > 0]
                 ref_index = random.randint(0, len(ref_lines) - 1)
-                ref_line = ref_lines[ref_index + 2].strip()
+                ref_line = ref_lines[ref_index + 3].strip()
                 if len(book_refs) == 0:
                     book_refs.append([])
                 book_refs[0].append(ref_line)
             else:
                 # For each reference text, add to book_refs
                 for ref_index in range(len(ref_files)):
-                    ref_line = lines[ref_index + 2].strip()
+                    ref_line = lines[ref_index + 3].strip()
                     if len(book_refs) == ref_index:
                         book_refs.append([])
                     book_refs[ref_index].append(ref_line)
@@ -250,6 +257,7 @@ def load_test_data(
     tokenizer: Tokenizer,
     vref_file_name: str,
     pred_file_name: str,
+    conf_file_name: str,
     ref_pattern: str,
     output_file_name: str,
     ref_projects: Set[str],
@@ -261,6 +269,7 @@ def load_test_data(
     refs: List[List[str]] = []
     book_dict: Dict[str, Tuple[List[str], List[List[str]]]] = {}
     pred_file_path = config.exp_dir / pred_file_name
+    conf_file_path = config.exp_dir / conf_file_name
     with ExitStack() as stack:
         pred_file = stack.enter_context(pred_file_path.open("r", encoding="utf-8"))
         out_file = stack.enter_context((config.exp_dir / output_file_name).open("w", encoding="utf-8"))
@@ -312,6 +321,7 @@ def load_test_data(
                 pred_file_path,
                 ref_file_paths,
                 vref_file_path,
+                conf_file_path,
                 select_rand_ref_line,
                 books,
             )
@@ -493,6 +503,7 @@ def test_checkpoint(
             tokenizer,
             vref_file_name,
             predictions_file_name,
+            predictions_conf_file_name,
             refs_pattern,
             predictions_detok_file_name,
             ref_projects,

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -166,7 +166,9 @@ class TranslationTask:
                 translator.translate_text(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
                 end = time.time()
                 print(f"Translated {src_file_path.name} to {trg_file_path.name} in {((end-start)/60):.2f} minutes")
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(
+            self.name, patterns=("*.SFM", "*.SFM.confidences.tsv", "*.txt", "*.txt.confidences.tsv"), overwrite=True
+        )
 
     def translate_files(
         self,

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -255,7 +255,9 @@ class TranslationTask:
                     preserve_usfm_markers=preserve_usfm_markers,
                     experiment_ckpt_str=experiment_ckpt_str,
                 )
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(
+            self.name, patterns=("*.SFM", "*.SFM.confidences.tsv", "*.txt", "*.txt.confidences.tsv"), overwrite=True
+        )
 
     def _init_translation_task(self, experiment_suffix: str) -> Tuple[Translator, Config, str]:
         clearml = SILClearML(

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -122,7 +122,7 @@ class TranslationTask:
                 translation_failed.append(book)
                 LOGGER.exception(f"Was not able to translate {book}.")
 
-        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM"), overwrite=True)
+        SIL_NLP_ENV.copy_experiment_to_bucket(self.name, patterns=("*.SFM", "*.SFM.confidences.tsv"), overwrite=True)
 
         if len(translation_failed) > 0:
             raise RuntimeError(f"Some books failed to translate: {' '.join(translation_failed)}")


### PR DESCRIPTION
This addresses issue #715. The `test.py` script now outputs a file called `test.trg-predictions.txt.[ckpt_num].confidences.tsv`. The file has two rows for each verse. The first row has the verse number and then each token, and the second row has the sequence confidence and then each individual token confidence, so that they are vertically paired with the first row. The `diff_predictions.py` script now has a couple new flags, `--chapter-score` which @AmeWenJ added that runs diff predictions at a chapter level rather than a verse level, and `--confidence` which adds a column to the dataframe for confidence scores.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/716)
<!-- Reviewable:end -->
