### PR TITLE
Add tags to clearml tasks

### DIFF
--- a/silnlp/common/analyze.py
+++ b/silnlp/common/analyze.py
@@ -480,9 +480,13 @@ def main() -> None:
 
     get_git_revision_hash()
 
-    if args.clearml_queue is not None and "cpu" not in args.clearml_queue:
-        LOGGER.warning("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")
-        exit()
+    if args.clearml_queue is not None:
+        if "cpu" not in args.clearml_queue:
+            LOGGER.warning("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")
+            exit()
+        if args.clearml_tag is None:
+            parser.error("Missing ClearML tag. Add a tag using --clearml-tag. Possible tags: " + f"{TAGS_LIST}")
+
     clearml = SILClearML(args.experiment, args.clearml_queue, tag=args.clearml_tag)
     exp_name = clearml.name
 

--- a/silnlp/common/analyze.py
+++ b/silnlp/common/analyze.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from ..alignment.config import get_aligner_name
 from ..alignment.utils import add_alignment_scores
-from ..nmt.clearml_connection import SILClearML
+from ..nmt.clearml_connection import TAGS_LIST, SILClearML
 from ..nmt.config import Config, get_data_file_pairs
 from .collect_verse_counts import DT_CANON, NT_CANON, OT_CANON, collect_verse_counts
 from .corpus import filter_parallel_corpus, get_mt_corpus_path, get_scripture_parallel_corpus, include_chapters
@@ -468,6 +468,14 @@ def main() -> None:
         help="Run remotely on ClearML queue.  Default: None - don't register with ClearML.  The queue 'local' will run "
         + "it locally and register it with ClearML.",
     )
+    parser.add_argument(
+        "--clearml-tag",
+        metavar="tag",
+        choices=TAGS_LIST,
+        default=None,
+        type=str,
+        help=f"Tag to add to the ClearML Task - {TAGS_LIST}",
+    )
     args = parser.parse_args()
 
     get_git_revision_hash()
@@ -475,7 +483,7 @@ def main() -> None:
     if args.clearml_queue is not None and "cpu" not in args.clearml_queue:
         LOGGER.warning("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")
         exit()
-    clearml = SILClearML(args.experiment, args.clearml_queue)
+    clearml = SILClearML(args.experiment, args.clearml_queue, tag=args.clearml_tag)
     exp_name = clearml.name
 
     config = clearml.config

--- a/silnlp/common/postprocess_draft.py
+++ b/silnlp/common/postprocess_draft.py
@@ -87,6 +87,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.clearml_queue is not None and args.clearml_tag is None:
+        parser.error("Missing ClearML tag. Add a tag using --clearml-tag. Possible tags: " + f"{TAGS_LIST}")
+
     experiment = args.experiment.replace("\\", "/")
     args.output_folder = Path(args.output_folder.replace("\\", "/")) if args.output_folder else None
     postprocess_config = PostprocessConfig(vars(args))

--- a/silnlp/common/postprocess_draft.py
+++ b/silnlp/common/postprocess_draft.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 from pathlib import Path
 
-from ..nmt.clearml_connection import SILClearML
+from ..nmt.clearml_connection import TAGS_LIST, SILClearML
 from ..nmt.config_utils import load_config
 from ..nmt.postprocess import postprocess_experiment
 from .postprocesser import PostprocessConfig, PostprocessHandler
@@ -76,6 +76,15 @@ def main() -> None:
         help="Run remotely on ClearML queue.  Default: None - don't register with ClearML.  The queue 'local' will run "
         + "it locally and register it with ClearML.",
     )
+
+    parser.add_argument(
+        "--clearml-tag",
+        metavar="tag",
+        choices=TAGS_LIST,
+        default=None,
+        type=str,
+        help=f"Tag to add to the ClearML Task - {TAGS_LIST}",
+    )
     args = parser.parse_args()
 
     experiment = args.experiment.replace("\\", "/")
@@ -88,7 +97,7 @@ def main() -> None:
     if args.clearml_queue is not None:
         if "cpu" not in args.clearml_queue:
             raise ValueError("Running this script on a GPU queue will not speed it up. Please only use CPU queues.")
-        clearml = SILClearML(experiment, args.clearml_queue)
+        clearml = SILClearML(experiment, args.clearml_queue, tag=args.clearml_tag)
         config = clearml.config
     else:
         config = load_config(experiment)

--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -11,6 +11,8 @@ from .config_utils import create_config
 
 LOGGER = logging.getLogger(__name__)
 
+TAGS_LIST = ["research", "dev", "eitl", "onboarding"]
+
 
 @dataclass
 class SILClearML:
@@ -22,6 +24,7 @@ class SILClearML:
     clearml_project_folder: str = ""
     commit: Optional[str] = None
     use_default_model_dir: bool = True
+    tag: Optional[str] = None
 
     def __post_init__(self) -> None:
         self.name = self.name.replace("\\", "/")
