### PR TITLE
Multiple translations fix

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -61,6 +61,9 @@ class SentenceTranslation:
     def get_sequence_confidence_score(self) -> Optional[float]:
         return self._sequence_score
 
+    def join_tokens_for_test_file(self) -> str:
+        return " ".join([token for token in self._tokens if token != "<pad>"])
+
     def join_tokens_for_confidence_file(self) -> str:
         return "\t".join(self._tokens)
 
@@ -123,6 +126,9 @@ class TranslatedDraft:
 
     def get_all_translations(self) -> List[str]:
         return [st.get_translation() for st in self._sentence_translations]
+
+    def get_all_tokenized_translations(self) -> List[str]:
+        return [st.join_tokens_for_test_file() for st in self._sentence_translations]
 
 
 # A wrapper around List[SentenceTranslationGroup] that allows upstream consumers to view a

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1193,7 +1193,7 @@ class HuggingFaceNMTModel(NMTModel):
                     else:
                         translation_draft_path = translation_path
                     out_file = stack.enter_context(translation_draft_path.open("w", encoding="utf-8", newline="\n"))
-                    out_file.write("\n".join(translated_draft.get_all_translations()) + "\n")
+                    out_file.write("\n".join(translated_draft.get_all_tokenized_translations()) + "\n")
 
                     if save_confidences:
                         generate_test_confidence_files(


### PR DESCRIPTION
I discovered a bug that was causing the test step to fail.  This PR addresses that issue by using the correct data types from the translator and printing a tokenized version of the translations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/834)
<!-- Reviewable:end -->
