### PR TITLE
add encoding to diff predictions when opening confidence file

### DIFF
--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -557,7 +557,7 @@ def add_scores(df: pd.DataFrame, scorers: List[str], preserve_case: bool, tokeni
 
 def get_sequence_confidences(confidences_file: Path) -> List[float]:
     confidences = []
-    with open(confidences_file, "r") as f:
+    with open(confidences_file, "r", encoding="utf-8") as f:
         lines = f.readlines()
         for i in range(3, len(lines), 2):
             confidences.append(float(lines[i].split("\t")[0]))


### PR DESCRIPTION
This patches a bug where a UnicodeDecodeError was occurring because the encoding was not specified when opening the file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/770)
<!-- Reviewable:end -->
