### PR TITLE
#756 mig gpu

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -2231,6 +2231,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 def _should_reduce_batch_size(exception: Exception) -> bool:
     if should_reduce_batch_size(exception):
         return True
+    # Check for MIG Out of Memory error. Can remove when should_reduce_batch_size works on MIGs.
     if 'NVML_SUCCESS == r INTERNAL ASSERT FAILED at "../c10/cuda/CUDACachingAllocator.cpp"' in str(exception):
         return True
     return False

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -833,6 +833,7 @@ class OutputGroup:
     def get_sequence_score(self) -> List[float]:
         return [output["sequence_score"] for output in self.outputs]
 
+
 @dataclass
 class InferenceModelParams:
     checkpoint: Union[CheckpointType, str, int]
@@ -2215,7 +2216,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
             try:
                 return function(batch_size, *args, **kwargs)
             except Exception as e:
-                if should_reduce_batch_size(e):
+                if _should_reduce_batch_size(e):
                     gc.collect()
                     torch.cuda.empty_cache()
                     batch_size //= 2
@@ -2225,3 +2226,11 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     raise
 
     return decorator
+
+
+def _should_reduce_batch_size(exception: Exception) -> bool:
+    if should_reduce_batch_size(exception):
+        return True
+    if 'NVML_SUCCESS == r INTERNAL ASSERT FAILED at "../c10/cuda/CUDACachingAllocator.cpp":838' in str(exception):
+        return True
+    return False

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -2231,6 +2231,6 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 def _should_reduce_batch_size(exception: Exception) -> bool:
     if should_reduce_batch_size(exception):
         return True
-    if 'NVML_SUCCESS == r INTERNAL ASSERT FAILED at "../c10/cuda/CUDACachingAllocator.cpp":838' in str(exception):
+    if 'NVML_SUCCESS == r INTERNAL ASSERT FAILED at "../c10/cuda/CUDACachingAllocator.cpp"' in str(exception):
         return True
     return False


### PR DESCRIPTION
This fixes an issue where a unique out of memory exception on MIGs was causing our pipeline to error out. This PR creates a wrapper function for `should_reduce_batch_size` to add an extra check for the MIG out of memory exception. This can be removed if pytorch adds a fix to raise an expected out of memory exception, or if accelerate patches the `should_reduce_batch_size` method to support the current exception on MIGs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/819)
<!-- Reviewable:end -->
