### PR TITLE
Revert to older implementation of USFM marker placement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5174,13 +5174,13 @@ type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12
 
 [[package]]
 name = "sil-machine"
-version = "1.6.2"
+version = "1.4.0"
 description = "A natural language processing library that is focused on providing tools for resource-poor languages."
 optional = false
 python-versions = "<3.13,>=3.9"
 files = [
-    {file = "sil_machine-1.6.2-py3-none-any.whl", hash = "sha256:89ab7cfe53856c474a1dfb705e90cd3eec6da399b77237005bb16139f43ec353"},
-    {file = "sil_machine-1.6.2.tar.gz", hash = "sha256:25f1818a8a14a4b26e1eacda2f527fbe7ffadba7cdeaa98d450ef5ae6313cc7c"},
+    {file = "sil_machine-1.4.0-py3-none-any.whl", hash = "sha256:ceea8358c426d5bd129e6a8dff779aa19430ac69087b99a7177660fd24f26eaf"},
+    {file = "sil_machine-1.4.0.tar.gz", hash = "sha256:7f66567313e29654b8cf44d4c9d1156700a879313450a400e018bf06a1818e44"},
 ]
 
 [package.dependencies]
@@ -5190,7 +5190,7 @@ charset-normalizer = ">=2.1.1,<3.0.0"
 networkx = ">=3,<4"
 numpy = ">=1.24.4,<2.0.0"
 regex = ">=2021.7.6"
-sil-thot = {version = ">=3.4.6,<4.0.0", optional = true, markers = "extra == \"thot\""}
+sil-thot = {version = ">=3.4.4,<4.0.0", optional = true, markers = "extra == \"thot\""}
 sortedcontainers = ">=2.4.0,<3.0.0"
 urllib3 = "<2"
 
@@ -5198,7 +5198,7 @@ urllib3 = "<2"
 huggingface = ["datasets (>=2.4.0,<3.0.0)", "sacremoses (>=0.0.53,<0.0.54)", "transformers (>=4.38.0,<4.46)"]
 jobs = ["clearml[s3] (>=1.13.1,<2.0.0)", "dynaconf (>=3.2.5,<4.0.0)", "json-stream (>=1.3.0,<2.0.0)"]
 sentencepiece = ["sentencepiece (>=0.2.0,<0.3.0)"]
-thot = ["sil-thot (>=3.4.6,<4.0.0)"]
+thot = ["sil-thot (>=3.4.4,<4.0.0)"]
 
 [[package]]
 name = "sil-thot"
@@ -6217,4 +6217,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "8b1efa077c6a39ee15a1f3276f40478d9ce3f1753f956e1d601d7ba6cf6d11de"
+content-hash = "54d8af4e3f58502aa4dd5ed36edec8ceb0f4ea759b220d292252de9c28bb73e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ s3path = "0.3.4"
 sacrebleu = "^2.3.1"
 ctranslate2 = "^3.5.1"
 libclang = "14.0.6"
-sil-machine = {extras = ["thot"], version = "^1.6.2"}
+sil-machine = {extras = ["thot"], version = "1.4.0"}
 datasets = "^2.7.1"
 torch = {version = "^2.4", source = "torch"}
 sacremoses = "^0.0.53"

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -9,14 +9,14 @@ from typing import Iterable, List, Optional
 import docx
 import nltk
 from iso639 import Lang
