### PR TITLE
Guess book id when translating isolated USFM files

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -178,7 +178,11 @@ class Translator(ABC):
                 project=src_settings.name,
             )
         else:
-            src_file_text = UsfmFileText("usfm.sty", "utf-8-sig", "", src_file_path, include_all_text=True)
+            # Guess book ID
+            with src_file_path.open(encoding="utf-8-sig") as f:
+                book_id = f.read().split()[1].upper()
+
+            src_file_text = UsfmFileText("usfm.sty", "utf-8-sig", book_id, src_file_path, include_all_text=True)
         stylesheet = src_settings.stylesheet if src_from_project else UsfmStylesheet("usfm.sty")
 
         sentences = [re.sub(" +", " ", s.text.strip()) for s in src_file_text]

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -131,9 +131,7 @@ class TranslationTask:
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
     ) -> None:
-        translator, config, _ = self._init_translation_task(
-            experiment_suffix=f"_{self.checkpoint}_{src_prefix}", patterns=[src_prefix, trg_prefix]
-        )
+        translator, config, _ = self._init_translation_task(experiment_suffix=f"_{self.checkpoint}_{src_prefix}")
         if trg_prefix is None:
             raise RuntimeError("A target file prefix must be specified.")
         if start_seq is None or end_seq is None:
@@ -178,8 +176,7 @@ class TranslationTask:
         postprocess_handler: PostprocessHandler = PostprocessHandler(),
     ) -> None:
         translator, config, step_str = self._init_translation_task(
-            experiment_suffix=f"_{self.checkpoint}_{os.path.basename(src)}",
-            patterns=[src, trg] if trg is not None else [src],
+            experiment_suffix=f"_{self.checkpoint}_{os.path.basename(src)}"
         )
 
         if src_iso is None:


### PR DESCRIPTION
This was a leftover issue from when we switched to using the machine USFM parser. I say it's a guess because we're not extracting the book ID from the file name and I don't know if there's an explicit requirement for the \id line to start with the 3-character book code, but I think in reality they all do.

This also fixes an issue I ran into while testing, the "patterns" arguments are just left over from the days of non-mounted buckets.