### PR TITLE
Assume default model dir if train is not present

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -94,7 +94,7 @@ class SILExperiment:
             translator = TranslationTask(
                 name=self.name,
                 checkpoint=config.get("checkpoint", "last"),
-                use_default_model_dir=True if not (self.run_test or self.run_train) else self.save_checkpoints,
+                use_default_model_dir=True if not (self.run_train) else self.save_checkpoints,
                 commit=self.commit,
             )
 


### PR DESCRIPTION
This fixes an issue with my previous [PR](https://github.com/sillsdev/silnlp/pull/811)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/813)
<!-- Reviewable:end -->
