### PR TITLE
Only download punkt package when needed

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -36,7 +36,6 @@ from .postprocesser import NoDetectedQuoteConventionException, PostprocessHandle
 from .usfm_utils import PARAGRAPH_TYPE_EMBEDS
 
 LOGGER = logging.getLogger((__package__ or "") + ".translate")
-nltk.download("punkt")
 
 CONFIDENCE_SCORES_SUFFIX = ".confidences.tsv"
 
@@ -527,6 +526,7 @@ class Translator(AbstractContextManager["Translator"], ABC):
         produce_multiple_translations: bool = False,
         tags: Optional[List[str]] = None,
     ) -> None:
+        nltk.download("punkt")
         tokenizer: nltk.tokenize.PunktSentenceTokenizer
         try:
             src_lang = Lang(src_iso)


### PR DESCRIPTION
This PR addresses one point of this [issue](https://github.com/sillsdev/silnlp/issues/877). It removes the need to check the download of NLTK's `punkt` package for every execution. It now only downloads `punkt` within `silnlp.common.translator.Translator.translate_docx`, since that is the only function using the package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/881)
<!-- Reviewable:end -->
