### PR TITLE
Refactor for metadata approach to update block handlers, add end-of-verse option for paragraph markers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5159,13 +5159,13 @@ type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12
 
 [[package]]
 name = "sil-machine"
-version = "1.7.3"
+version = "1.7.4"
 description = "A natural language processing library that is focused on providing tools for resource-poor languages."
 optional = false
 python-versions = "<3.13,>=3.9"
 files = [
-    {file = "sil_machine-1.7.3-py3-none-any.whl", hash = "sha256:f53e11a38e30ba52c57399466d83765fbb6a4b69bfce1ee13f53107d859b7c29"},
-    {file = "sil_machine-1.7.3.tar.gz", hash = "sha256:272f7c89ed49d166d44a68092afb72049a78c2ec0bbdde324734d2c2fcf8cb6e"},
+    {file = "sil_machine-1.7.4-py3-none-any.whl", hash = "sha256:88363b4160af1bb24b1fd523839002975f9c0e2635c3ca73363b55ec3f2d9023"},
+    {file = "sil_machine-1.7.4.tar.gz", hash = "sha256:16ba024ae7f3fe5c0e140e3f95dad56f29ac9300741f338f0a297edddc28fde4"},
 ]
 
 [package.dependencies]
@@ -6177,4 +6177,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "63c6e3d81fa851530a7bf2e99edda02868764bb495649f3f8451d23270c82fc5"
+content-hash = "07fb940926cfc8ba2957349240f76a80123adaeab5c3711205da614be3410dc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tqdm = "^4.62.2"
 sacrebleu = "^2.3.1"
 ctranslate2 = "^3.5.1"
 libclang = "14.0.6"
-sil-machine = {extras = ["thot"], version = "1.7.3"}
+sil-machine = {extras = ["thot"], version = "1.7.4"}
 datasets = "^2.7.1"
 torch = {version = "^2.4", source = "torch"}
 sacremoses = "^0.0.53"

--- a/silnlp/common/postprocess_draft.py
+++ b/silnlp/common/postprocess_draft.py
@@ -47,10 +47,9 @@ def main() -> None:
         help="Output folder for the postprocessed draft. Defaults to the folder of the original draft.",
     )
     parser.add_argument(
-        "--include-paragraph-markers",
-        default=False,
-        action="store_true",
-        help="Attempt to place paragraph markers in translated verses based on the source project's markers",
+        "--paragraph-behavior",
+        default="end",
+        help="Behavior of paragraph markers for files in USFM format, possible values are 'end', 'place', and 'strip'",
     )
     parser.add_argument(
         "--include-style-markers",

--- a/silnlp/nmt/postprocess.py
+++ b/silnlp/nmt/postprocess.py
@@ -132,15 +132,14 @@ def postprocess_draft(
             )
             return
 
-    postprocess_handler.create_update_block_handlers(src_refs, src_sents, draft_sents)
+    postprocess_handler.construct_rows(src_refs, src_sents, draft_sents)
 
     with src_path.open(encoding=encoding) as f:
         usfm = f.read()
-    rows = [([ref], sent) for ref, sent in zip(src_refs, draft_sents)]
 
     for config in postprocess_handler.configs:
         handler = UpdateUsfmParserHandler(
-            rows=rows,
+            rows=config.rows,
             id_text=book,
             text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
             paragraph_behavior=config.get_paragraph_behavior(),

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -319,10 +319,9 @@ def main() -> None:
         help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
     )
     parser.add_argument(
-        "--include-paragraph-markers",
-        default=False,
-        action="store_true",
-        help="For files in USFM format, attempt to place paragraph markers in translated verses based on the source project's markers",
+        "--paragraph-behavior",
+        default="end",
+        help="Behavior of paragraph markers for files in USFM format, possible values are 'end', 'place', and 'strip'",
     )
     parser.add_argument(
         "--include-style-markers",
@@ -349,6 +348,12 @@ def main() -> None:
         help="Deprecated argument, equivalent to --include-paragraph-markers AND --include-style-markers",
     )
     parser.add_argument(
+        "--include-paragraph-markers",
+        default=False,
+        action="store_true",
+        help="For files in USFM format, attempt to place paragraph markers in translated verses based on the source project's markers",
+    )
+    parser.add_argument(
         "--clearml-queue",
         default=None,
         type=str,
@@ -373,9 +378,12 @@ def main() -> None:
         name=args.experiment, checkpoint=args.checkpoint, clearml_queue=args.clearml_queue, commit=args.commit
     )
 
+    # Get postprocessing options and do backwards-compatiblity adjustments
     postprocess_config = extract_postprocess_options_from_dict(vars(args))
+    if args.include_paragraph_markers:
+        postprocess_config["paragraph_behavior"] = "place"
     if args.preserve_usfm_markers:
-        postprocess_config["include_paragraph_markers"] = True
+        postprocess_config["paragraph_behavior"] = "place"
         postprocess_config["include_style_markers"] = True
     if args.include_inline_elements:
         postprocess_config["include_embeds"] = True


### PR DESCRIPTION
Added a new command line option `--paragraph-behavior` that takes a string argument with possible values "end" (default), "place", or "strip". I kept the old `--include_paragraph_markers` option and mapped it to `--paragraph-behavior place`.

Closes #764