@@ -43,6 +46,7 @@ class SILClearML:
             self.task: Task = Task.init(
                 project_name=self.project_prefix + project + self.project_suffix,
                 task_name=exp_name + self.experiment_suffix,
+                tags=[f"silnlp-{self.tag}"] if self.tag else None,
             )
 
             self._determine_clearml_project_name()

--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -211,6 +211,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if args.clearml_queue is not None and args.clearml_tag is None:
+        parser.error("Missing ClearML tag. Add a tag using --clearml-tag. Possible tags: " + f"{TAGS_LIST}")
+
     if args.mt_dir is not None:
         SIL_NLP_ENV.set_machine_translation_dir(SIL_NLP_ENV.data_dir / args.mt_dir)
 

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -14,7 +14,7 @@ from ..common.paratext import book_file_name_digits, get_project_dir
 from ..common.postprocesser import PostprocessConfig, PostprocessHandler
 from ..common.translator import TranslationGroup, Translator
 from ..common.utils import get_git_revision_hash, show_attrs
-from .clearml_connection import SILClearML
+from .clearml_connection import TAGS_LIST, SILClearML
 from .config import CheckpointType, Config, NMTModel
 
 LOGGER = logging.getLogger(__package__ + ".translate")
@@ -36,7 +36,7 @@ class NMTTranslator(Translator, AbstractContextManager):
         return self._model.translate(
             sentences, src_iso, trg_iso, produce_multiple_translations, vrefs, self._checkpoint
         )
-    
+
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         self._model.clear_cache()
 
@@ -48,6 +48,7 @@ class TranslationTask:
     use_default_model_dir: bool = True
     clearml_queue: Optional[str] = None
     commit: Optional[str] = None
+    clearml_tag: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.checkpoint is None:
@@ -81,7 +82,9 @@ class TranslationTask:
 
                 trg_project_dir = get_project_dir(trg_project)
                 if not trg_project_dir.is_dir():
-                    raise FileNotFoundError(f"Target project {trg_project} not found in projects folder {trg_project_dir}")
+                    raise FileNotFoundError(
+                        f"Target project {trg_project} not found in projects folder {trg_project_dir}"
+                    )
             else:
                 trg_project = None
 
@@ -250,7 +253,9 @@ class TranslationTask:
                         src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations, save_confidences
                     )
                 elif ext == ".docx":
-                    translator.translate_docx(src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations)
+                    translator.translate_docx(
+                        src_file_path, trg_file_path, src_iso, trg_iso, produce_multiple_translations
+                    )
                 elif ext == ".usfm" or ext == ".sfm":
                     experiment_ckpt_str = f"{self.name}:{self.checkpoint}"
                     if not config.model_dir.exists():
@@ -280,6 +285,7 @@ class TranslationTask:
             experiment_suffix=experiment_suffix,
             commit=self.commit,
             use_default_model_dir=self.use_default_model_dir,
+            tag=self.clearml_tag,
         )
         self.name = clearml.name
 
@@ -415,13 +421,21 @@ def main() -> None:
         + "it locally and register it with ClearML.",
     )
     parser.add_argument(
+        "--clearml-tag",
+        metavar="tag",
+        choices=TAGS_LIST,
+        default=None,
+        type=str,
+        help=f"Tag to add to the ClearML Task - {TAGS_LIST}",
+    )
+    parser.add_argument(
+        "--commit", type=str, default=None, help="The silnlp git commit id with which to run a remote job"
+    )
+    parser.add_argument(
         "--debug",
         default=False,
         action="store_true",
         help="Show information about the environment variables and arguments.",
-    )
-    parser.add_argument(
-        "--commit", type=str, default=None, help="The silnlp git commit id with which to run a remote job"
     )
 
     args = parser.parse_args()
@@ -433,6 +447,7 @@ def main() -> None:
         checkpoint=args.checkpoint,
         clearml_queue=args.clearml_queue,
         commit=args.commit,
+        clearml_tag=args.clearml_tag,
     )
 
     postprocess_handler = PostprocessHandler([PostprocessConfig(vars(args))])

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -440,6 +440,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    if args.clearml_queue is not None and args.clearml_tag is None:
+        parser.error("Missing ClearML tag. Add a tag using --clearml-tag. Possible tags: " + f"{TAGS_LIST}")
+
     get_git_revision_hash()
 
     translator = TranslationTask(


### PR DESCRIPTION
This PR adds the optional argument `--clearml-tag` to scripts that use ClearML to add a tag to Tasks that are run on ClearML. The possible options for `--clearml-tag` are: `research`, `dev`, `eitl`, and `onboarding`. Each of them will be appended with `silnlp-` once the Task is created to match the formatting of the SF tags.

I can make tags required or change the list of possible tags if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/823)
<!-- Reviewable:end -->
