### PR TITLE
Add quality estimation module

### DIFF
--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -23,14 +23,12 @@ class VerseScore:
     projected_chrf3: Optional[float] = None
 
 
-def estimate_quality(diff_predictions_file: Path, confidence_files: List[Path]):
-    verse_scores: List[VerseScore] = []
-    for confidence_file in confidence_files:
-        verse_scores += project_chrf3(diff_predictions_file, confidence_file)
+def estimate_quality(diff_predictions_file: Path, confidence_files: List[Path]) -> None:
+    verse_scores: List[VerseScore] = project_chrf3(diff_predictions_file, confidence_files)
     compute_usable_proportions(verse_scores, confidence_files[0].parent)
 
 
-def project_chrf3(diff_predictions_file: Path, confidence_file: Path) -> List[VerseScore]:
+def project_chrf3(diff_predictions_file: Path, confidence_files: List[Path]) -> List[VerseScore]:
     chrf3_scores, confidence_scores = extract_diff_predictions(diff_predictions_file)
     if len(chrf3_scores) != len(confidence_scores):
         raise ValueError(
@@ -38,13 +36,16 @@ def project_chrf3(diff_predictions_file: Path, confidence_file: Path) -> List[Ve
             f"in {diff_predictions_file} do not match."
         )
     slope, intercept = linregress(confidence_scores, chrf3_scores)[:2]
-    verse_scores = extract_confidences(confidence_file)
-    with open(confidence_file.with_suffix(".projected_chrf3.tsv"), "w", encoding="utf-8") as output_file:
-        output_file.write("VRef\tConfidence\tProjected chrF3\n")
-        for verse_score in verse_scores:
-            projected_chrf3 = slope * verse_score.confidence + intercept
-            verse_score.projected_chrf3 = projected_chrf3
-            output_file.write(f"{verse_score.vref}\t{verse_score.confidence}\t{projected_chrf3:.2f}\n")
+    verse_scores: List[VerseScore] = []
+    for confidence_file in confidence_files:
+        file_scores = extract_confidences(confidence_file)
+        verse_scores += file_scores
+        with open(confidence_file.with_suffix(".projected_chrf3.tsv"), "w", encoding="utf-8") as output_file:
+            output_file.write("VRef\tConfidence\tProjected chrF3\n")
+            for verse_score in verse_scores:
+                projected_chrf3 = slope * verse_score.confidence + intercept
+                verse_score.projected_chrf3 = projected_chrf3
+                output_file.write(f"{verse_score.vref}\t{verse_score.confidence}\t{projected_chrf3:.2f}\n")
     return verse_scores
 
 
@@ -194,27 +195,31 @@ def calculate_usable_prob(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Estimate the quality of drafts created by an NMT model.")
-    parser.add_argument("experiment", help="Experiment name")
     parser.add_argument(
-        "diff_predictions_file_name", help="The diff predictions file name to determine line of best fit."
+        "diff_predictions", help="The diff predictions path relative to MT/experiments to determine line of best fit."
     )
     parser.add_argument(
         "confidence_files",
         nargs="*",
-        help="Relative paths for the confidence files to process (relative to experiment folder or --dir if specified) "
-        + "e.g. 'infer/5000/source/631JHN.SFM.confidences.tsv' or '631JHN.SFM.confidences.tsv --dir infer/5000/source'",
+        help="Relative paths for the confidence files to process (relative to MT/experiments or --confidence-dir "
+        + "if specified) e.g. 'project_folder/exp_folder/infer/5000/source/631JN.SFM.confidences.tsv' or "
+        + "'631JN.SFM.confidences.tsv --confidence-dir project_folder/exp_folder/infer/5000/source'.",
     )
     parser.add_argument(
         "--confidence-dir",
         type=Path,
-        help="Folder (relative to experiment folder) containing confidence files e.g. 'infer/5000/source/'",
+        default=None,
+        help="Folder (relative to experiment MT/experiments) containing confidence files e.g. 'infer/5000/source/'.",
     )
     parser.add_argument(
         "--books",
         nargs="+",
         metavar="book_ids",
         help="Provide book ids (e.g. 1JN LUK) to select confidence files rather than providing file paths with "
-        + "the confidence_files positional argument",
+        + "the confidence_files positional argument.",
+    )
+    parser.add_argument(
+        "--draft-index", type=int, default=None, help="If using --books with multiple drafts, specify the draft index."
     )
     args = parser.parse_args()
 
@@ -228,25 +233,30 @@ def main() -> None:
             "You must specify either confidence_files or --books to indicate which confidence files to use."
         )
 
-    exp_dir = Path(get_mt_exp_dir(args.experiment))
-    if bool(args.confidence_dir):
-        confidence_dir = exp_dir / args.confidence_dir
-    else:
-        confidence_dir = exp_dir
+    confidence_dir = get_mt_exp_dir(args.confidence_dir or Path())
 
     if using_files:
         if len(args.confidence_files) == 0:
             raise ValueError("Please provide at least one confidence file for the confidence_files argument.")
-        confidence_files = [confidence_dir / confidence_file for confidence_file in args.confidence_files]
+        confidence_files = [
+            confidence_dir / confidence_file if confidence_dir else confidence_file
+            for confidence_file in args.confidence_files
+        ]
 
     elif using_books:
         if len(args.books) == 0:
             raise ValueError("Please provide at least one book for the --books argument.")
+        if args.draft_index is not None:
+            if not isinstance(args.draft_index, int) or args.draft_index < 0:
+                raise ValueError("Draft index must be a non-negative integer.")
+            draft_suffix = "." + str(args.draft_index)
+        else:
+            draft_suffix = ""
         confidence_files = []
         for book_id in args.books:
-            confidence_files.extend(confidence_dir.glob(f"[0-9]*{book_id}.*.confidences.tsv"))
+            confidence_files.extend(confidence_dir.glob(f"[0-9]*{book_id}{draft_suffix}.*.confidences.tsv"))
 
-    estimate_quality(exp_dir / args.diff_predictions_file_name, confidence_files)
+    estimate_quality(get_mt_exp_dir(args.diff_predictions), confidence_files)
 
 
 if __name__ == "__main__":

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -176,7 +176,7 @@ def parse_parameters(parameter_file: Path) -> Tuple[UsabilityParameters, Usabili
                 label, count, mean, variance = parts
                 params[label] = UsabilityParameters(float(count), float(mean), float(variance))
     else:
-        LOGGER.warning(f"{parameter_file} does not exist. Using default parameters.")
+        LOGGER.warning(f"{parameter_file.name} does not exist. Using default parameters.")
 
     return params["usable"], params["unusable"]
 

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -42,13 +42,13 @@ def project_chrf3(diff_predictions_file: Path, confidence_file: Path) -> List[Ve
     return verse_scores
 
 
-def extract_diff_predictions(diff_predictions_file_path) -> Tuple[List[str], List[str]]:
+def extract_diff_predictions(diff_predictions_file_path) -> Tuple[List[float], List[float]]:
     chrf3_scores = extract_diff_predictions_column(diff_predictions_file_path, "chrf3")
     confidence_scores = extract_diff_predictions_column(diff_predictions_file_path, "confidence")
     return chrf3_scores, confidence_scores
 
 
-def extract_diff_predictions_column(file_path: Path, target_header: str) -> List[str]:
+def extract_diff_predictions_column(file_path: Path, target_header: str) -> List[float]:
     wb = load_workbook(file_path)
     ws = wb.active
 
@@ -73,7 +73,7 @@ def extract_diff_predictions_column(file_path: Path, target_header: str) -> List
     for row in ws.iter_rows(min_row=header_row_idx + 1, min_col=col_idx, max_col=col_idx):
         cell_value = row[0].value
         if cell_value is not None:
-            data.append(cell_value)
+            data.append(float(cell_value))
 
     return data
 
@@ -117,9 +117,7 @@ class UsabilityParameters:
     variance: float
 
 
-def compute_usable_proportions(
-    verse_scores: List[VerseScore], output_dir: Path
-) -> Tuple[Dict[str, float], Dict[str, Dict[int, float]]]:
+def compute_usable_proportions(verse_scores: List[VerseScore], output_dir: Path) -> None:
     usable_params, unusable_params = parse_parameters(output_dir / "usability_parameters.tsv")
 
     book_totals = defaultdict(float)
@@ -188,7 +186,7 @@ def main() -> None:
     parser.add_argument(
         "confidence_files",
         nargs="*",
-        help="Relative paths for the confidence files to process (relative to experiment folder or --dir if specified)"
+        help="Relative paths for the confidence files to process (relative to experiment folder or --dir if specified) "
         + "e.g. 'infer/5000/source/631JHN.SFM.confidences.tsv' or '631JHN.SFM.confidences.tsv --dir infer/5000/source'",
     )
     parser.add_argument(

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -1,0 +1,191 @@
+import argparse
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from math import exp
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from machine.scripture import VerseRef
+from openpyxl import load_workbook
+from scipy.stats import linregress
+
+from silnlp.nmt.config import get_mt_exp_dir
+
+
+@dataclass
+class VerseScore:
+    vref: str
+    confidence: float
+    projected_chrf3: Optional[float] = None
+
+
+def estimate_quality(
+    experiment: str, diff_predictions_file_name: str, confidences_relative_path: str
+) -> List[VerseScore]:
+    exp_dir = Path(get_mt_exp_dir(experiment))
+    chrf3_scores, confidence_scores = extract_diff_predictions(exp_dir / diff_predictions_file_name)
+    if len(chrf3_scores) != len(confidence_scores):
+        raise ValueError("The number of chrF3 scores and confidence scores do not match.")
+    slope, intercept = linregress(confidence_scores, chrf3_scores)[:2]
+    vref_scores = extract_confidences(exp_dir / confidences_relative_path)
+    with open(exp_dir / "projected_chrf3.tsv", "w", encoding="utf-8") as output_file:
+        output_file.write("VRef\tConfidence\tProjected chrF3\n")
+        for vref_score in vref_scores:
+            projected_chrf3 = slope * vref_score.confidence + intercept
+            vref_score.projected_chrf3 = projected_chrf3
+            output_file.write(f"{vref_score.vref}\t{vref_score.confidence}\t{projected_chrf3:.2f}\n")
+
+    compute_usable_proportions(vref_scores, exp_dir)
+
+
+def extract_diff_predictions(diff_predictions_file_path) -> Tuple[List[str], List[str]]:
+    chrf3_scores = extract_diff_predictions_column(diff_predictions_file_path, "chrf3")
+    confidence_scores = extract_diff_predictions_column(diff_predictions_file_path, "confidence")
+    return chrf3_scores, confidence_scores
+
+
+def extract_diff_predictions_column(file_path: Path, target_header: str) -> List[str]:
+    wb = load_workbook(file_path)
+    ws = wb.active
+
+    header_row_idx = None
+    col_idx = None
+
+    for row in ws.iter_rows():
+        for cell in row:
+            if cell.value == "Score Summary":
+                break
+            if str(cell.value).lower() == target_header.lower():
+                header_row_idx = cell.row
+                col_idx = cell.column
+                break
+        if header_row_idx:
+            break
+
+    if not header_row_idx:
+        raise ValueError(f"Header '{target_header}' not found.")
+
+    data = []
+    for row in ws.iter_rows(min_row=header_row_idx + 1, min_col=col_idx, max_col=col_idx):
+        cell_value = row[0].value
+        if cell_value is not None:
+            data.append(cell_value)
+
+    return data
+
+
+def extract_confidences(input_file_path: Path) -> List[VerseScore]:
+    current_book = ""
+    current_chapter = 0
+    current_verse = 0
+    is_at_verse_reference = False
+
+    vref_confidences: List[VerseScore] = []
+    with open(input_file_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.lower().startswith("vref") or line.lower().startswith("sequence score"):
+                continue
+
+            match = re.match(r"^([0-9A-Z][A-Z]{2}) (\d+):(\d+)(/.*)?", line)
+            if match:
+                current_book = match.group(1)
+                current_chapter = int(match.group(2))
+                current_verse = int(match.group(3))
+                extra = match.group(4)
+
+                is_at_verse_reference = current_verse != 0 and not extra
+            elif is_at_verse_reference:
+                cols = line.split("\t")
+                if cols:
+                    vref_confidences += [
+                        VerseScore(f"{current_book} {current_chapter}:{current_verse}", float(cols[0]))
+                    ]
+    return vref_confidences
+
+
+@dataclass
+class UsabilityParameters:
+    count: float
+    mean: float
+    variance: float
+
+
+def compute_usable_proportions(
+    verse_scores: List[VerseScore], output_dir: Path
+) -> Tuple[Dict[str, float], Dict[str, Dict[int, float]]]:
+    usable_params, unusable_params = parse_parameters(output_dir / "usability_parameters.tsv")
+
+    book_totals = defaultdict(float)
+    book_counts = defaultdict(int)
+    chapter_totals = defaultdict(lambda: defaultdict(float))
+    chapter_counts = defaultdict(lambda: defaultdict(int))
+
+    for verse_score in verse_scores:
+        vref = VerseRef.from_string(verse_score.vref)
+        if vref.verse_num == 0:
+            continue
+
+        prob = calculate_usable_prob(verse_score.projected_chrf3, usable_params, unusable_params)
+        book_totals[vref.book] += prob
+        book_counts[vref.book] += 1
+        chapter_totals[vref.book][vref.chapter_num] += prob
+        chapter_counts[vref.book][vref.chapter_num] += 1
+
+    with open(output_dir / "usability_books.tsv", "w", encoding="utf-8", newline="\n") as f:
+        for book in sorted(book_totals):
+            avg_prob = book_totals[book] / book_counts[book]
+            f.write(f"{book}\t{avg_prob:.6f}\n")
+
+    with open(output_dir / "usability_chapters.tsv", "w", encoding="utf-8", newline="\n") as f:
+        for book in sorted(chapter_totals):
+            for chapter in sorted(chapter_totals[book]):
+                avg_prob = chapter_totals[book][chapter] / chapter_counts[book][chapter]
+                f.write(f"{book}\t{chapter}\t{avg_prob:.6f}\n")
+
+
+def parse_parameters(parameter_file: Path) -> Tuple[UsabilityParameters, UsabilityParameters]:
+    params = {
+        "usable": UsabilityParameters(263, 51.4, 95.19),
+        "unusable": UsabilityParameters(97, 45.85, 99.91),
+    }
+    if parameter_file.exists():
+        with open(parameter_file, "r", encoding="utf-8") as f:
+            for line in f:
+                label, count, mean, variance = line.strip().split("\t")
+                params[label] = UsabilityParameters(float(count), float(mean), float(variance))
+    else:
+        print(f"Warning: {parameter_file} does not exist. Using default parameters.")
+
+    return params["usable"], params["unusable"]
+
+
+def calculate_usable_prob(
+    chrf3: float,
+    usable: UsabilityParameters,
+    unusable: UsabilityParameters,
+) -> float:
+    usable_weight = exp(-((chrf3 - usable.mean) ** 2) / (2 * usable.variance)) * usable.count
+    unusable_weight = exp(-((chrf3 - unusable.mean) ** 2) / (2 * unusable.variance)) * unusable.count
+
+    return usable_weight / (usable_weight + unusable_weight)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Estimate the quality of drafts created by an NMT model.")
+    parser.add_argument("experiment", help="Experiment name")
+    parser.add_argument(
+        "diff_predictions_file_name", help="The diff predictions filename to determine line of best fit."
+    )
+    parser.add_argument(
+        "confidences_relative_path",
+        help="The file path to the confidences file relative to the current experiment directory.",
+    )
+    args = parser.parse_args()
+
+    estimate_quality(args.experiment, args.diff_predictions_file_name, args.confidences_relative_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -176,7 +176,7 @@ def parse_parameters(parameter_file: Path) -> Tuple[UsabilityParameters, Usabili
                 label, count, mean, variance = parts
                 params[label] = UsabilityParameters(float(count), float(mean), float(variance))
     else:
-        LOGGER.warning(f"{parameter_file.name} does not exist. Using default parameters.")
+        LOGGER.warning(f"{parameter_file} does not exist. Using default parameters.")
 
     return params["usable"], params["unusable"]
 


### PR DESCRIPTION
This module adds support for estimating the quality of drafts with regard to confidence, chrf3, and usability.

It requires a diff_predictions file to establish a correlation between confidence and chrF3, as well as confidence files to project chrF3 and ultimately usability from. The user has a few options to specify confidence files. They can provide a list of file paths (relative to the experiment directory) or they can specify just the book ids. They can also change the directory to look for confidence files in (relative to the experiment directory) e.g. /infer/5000/source. See the argument descriptions for more details. Also, if a usability_parameters.tsv file is present, it will use the parameters in that file for the chrf3 - usability distribution rather than the default parameters that we gathered from usability surveys.

It outputs '*.projected_chrf3.tsv' files corresponding to each confidence file, listing the vref, confidence, and projected_chrf3 for each verse. It then also outputs a single usability_chapters.tsv file covering chapter usability for all chapter refs in all the confidence files, as well as a single usability_books.tsv for book usability.

Currently it only supports chrF3 as a projected scorer and assumes confidence files were generated from a .SFM file rather than a .txt file so that vref information can be retrieved. Future work could be done to expand functionality as the need arises.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/793)
<!-- Reviewable:end -->
