### PR TITLE
Replaced evaluation_strategy with eval_strategy

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -129,7 +129,7 @@ TRAINING_ARGS_CONFIG_MAPPING = {
         "eval_accumulation_steps",
         "eval_delay",
         "eval_steps",
-        "evaluation_strategy",
+        "eval_strategy",
         "greater_is_better",
         "include_inputs_for_metrics",
         "load_best_model_at_end",
@@ -326,7 +326,7 @@ class HuggingFaceConfig(Config):
                     "lora_config": {},
                 },
                 "eval": {
-                    "evaluation_strategy": "steps",
+                    "eval_strategy": "steps",
                     "eval_steps": 1000,
                     "early_stopping": None,
                     "load_best_model_at_end": True,
@@ -380,7 +380,7 @@ class HuggingFaceConfig(Config):
 
         # disable evaluation if there is no validation split
         if not self.has_val_split:
-            config["eval"]["evaluation_strategy"] = "no"
+            config["eval"]["eval_strategy"] = "no"
             config["eval"]["load_best_model_at_end"] = False
             config["eval"]["early_stopping"] = None
             config["eval"]["metric_for_best_model"] = None


### PR DESCRIPTION
This small PR renames the `evaluation_strategy` config option to `eval_strategy` to fix a warning mentioned in [this issue](https://github.com/sillsdev/silnlp/issues/670).

This will also prevent errors whenever SILNLP is updated to another version of Transformers.

Here is the warning:
`evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead.

If we do not want this to break existing configs, we could map `evaluation_strategy` to `eval_strategy` to allow both names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/741)
<!-- Reviewable:end -->
