### PR TITLE
Verse segmentation

### DIFF
--- a/silnlp/alignment/group_verses_into_passages.py
+++ b/silnlp/alignment/group_verses_into_passages.py
@@ -68,10 +68,16 @@ def assign_verses_to_passages(project_name: str, passage_file: Path) -> List[Pas
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Collect verse counts and compute alignment scores")
+    parser = argparse.ArgumentParser(
+        description="Collects text from a Paratext project and groups in into specified passages."
+    )
     parser.add_argument("--project", help="Name of source Paratext project", required=True, type=str)
-    parser.add_argument("--input-passages", help=".tsv file with target passages", required=True, type=str)
-    parser.add_argument("--output-passages", help=".tsv file with target passages", required=True, type=str)
+    parser.add_argument(
+        "--input-passages", help="Input .tsv file with source passage references", required=True, type=str
+    )
+    parser.add_argument(
+        "--output-passages", help="Output .tsv file to contain target passages", required=True, type=str
+    )
     args = parser.parse_args()
 
     passages = assign_verses_to_passages(args.project, Path(args.input_passages))

--- a/silnlp/alignment/segment_verses.py
+++ b/silnlp/alignment/segment_verses.py
@@ -244,7 +244,7 @@ class FewestCrossedAlignmentsVerseSegmenter(VerseSegmenter):
                 target_verse_offsets.append(len(target_tokens))
                 continue
 
-            fewest_crossed_alignments = 1000000
+            fewest_crossed_alignments = 1_000_000
             best_split_indices = []
             for trg_word_index in range(last_target_verse_offset + 1, len(target_tokens)):
                 crossed_alignments = word_alignments.get_num_crossed_alignments(verse_token_offset - 1, trg_word_index)


### PR DESCRIPTION
This PR adds a new script called `segment_verses.py` that can segment passages into individual verses by aligning the passages against known verse segmentations (i.e. any Paratext project).  It is also able to evaluate the accuracy of the segmentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/827)
<!-- Reviewable:end -->
