### PR TITLE
Add extract_corpora to onboard_project

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -65,24 +65,40 @@ def main() -> None:
         project_path = SIL_NLP_ENV.pt_projects_dir / project
         if project_path.is_dir():
             projects_found.add(project)
+    extract_corpora(
+        projects=projects_found,
+        include=args.include,
+        exclude=args.exclude,
+        markers=args.markers,
+        lemmas=args.lemmas,
+        project_vrefs=args.project_vrefs,
+    )
+    # Tell the user which projects couldn't be found.
+    for project in projects:
+        if project not in projects_found:
+            LOGGER.warning(f"Couldn't find project {project} in {SIL_NLP_ENV.pt_projects_dir}.")
 
+
+def extract_corpora(
+    projects: Set[str], include=[], exclude=[], markers=False, lemmas=False, project_vrefs=False
+) -> None:
     # Process the projects that have data and tell the user.
-    if len(projects_found) > 0:
-        expected_verse_count = get_expected_verse_count(args.include, args.exclude)
+    if len(projects) > 0:
+        expected_verse_count = get_expected_verse_count(include, exclude)
         SIL_NLP_ENV.mt_scripture_dir.mkdir(exist_ok=True, parents=True)
         SIL_NLP_ENV.mt_terms_dir.mkdir(exist_ok=True, parents=True)
-        for project in projects_found:
+        for project in projects:
             LOGGER.info(f"Extracting {project}...")
             project_dir = get_project_dir(project)
             check_versification(project_dir)
             corpus_filename, verse_count = extract_project(
                 project_dir,
                 SIL_NLP_ENV.mt_scripture_dir,
-                args.include,
-                args.exclude,
-                args.markers,
-                args.lemmas,
-                args.project_vrefs,
+                include,
+                exclude,
+                markers,
+                lemmas,
+                project_vrefs,
             )
             # check if the number of lines in the file is correct (the same as vref.txt)
             LOGGER.info(f"# of Verses: {verse_count}")
@@ -93,11 +109,6 @@ def main() -> None:
             LOGGER.info("Done.")
     else:
         LOGGER.warning(f"Couldn't find any data to process for any project in {SIL_NLP_ENV.pt_projects_dir}.")
-
-    # Tell the user which projects couldn't be found.
-    for project in projects:
-        if project not in projects_found:
-            LOGGER.warning(f"Couldn't find project {project} in {SIL_NLP_ENV.pt_projects_dir}.")
 
 
 if __name__ == "__main__":

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -67,11 +67,11 @@ def main() -> None:
             projects_found.add(project)
     extract_corpora(
         projects=projects_found,
-        include=args.include,
-        exclude=args.exclude,
-        markers=args.markers,
-        lemmas=args.lemmas,
-        project_vrefs=args.project_vrefs,
+        books_to_include=args.include,
+        books_to_exclude=args.exclude,
+        include_markers=args.markers,
+        extract_lemmas=args.lemmas,
+        extract_project_vrefs=args.project_vrefs,
     )
     # Tell the user which projects couldn't be found.
     for project in projects:
@@ -80,11 +80,16 @@ def main() -> None:
 
 
 def extract_corpora(
-    projects: Set[str], include=[], exclude=[], markers=False, lemmas=False, project_vrefs=False
+    projects: Set[str],
+    books_to_include=[],
+    books_to_exclude=[],
+    include_markers=False,
+    extract_lemmas=False,
+    extract_project_vrefs=False,
 ) -> None:
     # Process the projects that have data and tell the user.
     if len(projects) > 0:
-        expected_verse_count = get_expected_verse_count(include, exclude)
+        expected_verse_count = get_expected_verse_count(books_to_include, books_to_exclude)
         SIL_NLP_ENV.mt_scripture_dir.mkdir(exist_ok=True, parents=True)
         SIL_NLP_ENV.mt_terms_dir.mkdir(exist_ok=True, parents=True)
         for project in projects:
@@ -94,11 +99,11 @@ def extract_corpora(
             corpus_filename, verse_count = extract_project(
                 project_dir,
                 SIL_NLP_ENV.mt_scripture_dir,
-                include,
-                exclude,
-                markers,
-                lemmas,
-                project_vrefs,
+                books_to_include,
+                books_to_exclude,
+                include_markers,
+                extract_lemmas,
+                extract_project_vrefs,
             )
             # check if the number of lines in the file is correct (the same as vref.txt)
             LOGGER.info(f"# of Verses: {verse_count}")

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -71,6 +71,41 @@ def main() -> None:
     parser.add_argument(
         "--overwrite", help="Overwrite any existing files and folders", default=False, action="store_true"
     )
+    parser.add_argument(
+        "--extract-corpora",
+        help="Extract text corpora.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--include",
+        metavar="books",
+        nargs="+",
+        default=[],
+        help="The books to include; e.g., 'NT', 'OT', 'GEN'. Only used with extract-corpora.",
+    )
+    parser.add_argument(
+        "--exclude",
+        metavar="books",
+        nargs="+",
+        default=[],
+        help="The books to exclude; e.g., 'NT', 'OT', 'GEN'. Only used with extract-corpora.",
+    )
+    parser.add_argument(
+        "--markers", default=False, action="store_true", help="Include USFM markers. Only used with extract-corpora."
+    )
+    parser.add_argument(
+        "--lemmas",
+        default=False,
+        action="store_true",
+        help="Extract lemmas if available. Only used with extract-corpora.",
+    )
+    parser.add_argument(
+        "--project-vrefs",
+        default=False,
+        action="store_true",
+        help="Extract project verse refs. Only used with extract-corpora.",
+    )
 
     args = parser.parse_args()
     project_name = args.project
@@ -80,6 +115,18 @@ def main() -> None:
 
     if args.copy_from:
         copy_paratext_project_folder(Path(args.copy_from), paratext_project_dir, overwrite=args.overwrite)
+
+    if args.extract_corpora:
+        from .extract_corpora import extract_corpora
+
+        extract_corpora(
+            projects={project_name},
+            include=args.include,
+            exclude=args.exclude,
+            markers=args.markers,
+            lemmas=args.lemmas,
+            project_vrefs=args.project_vrefs,
+        )
 
 
 if __name__ == "__main__":

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -121,11 +121,11 @@ def main() -> None:
 
         extract_corpora(
             projects={project_name},
-            include=args.include,
-            exclude=args.exclude,
-            markers=args.markers,
-            lemmas=args.lemmas,
-            project_vrefs=args.project_vrefs,
+            books_to_include=args.include,
+            books_to_exclude=args.exclude,
+            include_markers=args.markers,
+            extract_lemmas=args.lemmas,
+            extract_project_vrefs=args.project_vrefs,
         )
 
 


### PR DESCRIPTION
This PR adds the following args to `onboard_project` and refactors `extract_corpora` to allow `onboard_project` to call `extract_corpora`:

- `--extract-corpora`
- `--include`
- `--exclude`
- `--markers`
- `--lemmas`
- `--project-vrefs`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/754)
<!-- Reviewable:end -->
