### PR TITLE
Fixes issue with translate and temp model directories

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -92,7 +92,10 @@ class SILExperiment:
 
         for config in translate_configs.get("translate", []):
             translator = TranslationTask(
-                name=self.name, checkpoint=config.get("checkpoint", "last"), commit=self.commit
+                name=self.name,
+                checkpoint=config.get("checkpoint", "last"),
+                save_checkpoints=self.save_checkpoints,
+                commit=self.commit,
             )
 
             # Backwards compatibility

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1700,7 +1700,7 @@ class HuggingFaceNMTModel(NMTModel):
             checkpoint_path, _ = self.get_checkpoint_path(ckpt)
             model_name = str(checkpoint_path)
         else:
-            LOGGER.warn("Model has no checkpoints. Using base model.")
+            LOGGER.warning("Model has no checkpoints. Using base model.")
             model_name = self._config.model
 
         dtype = torch.bfloat16 if self._is_t5 else torch.float16

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -41,6 +41,7 @@ class NMTTranslator(Translator):
 class TranslationTask:
     name: str
     checkpoint: Union[str, int] = "last"
+    save_checkpoints: bool = False
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
 
@@ -266,6 +267,7 @@ class TranslationTask:
             project_suffix="_infer",
             experiment_suffix=experiment_suffix,
             commit=self.commit,
+            use_default_model_dir=self.save_checkpoints,
         )
         self.name = clearml.name
 


### PR DESCRIPTION
This PR adds `save_checkpoints` to `TranslationTask`, so that translations will use the temporary model directory when `save_checkpoints=False`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/805)
<!-- Reviewable:end -->
