### PR TITLE
Removed mentions of the cache from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,8 @@ These are the main requirements for the SILNLP code to run on a local machine. S
    * Note that this does not give you direct access to a MinIO or B2 bucket from within the Docker container, it only allows you to run scripts referencing files in the bucket.
    * For instructions on how to permanently set up environment variables for your operating system, see the corresponding section under the Development Environment Setup header below.
 
-11. If using MinIO or B2, there are two options:
-   * Option 1: Mount the bucket to your filesystem following the instructions under [Install and Configure Rclone](https://github.com/sillsdev/silnlp/blob/master/bucket_setup.md#install-and-configure-rclone).
-   * Option 2: Create a local cache for the bucket following the instructions under [Create SILNLP cache](https://github.com/sillsdev/silnlp/blob/master/manual_setup.md#create-silnlp-cache).
+11. If using MinIO or B2, you will need to set up rclone:
+   * Mount the bucket to your filesystem following the instructions under [Install and Configure Rclone](https://github.com/sillsdev/silnlp/blob/master/bucket_setup.md#install-and-configure-rclone).
 
 ## Development Environment Setup
 

--- a/manual_setup.md
+++ b/manual_setup.md
@@ -81,12 +81,6 @@ See [Bucket setup](bucket_setup.md).
 
 See [ClearML setup](clear_ml_setup.md).
 
-### Create SILNLP cache
-* Home directory ($HOME) on windows is usually C:\Users\<Username>\; on linux it is /home/username; and on macOS it is /Users/<Username>/. In your home directory, create the following directories.
-* Create the directory "$HOME/.cache/silnlp"
-* Create the directory "$HOME/.cache/silnlp/experiments" and set the environment variable SIL_NLP_CACHE_EXPERIMENT_DIR to that path.
-* Create the directory "$HOME/.cache/silnlp/projects" and set the environment variable SIL_NLP_CACHE_PROJECT_DIR to that path.
-
 ### Additional Environment Variables
 * Set the following environment variables with your respective credentials: CLEARML_API_ACCESS_KEY, CLEARML_API_SECRET_KEY, MINIO_ACCESS_KEY, MINIO_SECRET_KEY B2_KEY_ID, B2_APPLICATION_KEY.
 * Set SIL_NLP_DATA_PATH to "/silnlp" if you are not using MinIO or B2 and will be storing files locally.


### PR DESCRIPTION
This PR removes old mentions of the silnlp cache from the README instructions, since the cache was removed entirely in this [PR](https://github.com/sillsdev/silnlp/pull/730).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/773)
<!-- Reviewable:end -->