-from machine.corpora import (
+from machine.corpora import (  # UpdateUsfmMarkerBehavior, UpdateUsfmTextBehavior, FileParatextProjectTextUpdater,
     FileParatextProjectSettingsParser,
-    FileParatextProjectTextUpdater,
-    UpdateUsfmMarkerBehavior,
+    UpdateUsfmBehavior,
     UpdateUsfmParserHandler,
-    UpdateUsfmTextBehavior,
     UsfmFileText,
+    UsfmParserState,
     UsfmStylesheet,
+    UsfmTokenType,
     parse_usfm,
 )
 from machine.scripture import VerseRef
@@ -27,6 +27,36 @@ from .usfm_preservation import StatisticalUsfmPreserver
 
 LOGGER = logging.getLogger(__package__ + ".translate")
 nltk.download("punkt")
+
+
+class ParagraphUpdateUsfmParserHandler(UpdateUsfmParserHandler):
+    def _collect_tokens(self, state: UsfmParserState) -> None:
+        self._tokens.extend(self._new_tokens)
+        self._new_tokens.clear()
+        while self._token_index <= state.index + state.special_token_count:
+            if (
+                state.tokens[self._token_index].type == UsfmTokenType.PARAGRAPH
+                and state.tokens[self._token_index].marker != "rem"
+            ):
+                # Because paragraph marker tokens are passed at the end of the verse,
+                # it is necessary to calculate how many positions each one needs to move up.
+                # This logic inserts them between the earliest instance of consecutive text tokens in the verse
+                num_text = 0
+                rem_offset = 0
+                for i in range(len(self._tokens) - 1, -1, -1):
+                    if self._tokens[i].type == UsfmTokenType.TEXT:
+                        num_text += 1
+                    elif self._tokens[i].type == UsfmTokenType.PARAGRAPH and self._tokens[i].marker == "rem":
+                        rem_offset += num_text + 1
+                        num_text = 0
+                    else:
+                        break
+                if num_text >= 2:
+                    self._tokens.insert(-(rem_offset + num_text - 1), state.tokens[self._token_index])
+                    self._token_index += 1
+                    break  # should this be continue instead? is there just no difference bc only 1 paragraph marker is added at a time?
+            self._tokens.append(state.tokens[self._token_index])
+            self._token_index += 1
 
 
 def insert_draft_remark(
@@ -220,40 +250,54 @@ class Translator(ABC):
             # Insert translation into the USFM structure of an existing project
             # If the target project is not the same as the translated file's original project,
             # no verses outside of the ones translated will be overwritten
-            if trg_project is not None or src_from_project:
-                dest_updater = FileParatextProjectTextUpdater(
-                    get_project_dir(trg_project if trg_project is not None else src_file_path.parent.name)
-                )
-                usfm_out = dest_updater.update_usfm(
-                    book_id=src_file_text.id,
-                    rows=rows,
-                    text_behavior=(
-                        UpdateUsfmTextBehavior.PREFER_NEW
-                        if trg_project is not None
-                        else UpdateUsfmTextBehavior.STRIP_EXISTING
-                    ),
-                    paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    embed_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    style_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    preserve_paragraph_styles=[],
-                )
+            with open(src_file_path, encoding=src_settings.encoding if src_from_project else "utf-8-sig") as f:
+                usfm = f.read()
+            handler = ParagraphUpdateUsfmParserHandler(
+                rows=rows,
+                id_text=vrefs[0].book,
+                behavior=UpdateUsfmBehavior.STRIP_EXISTING,
+            )
+            stylesheet = src_settings.stylesheet if src_from_project else UsfmStylesheet("usfm.sty")
+            parse_usfm(usfm, handler, stylesheet, src_settings.versification if src_from_project else None)
+            usfm_out = handler.get_usfm(stylesheet)
 
-                if usfm_out is None:
-                    raise FileNotFoundError(f"Book {src_file_text.id} does not exist in target project {trg_project}")
-            else:  # Slightly more manual version for updating an individual file
-                with open(src_file_path, encoding="utf-8-sig") as f:
-                    usfm = f.read()
-                handler = UpdateUsfmParserHandler(
-                    rows=rows,
-                    id_text=vrefs[0].book,
-                    text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
-                    paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    embed_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    style_behavior=UpdateUsfmMarkerBehavior.STRIP,
-                    preserve_paragraph_styles=[],
-                )
-                parse_usfm(usfm, handler)
-                usfm_out = handler.get_usfm()
+            # NOTE: Above is a temporary use of the USFM updater,
+            # and below is the version compatible with the most current version of sil-machine/machine.py (1.6.2)
+
+            # if trg_project is not None or src_from_project:
+            #     dest_updater = FileParatextProjectTextUpdater(
+            #         get_project_dir(trg_project if trg_project is not None else src_file_path.parent.name)
+            #     )
+            #     usfm_out = dest_updater.update_usfm(
+            #         book_id=src_file_text.id,
+            #         rows=rows,
+            #         text_behavior=(
+            #             UpdateUsfmTextBehavior.PREFER_NEW
+            #             if trg_project is not None
+            #             else UpdateUsfmTextBehavior.STRIP_EXISTING
+            #         ),
+            #         paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         embed_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         style_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         preserve_paragraph_styles=[],
+            #     )
+
+            #     if usfm_out is None:
+            #         raise FileNotFoundError(f"Book {src_file_text.id} does not exist in target project {trg_project}")
+            # else:  # Slightly more manual version for updating an individual file
+            #     with open(src_file_path, encoding="utf-8-sig") as f:
+            #         usfm = f.read()
+            #     handler = UpdateUsfmParserHandler(
+            #         rows=rows,
+            #         id_text=vrefs[0].book,
+            #         text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
+            #         paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         embed_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         style_behavior=UpdateUsfmMarkerBehavior.STRIP,
+            #         preserve_paragraph_styles=[],
+            #     )
+            #     parse_usfm(usfm, handler)
+            #     usfm_out = handler.get_usfm()
 
             # Insert draft remark and write to output path
             description = f"project {src_file_text.project}" if src_from_project else f"file {src_file_path.name}"

--- a/silnlp/common/usfm_preservation.py
+++ b/silnlp/common/usfm_preservation.py
@@ -75,7 +75,7 @@ class UsfmPreserver:
                 sents.pop(i)
                 vrefs.pop(i)
 
-        self._para_embeds = reversed(para_embeds)
+        self._para_embeds = list(reversed(para_embeds))
         return sents, vrefs
 
     def _extract_markers(
@@ -145,16 +145,27 @@ class UsfmPreserver:
 
         # Construct rows for the USFM file
         embed_idx = 0
+        para_embed_idx = 0
         rows = []
+
+        # Add any paragraph-style embeds that come before the main sentences
+        while para_embed_idx < len(self._para_embeds) and self._para_embeds[para_embed_idx][0] == para_embed_idx:
+            rows.append(([self._para_embeds[para_embed_idx][1]], self._para_embeds[para_embed_idx][2]))
+            para_embed_idx += 1
+
         for i, (ref, translation, inserts) in enumerate(zip(self._vrefs, translations, to_insert)):
-            row_text = translation[: inserts[0][0]] if len(inserts) > 0 else translation
+            # row_text = translation[: inserts[0][0]] if len(inserts) > 0 else translation
+            row_texts = [translation[: inserts[0][0]]] if len(inserts) > 0 else [translation]
 
             for j, (insert_idx, is_para_marker, marker) in enumerate(inserts):
                 if is_para_marker:
-                    row_text += "\n"
+                    row_texts.append("")
 
-                row_text += (
-                    marker
+                # row_text += (
+                row_texts[-1] += (
+                    #     ("\n" if is_para_marker else "")
+                    #     + marker
+                    (marker if not is_para_marker else "")
                     + (
                         " "  # Extra space if inserting an end marker before a non-punctuation character
                         if "*" in marker and insert_idx < len(translation) and translation[insert_idx].isalpha()
@@ -167,19 +178,38 @@ class UsfmPreserver:
                     )
                 )
                 # Prevent spaces before end markers
-                if j + 1 < len(inserts) and "*" in inserts[j + 1][2] and len(row_text) > 0 and row_text[-1] == " ":
-                    row_text = row_text[:-1]
+                # if j + 1 < len(inserts) and "*" in inserts[j + 1][2] and len(row_text) > 0 and row_text[-1] == " ":
+                #     row_text = row_text[:-1]
+                if (
+                    j + 1 < len(inserts)
+                    and "*" in inserts[j + 1][2]
+                    and len(row_texts[-1]) > 0
+                    and row_texts[-1][-1] == " "
+                ):
+                    row_texts[-1] = row_texts[-1][:-1]
 
             # Append any transferred embeds that match the current ScriptureRef
             while embed_idx < len(self._char_embeds) and self._char_embeds[embed_idx][0] == i:
-                row_text += self._char_embeds[embed_idx][1]
+                # row_text += self._char_embeds[embed_idx][1]
+                row_texts[-1] += self._char_embeds[embed_idx][1]
                 embed_idx += 1
 
-            rows.append(([ref], row_text))
+            # rows.append(([ref], row_text))
+            for row_text in row_texts:
+                rows.append(([ref], row_text))
 
-        # Add transferred paragraph-type embeds
-        for sent_idx, ref, sent in self._para_embeds:
-            rows.insert(sent_idx, ([ref], sent))
+            # (sent_idx, ref, embed contents)
+            # sent_idx == orig idx, in order
+            while (
+                para_embed_idx < len(self._para_embeds)
+                and self._para_embeds[para_embed_idx][0] == i + 1 + para_embed_idx
+            ):
+                rows.append(([self._para_embeds[para_embed_idx][1]], self._para_embeds[para_embed_idx][2]))
+                para_embed_idx += 1
+
+        # # Add transferred paragraph-type embeds
+        # for sent_idx, ref, sent in self._para_embeds:
+        #     rows.insert(sent_idx, ([ref], sent))
 
         return rows
 
@@ -192,6 +222,9 @@ class UsfmPreserver:
     def _predict_marker_locations(
         self, adj_src_toks: List[int], trg_sents: List[str], trg_tok_ranges: List[List[Range[int]]]
     ) -> List[int]:
+        if len(adj_src_toks) == 0:
+            return []
+
         alignment_matrices: List[WordAlignmentMatrix] = self._get_alignment_matrices(trg_sents)
 
         # Gets the number of alignment pairs that "cross the line" between


### PR DESCRIPTION
This is the implementation of marker placement pre- any related updates to machine.py, but keeping as many improvements made to this code since then. The only obvious way that output USFM will be different is that all of the paragraph markers for a verse will be present, even when they are not being placed, as it was before any marker placement-related updates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/718)
<!-- Reviewable:end -->
