### PR TITLE
add confidence as scorer if --save-confidences is present

### DIFF
--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -602,6 +602,8 @@ def test(
 
     books_nums = get_chapters(books)
 
+    if save_confidences and "confidence" not in scorers:
+        scorers.add("confidence")
     if len(scorers) == 0:
         scorers.add("bleu")
     scorers.intersection_update(set(_SUPPORTED_SCORERS))


### PR DESCRIPTION
Addresses issue #795 by adding confidence as a scorer for test.py (and by extension experiment.py) if the --save-confidences flag is present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/796)
<!-- Reviewable:end -->
