### PR TITLE
#779 confidence

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -166,7 +166,7 @@ class Translator(ABC):
         src_iso: str,
         trg_iso: str,
         produce_multiple_translations: bool = False,
-        save_confidences: bool = True,
+        save_confidences: bool = False,
         chapters: List[int] = [],
         trg_project: Optional[str] = None,
         postprocess_handler: PostprocessHandler = PostprocessHandler(),
@@ -323,7 +323,7 @@ class Translator(ABC):
                         continue
                     vref_confidence = exp(output[sentence_num][3][draft_index - 1])
                     if vref.chapter_num not in chapter_confidences:
-                        chapter_confidences[vref.chapter_num] = [vref_confidence]
+                        chapter_confidences[vref.chapter_num] = []
                     chapter_confidences[vref.chapter_num].append(vref_confidence)
 
                 all_verse_confidences: List[float] = []

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -123,7 +123,10 @@ def generate_confidence_files(
 
             file_confidences_path = trg_file_path.parent / "confidences.books.tsv"
             row1_col1_header = "Book"
-            col1_entry = vrefs[0].book
+            if vrefs:
+                col1_entry = vrefs[0].book
+            else:
+                col1_entry = trg_file_path.stem
         elif ext == ".txt":
             file_confidences_path = trg_file_path.parent / f"{trg_prefix}confidences.files.tsv"
             row1_col1_header = "File"
@@ -131,7 +134,7 @@ def generate_confidence_files(
         else:
             raise ValueError(
                 f"Invalid trg file extension {ext} when using --save-confidences in the translate step."
-                f"Valid file extensions for --save-confidence are .usfm, .sfm, and .txt."
+                f"Valid file extensions for --save-confidences are .usfm, .sfm, and .txt."
             )
         with (file_confidences_path).open("a", encoding="utf-8", newline="\n") as file_confidences_file:
             if file_confidences_file.tell() == 0:

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -136,7 +136,7 @@ def generate_confidence_files(
                 f"Invalid trg file extension {ext} when using --save-confidences in the translate step."
                 f"Valid file extensions for --save-confidences are .usfm, .sfm, and .txt."
             )
-        with (file_confidences_path).open("a", encoding="utf-8", newline="\n") as file_confidences_file:
+        with file_confidences_path.open("a", encoding="utf-8", newline="\n") as file_confidences_file:
             if file_confidences_file.tell() == 0:
                 file_confidences_file.write(f"{row1_col1_header}\tConfidence\n")
             file_confidences_file.write(f"{col1_entry}\t{gmean(sequence_confidences)}\n")

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -6,7 +6,7 @@ from datetime import date
 from itertools import groupby
 from math import exp
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import DefaultDict, Iterable, List, Optional
 
 import docx
 import nltk
@@ -70,7 +70,7 @@ def generate_confidence_files(
     translate_step: bool = False,
     trg_prefix: str = "",
     produce_multiple_translations: bool = False,
-    draft_index: Optional[int] = None,
+    draft_index: int = 0,
     vrefs: Optional[List[VerseRef]] = None,
 ) -> None:
     if produce_multiple_translations:
@@ -105,7 +105,7 @@ def generate_confidence_files(
             )
     if translate_step:
         if ext in {".usfm", ".sfm"}:
-            chapter_confidences: defaultdict[str, List[float]] = defaultdict(list)
+            chapter_confidences: DefaultDict[int, List[float]] = defaultdict(list)
             for sentence_num, vref in enumerate(vrefs):
                 if not vref.is_verse or output[sentence_num][0] is None:
                     continue

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -82,6 +82,7 @@ class Translator(ABC):
         trg_iso: str,
         produce_multiple_translations: bool = False,
         save_confidences: bool = False,
+        trg_prefix: str = "",
     ) -> None:
         output = list(self.translate(load_corpus(src_file_path), src_iso, trg_iso, produce_multiple_translations))
         translations = [translation for translation, _, _, _ in output]
@@ -119,12 +120,12 @@ class Translator(ABC):
                             )
                             + "\n"
                         )
