### PR TITLE
Fix misnamed variable `config` -> `translate_config`

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -93,7 +93,7 @@ class SILExperiment:
         for translate_config in translate_configs.get("translate", []):
             translator = TranslationTask(
                 name=self.name,
-                checkpoint=config.get("checkpoint", "last"),
+                checkpoint=translate_config.get("checkpoint", "last"),
                 use_default_model_dir=self.save_checkpoints,
                 commit=self.commit,
             )


### PR DESCRIPTION
A previous PR and merge had a misnamed variable in `experiment.py`, causing an error.  This PR corrects that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/817)
<!-- Reviewable:end -->
