### PR TITLE
Add NFKC normalization to tokenizer

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -12,6 +12,7 @@ from itertools import repeat
 from math import prod
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union, cast
+from unicodedata import normalize
 
 import datasets.utils.logging as datasets_logging
 import evaluate
@@ -1818,10 +1819,12 @@ class PunctuationNormalizingTokenizer(PreTrainedTokenizerFast):
 
         if isinstance(text, str):
             text = self._mpn.normalize(text)
+            text = normalize("NFKC", text)
         elif isinstance(text, (list, tuple)) and len(text) > 0:
             if isinstance(text[0], (list, tuple)) and len(text[0]) > 0:
-                text = [[self._mpn.normalize(item) for item in row] for row in text]
-            text = [self._mpn.normalize(item) for item in text]
+                text = [[normalize("NFKC", self._mpn.normalize(item)) for item in row] for row in text]
+            else:
+                text = [normalize("NFKC", self._mpn.normalize(item)) for item in text]
         return self._wrapped_tokenizer(text, **kwargs)
 
     def token_to_id(self, token: str) -> int:
@@ -1863,6 +1866,7 @@ class HuggingFaceTokenizer(Tokenizer):
     ) -> str:
         if isinstance(self._tokenizer, (NllbTokenizer, NllbTokenizerFast)):
             line = self._mpn.normalize(line)
+            line = normalize("NFKC", line)
         if not add_dummy_prefix:
             line = "\ufffc" + line
         if side == Side.SOURCE:


### PR DESCRIPTION
This PR changes the tokenization process to add Unicode normalization to NFKC.  The Sentence Piece tokenizer is trained with NFKC, and it will produce additional unnecessary tokens if the input characters are not composed correctly.  I had thought that the tokenizer applied NFKC automatically, but it seems that it does not.  This PR adds code to explicitly normalize the text before sending it to NLLB's tokenizer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/841)
<!-- Reviewable:end -->