-                with (trg_file_path.parent / "confidences.files.tsv").open(
+                with (trg_file_path.parent / f"{trg_prefix}confidences.files.tsv").open(
                     "a", encoding="utf-8", newline="\n"
                 ) as file_confidences_file:
                     if file_confidences_file.tell() == 0:
                         file_confidences_file.write("File\tConfidence\n")
-                    file_confidences_file.write(f"{str(trg_file_path)}\t{gmean(sequence_confidences)}\n")
+                    file_confidences_file.write(f"{trg_file_path.name}\t{gmean(sequence_confidences)}\n")
 
     def translate_book(
         self,

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -317,7 +317,7 @@ class Translator(ABC):
                             + "\n"
                         )
 
-                chapter_confidences: Dict[str, float] = {}
+                chapter_confidences: Dict[str, List[float]] = {}
                 for sentence_num, vref in enumerate(vrefs):
                     if not vref.is_verse or output[sentence_num][0] is None:
                         continue

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -321,6 +321,7 @@ class NMTModel(ABC):
         input_paths: List[Path],
         translation_paths: List[Path],
         produce_multiple_translations: bool = False,
+        save_confidences: bool = False,
         vref_paths: Optional[List[Path]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
     ) -> None: ...

--- a/silnlp/nmt/diff_predictions.py
+++ b/silnlp/nmt/diff_predictions.py
@@ -557,10 +557,17 @@ def add_scores(df: pd.DataFrame, scorers: List[str], preserve_case: bool, tokeni
 
 def get_sequence_confidences(confidences_file: Path) -> List[float]:
     confidences = []
-    with open(confidences_file, "r", encoding="utf-8") as f:
-        lines = f.readlines()
-        for i in range(3, len(lines), 2):
-            confidences.append(float(lines[i].split("\t")[0]))
+    try:
+        with open(confidences_file, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+            for i in range(3, len(lines), 2):
+                confidences.append(float(lines[i].split("\t")[0]))
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            "Cannot include confidence because the confidences file is missing. Include the --save-confidences "
+            "option when running test.py to generate the file and enable confidence scoring."
+        ) from e
+
     return confidences
 
 

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -182,7 +182,7 @@ def main() -> None:
         nargs="*",
         metavar="scorer",
         choices=_SUPPORTED_SCORERS,
-        default=["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu", "confidence"],
+        default=["bleu", "sentencebleu", "chrf3", "chrf3+", "chrf3++", "spbleu"],
         help=f"List of scorers - {_SUPPORTED_SCORERS}",
     )
 
@@ -213,7 +213,7 @@ def main() -> None:
         run_test=args.test,
         run_translate=args.translate,
         produce_multiple_translations=args.multiple_translations,
-        confidence=args.confidence,
+        save_confidences=args.save_confidences,
         scorers=set(s.lower() for s in args.scorers),
         score_by_book=args.score_by_book,
         commit=args.commit,

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -164,7 +164,7 @@ def main() -> None:
         "--save-confidences",
         default=False,
         action="store_true",
-        help="Create files for verse, chapter, book confidence.",
+        help="Generate confidence files for test and/or translate step.",
     )
     parser.add_argument("--score-by-book", default=False, action="store_true", help="Score individual books")
     parser.add_argument("--mt-dir", default=None, type=str, help="The machine translation directory.")

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -29,6 +29,7 @@ class SILExperiment:
     run_test: bool = False
     run_translate: bool = False
     produce_multiple_translations: bool = False
+    save_confidences: bool = False
     scorers: Set[str] = field(default_factory=set)
     score_by_book: bool = False
     commit: Optional[str] = None
@@ -76,6 +77,7 @@ class SILExperiment:
             by_book=self.score_by_book,
             scorers=self.scorers,
             produce_multiple_translations=self.produce_multiple_translations,
+            save_confidences=self.save_confidences,
         )
 
     def translate(self):
@@ -103,6 +105,7 @@ class SILExperiment:
                     config.get("trg_project"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
+                    self.save_confidences,
                     postprocess_handler,
                 )
             elif config.get("src_prefix"):
@@ -114,6 +117,7 @@ class SILExperiment:
                     config.get("src_iso"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
+                    self.save_confidences,
                 )
             elif config.get("src"):
                 translator.translate_files(
@@ -122,6 +126,7 @@ class SILExperiment:
                     config.get("src_iso"),
                     config.get("trg_iso"),
                     self.produce_multiple_translations,
+                    self.save_confidences,
                     postprocess_handler,
                 )
             else:
@@ -154,6 +159,12 @@ def main() -> None:
         default=False,
         action="store_true",
         help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
+    )
+    parser.add_argument(
+        "--save-confidences",
+        default=False,
+        action="store_true",
+        help="Create files for verse, chapter, book confidence.",
     )
     parser.add_argument("--score-by-book", default=False, action="store_true", help="Score individual books")
     parser.add_argument("--mt-dir", default=None, type=str, help="The machine translation directory.")
@@ -202,6 +213,7 @@ def main() -> None:
         run_test=args.test,
         run_translate=args.translate,
         produce_multiple_translations=args.multiple_translations,
