### PR TITLE
Prevent infinite loops if rclone transfers cannot complete

### DIFF
--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -127,10 +127,10 @@ def check_transfers() -> None:
         return
     LOGGER.info("Checking rclone transfer progress.")
     time.sleep(60)  # wait for the latest poll interval
-    while True:
+    transfers_complete = False
+    for i in range(4):
         with open("/root/rclone_log.txt", "r", encoding="utf-8") as log_file:
             log_lines = log_file.readlines()
-        transfers_complete = False
         for line in reversed(log_lines):
             if "vfs cache: cleaned" in line:
                 transfers_complete = bool(re.match(r".*in use 0, to upload 0, uploading 0,.*", line))
@@ -141,8 +141,10 @@ def check_transfers() -> None:
             break
         else:
             LOGGER.info(line)
-            LOGGER.info("rclone transfers are still in progress. Waiting one minute.")
-        time.sleep(60)
+            LOGGER.info(f"rclone transfers are still in progress. Waiting {2**i} minutes.")
+        time.sleep(60 * (2**i))  # exponential backoff, max 8 minutes, total wait time 15 minutes
+    if not transfers_complete:
+        LOGGER.warning("rclone transfers could not be completed. Some data may be lost or corrupted.")
 
 
 def try_n_times(func: Callable, n=10):


### PR DESCRIPTION
This PR adds some exponential backoff when checking rclone transfer progress to prevent infinite loops when waiting for rclone transfers to complete. It now waits 1 minute, then another minute, then 2, then 4, then 8. If the transfers could not be completed in that time, the job continues to exit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/903)
<!-- Reviewable:end -->
