### PR TITLE
Verse segmentation fix

### DIFF
--- a/silnlp/alignment/segment_verses.py
+++ b/silnlp/alignment/segment_verses.py
@@ -724,12 +724,8 @@ def main() -> None:
         vref_path = Path(args.target_passages).with_suffix(".vref.txt")
         template_vref_path = SIL_NLP_ENV.assets_dir / "vref.txt"
 
-        for trg_passage in trg_segmented_passages:
-            for verse in trg_passage.verses:
-                verse.reference.change_versification(ORIGINAL_VERSIFICATION)
-
         verse_map: Dict[str, str] = {
-            str(verse.reference): verse.text
+            str(verse.reference.to_versification(ORIGINAL_VERSIFICATION)): verse.text
             for trg_passage in trg_segmented_passages
             for verse in trg_passage.verses
         }


### PR DESCRIPTION
Previously, the verse segmentation algorithm was crashing when there was a passage that was only a single verse. This fixes that behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/883)
<!-- Reviewable:end -->