+        confidence=args.confidence,
         scorers=set(s.lower() for s in args.scorers),
         score_by_book=args.score_by_book,
         commit=args.commit,

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -71,8 +71,11 @@ class PairScore:
                 f",{self.bleu.precisions[2]:.2f},{self.bleu.precisions[3]:.2f},{self.bleu.bp:.3f}"
                 f",{self.bleu.sys_len:d},{self.bleu.ref_len:d}"
             )
-        for val in self.other_scores.values():
-            file.write(f",{val:.2f}")
+        for scorer, val in self.other_scores.items():
+            if scorer == "confidence":
+                file.write(f",{val:.8f}")
+            else:
+                file.write(f",{val:.2f}")
         file.write("\n")
 
 

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -391,6 +391,7 @@ def test_checkpoint(
     scorers: Set[str],
     books: Dict[int, List[int]],
     produce_multiple_translations: bool = False,
+    save_confidences: bool = False,
 ) -> List[PairScore]:
     config.set_seed()
     vref_file_names: List[str] = []
@@ -447,6 +448,7 @@ def test_checkpoint(
             source_paths,
             translation_paths,
             produce_multiple_translations,
+            save_confidences,
             vref_paths,
             step if checkpoint_type is CheckpointType.OTHER else checkpoint_type,
         )
@@ -580,6 +582,7 @@ def test(
     books: List[str] = [],
     by_book: bool = False,
     produce_multiple_translations: bool = False,
+    save_confidences: bool = False,
 ):
     exp_name = experiment
     config = load_config(exp_name)
@@ -612,6 +615,7 @@ def test(
             scorers,
             books_nums,
             produce_multiple_translations,
+            save_confidences,
         )
 
     if avg:
@@ -629,6 +633,7 @@ def test(
                 scorers,
                 books_nums,
                 produce_multiple_translations,
+                save_confidences,
             )
         except ValueError:
             LOGGER.warn("No average checkpoint available.")
@@ -650,6 +655,7 @@ def test(
                 scorers,
                 books_nums,
                 produce_multiple_translations,
+                save_confidences,
             )
 
     if last or (not best and checkpoint is None and not avg and config.model_dir.exists()):
@@ -667,6 +673,7 @@ def test(
                 scorers,
                 books_nums,
                 produce_multiple_translations,
+                save_confidences,
             )
 
     if not config.model_dir.exists():
@@ -682,6 +689,7 @@ def test(
             scorers,
             books_nums,
             produce_multiple_translations,
+            save_confidences,
         )
 
     for step in sorted(results.keys()):
@@ -743,6 +751,12 @@ def main() -> None:
         action="store_true",
         help="Produce multiple translations of each verse.",
     )
+    parser.add_argument(
+        "--save-confidences",
+        default=False,
+        action="store_true",
+        help="Create files for verse, chapter, book confidence.",
+    )
     args = parser.parse_args()
 
     get_git_revision_hash()
@@ -764,6 +778,7 @@ def main() -> None:
         books=books,
         by_book=args.by_book,
         produce_multiple_translations=args.multiple_translations,
+        save_confidences=args.save_confidences,
     )
 
 

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -148,8 +148,14 @@ def score_pair(
         if pair_confs is not None:
             confidences = pair_confs
         else:
-            with open(config.exp_dir / predictions_conf_file_name, "r", encoding="utf-8") as f:
-                confidences = [float(line.split("\t")[0]) for line in list(f)[3::2]]
+            try:
+                with open(config.exp_dir / predictions_conf_file_name, "r", encoding="utf-8") as f:
+                    confidences = [float(line.split("\t")[0]) for line in list(f)[3::2]]
+            except FileNotFoundError as e:
+                raise FileNotFoundError(
+                    "Cannot use confidence as a scorer because the confidences file is missing. "
+                    "Include the --save-confidences option to generate the file and enable confidence scoring."
+                ) from e
         other_scores["confidence"] = gmean(confidences)
 
     return PairScore(book, src_iso, trg_iso, bleu_score, len(pair_sys), ref_projects, other_scores, draft_index)

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -761,7 +761,7 @@ def main() -> None:
         "--save-confidences",
         default=False,
         action="store_true",
-        help="Create files for verse, chapter, book confidence.",
+        help="Generate file with verse confidences.",
     )
     args = parser.parse_args()
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -337,7 +337,8 @@ def main() -> None:
         "--save-confidences",
         default=False,
         action="store_true",
-        help="Create files for verse, chapter, book confidence.",
+        help="Generate files for verse, chapter, and book confidences if translating from .usfm or .sfm files. "
+        "Or generate them for sequence and trg file confidences if translating from .txt files.",
     )
     parser.add_argument(
         "--paragraph-behavior",

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -55,6 +55,7 @@ class TranslationTask:
         trg_project: Optional[str],
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
+        save_confidences: bool = False,
         postprocess_handler: PostprocessHandler = PostprocessHandler(),
     ):
         book_nums = get_chapters(books)
