### PR TITLE
Combine scores

### DIFF
--- a/silnlp/common/combine_scores.py
+++ b/silnlp/common/combine_scores.py
@@ -156,7 +156,7 @@ def write_to_excel(data_by_header, folder, output_filename):
         sheet_names = []
         for i, (header, rows) in enumerate(data_by_header.items()):
             # Filter and sort rows for Excel
-            filtered_rows = filter_excel_rows(rows[0], rows[1:])
+            filtered_rows = delete_rows(rows[0], rows[1:])
             sorted_rows = sort_rows_by_chrf3pp(rows[0], filtered_rows)
             # If no data rows remain, add a dummy row (all empty) to avoid openpyxl error
             if not sorted_rows:


### PR DESCRIPTION
Improvements to combine_scores.py:
Add folder name as part of the output file names - some apps prevent opening files with the same name, so this helps avoid that. It's also helpful to see which set of results are in the file.
Hide some columns in the Excel output, and auto-size visible columns.
Fix the FutureWarning caused by df = df.apply(pd.to_numeric, errors="ignore"), now that errors="ignore" is deprecated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/786)
<!-- Reviewable:end -->
