### PR TITLE
Remove extra EOS token during test step

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -65,6 +65,8 @@ class SentenceTranslation:
         return self._sequence_score
 
     def join_tokens_for_test_file(self) -> str:
+        # The first token is skipped because it is always equal to decoder_start_token_id,
+        # because of the way Huggingface implements encoder-decoder models
         return " ".join([token for token in self._tokens[1:] if token != "<pad>"])
 
     def join_tokens_for_confidence_file(self) -> str:


### PR DESCRIPTION
This PR fixes the issue where an extra end-of-sentence marker was being printed at the start of each sentence in `test.trg-predictions.txt`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/879)
<!-- Reviewable:end -->