@@ -109,6 +110,7 @@ class TranslationTask:
                     output_path,
                     trg_iso,
                     produce_multiple_translations,
+                    save_confidences,
                     chapters,
                     trg_project,
                     postprocess_handler,
@@ -130,6 +132,7 @@ class TranslationTask:
         src_iso: Optional[str],
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
+        save_confidences: bool = False,
     ) -> None:
         translator, config, _ = self._init_translation_task(experiment_suffix=f"_{self.checkpoint}_{src_prefix}")
         if trg_prefix is None:
@@ -162,7 +165,9 @@ class TranslationTask:
 
             if src_file_path.is_file() and not trg_file_path.is_file():
                 start = time.time()
-                translator.translate_text(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
+                translator.translate_text(
+                    src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations, save_confidences
+                )
                 end = time.time()
                 print(f"Translated {src_file_path.name} to {trg_file_path.name} in {((end-start)/60):.2f} minutes")
 
@@ -173,6 +178,7 @@ class TranslationTask:
         src_iso: Optional[str],
         trg_iso: Optional[str],
         produce_multiple_translations: bool = False,
+        save_confidences: bool = False,
         postprocess_handler: PostprocessHandler = PostprocessHandler(),
     ) -> None:
         translator, config, step_str = self._init_translation_task(
@@ -227,7 +233,9 @@ class TranslationTask:
             ext = src_file_path.suffix.lower()
             LOGGER.info(f"Translating {src_name}")
             if ext == ".txt":
-                translator.translate_text(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
+                translator.translate_text(
+                    src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations, save_confidences
+                )
             elif ext == ".docx":
                 translator.translate_docx(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
             elif ext == ".usfm" or ext == ".sfm":
@@ -240,6 +248,7 @@ class TranslationTask:
                     src_iso,
                     trg_iso,
                     produce_multiple_translations,
+                    save_confidences,
                     postprocess_handler=postprocess_handler,
                     experiment_ckpt_str=experiment_ckpt_str,
                 )
@@ -319,6 +328,12 @@ def main() -> None:
         help='Produce multiple translations of each verse. These will be saved in separate files with suffixes like ".1.txt", ".2.txt", etc.',
     )
     parser.add_argument(
+        "--save-confidences",
+        default=False,
+        action="store_true",
+        help="Create files for verse, chapter, book confidence.",
+    )
+    parser.add_argument(
         "--paragraph-behavior",
         default="end",
         help="Behavior of paragraph markers for files in USFM format, possible values are 'end', 'place', and 'strip'",
@@ -390,6 +405,7 @@ def main() -> None:
             args.trg_project,
             args.trg_iso,
             args.multiple_translations,
+            args.save_confidences,
             postprocess_handler,
         )
     elif args.src_prefix is not None:
@@ -407,6 +423,7 @@ def main() -> None:
             args.src_iso,
             args.trg_iso,
             args.multiple_translations,
+            args.save_confidences,
         )
     elif args.src is not None:
         if args.debug:
@@ -416,7 +433,13 @@ def main() -> None:
             )
             exit()
         translator.translate_files(
-            args.src, args.trg, args.src_iso, args.trg_iso, args.multiple_translations, postprocess_handler
+            args.src,
+            args.trg,
+            args.src_iso,
+            args.trg_iso,
+            args.multiple_translations,
+            args.save_confidences,
+            postprocess_handler,
         )
     else:
         raise RuntimeError("A Scripture book, file, or file prefix must be specified.")

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -166,7 +166,13 @@ class TranslationTask:
             if src_file_path.is_file() and not trg_file_path.is_file():
                 start = time.time()
                 translator.translate_text(
-                    src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations, save_confidences
+                    src_file_path,
+                    trg_file_path,
+                    src_iso,
+                    trg_iso,
+                    produce_multiple_translations,
+                    save_confidences,
+                    trg_prefix,
                 )
                 end = time.time()
                 print(f"Translated {src_file_path.name} to {trg_file_path.name} in {((end-start)/60):.2f} minutes")


### PR DESCRIPTION
This PR addresses #779, adding necessary features for the use of confidence metrics during the translation step. In particular, this adds the ability to generate chapter and book level confidence scores during translation, as well as a flag that enables all the confidence logic for test.py, translate.py, and experiment.py.

I tested with and without including the --save-confidences flag for test.py, translate.py, and experiment.py, ensuring that everything runs without error. I also tested that the confidence logic works for both .SFM and .txt files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/781)
<!-- Reviewable:end -->
