### PR TITLE
Multilingual inference

### DIFF
--- a/silnlp/common/translate_google.py
+++ b/silnlp/common/translate_google.py
@@ -25,7 +25,7 @@ class GoogleTranslator(Translator):
             LOGGER.warning("Google Translator does not support --multiple-translations")
 
         for sentence in sentences:
-            if len(sentence.text) == 0:
+            if sentence.text is None or len(sentence.text) == 0:
                 yield [SentenceTranslation("", [], [], None)]
             else:
                 results = self._translate_client.translate(

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -32,7 +32,7 @@ from ..common.corpus import (
     write_corpus,
 )
 from ..common.environment import SIL_NLP_ENV
-from ..common.translator import SentenceTranslationGroup
+from ..common.translator import SentenceTranslationGroup, TranslationInputSentence
 from ..common.utils import NoiseMethod, Side, add_tags_to_dataframe, add_tags_to_sentence, get_mt_exp_dir, set_seed
 from .augment import AugmentMethod
 from .corpora import (
@@ -71,6 +71,7 @@ class NMTModel(ABC):
     def translate_test_files(
         self,
         input_paths: List[Path],
+        test_gold_standard_paths: List[Path],
         translation_paths: List[Path],
         produce_multiple_translations: bool = False,
         save_confidences: bool = False,
@@ -81,11 +82,8 @@ class NMTModel(ABC):
     @abstractmethod
     def translate(
         self,
-        sentences: List[str],
-        src_isos: List[str],
-        trg_isos: List[str],
+        sentences: List[TranslationInputSentence],
         produce_multiple_translations: bool = False,
-        vrefs: Optional[List[VerseRef]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
     ) -> Generator[SentenceTranslationGroup, None, None]: ...
 

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -81,11 +81,11 @@ class NMTModel(ABC):
     @abstractmethod
     def translate(
         self,
-        sentences: Iterable[str],
-        src_iso: str,
-        trg_iso: str,
+        sentences: List[str],
+        src_isos: List[str],
+        trg_isos: List[str],
         produce_multiple_translations: bool = False,
-        vrefs: Optional[Iterable[VerseRef]] = None,
+        vrefs: Optional[List[VerseRef]] = None,
         ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
     ) -> Generator[SentenceTranslationGroup, None, None]: ...
 

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1869,9 +1869,9 @@ class PunctuationNormalizingTokenizer(PreTrainedTokenizerFast):
     def set_src_lang(self, src_lang: str):
         self._wrapped_tokenizer.src_lang = src_lang
 
-    @SpecialTokensMixin.pad_token_id.getter
-    def pad_token_id(self) -> int | None:
-        return self._wrapped_tokenizer.pad_token_id
+    @SpecialTokensMixin.eos_token_id.getter
+    def eos_token_id(self) -> int | None:
+        return self._wrapped_tokenizer.eos_token_id
 
 
 class HuggingFaceTokenizer(Tokenizer):
@@ -2004,7 +2004,7 @@ class SilTranslationPipeline(Text2TextGenerationPipeline):
         generate_kwargs["decoder_input_ids"] = torch.cat(
             (
                 torch.ones((in_b, 1), dtype=torch.long, device=model_inputs["input_ids"].device)
-                * self.tokenizer.pad_token_id,
+                * self.tokenizer.eos_token_id,
                 torch.unsqueeze(torch.from_numpy(self.tgt_langs[self.tgt_index : self.tgt_index + in_b]), 1).to(
                     model_inputs["input_ids"].device
                 ),

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -478,7 +478,7 @@ def test_checkpoint(
     vref_file_names: List[str] = []
     source_file_names: List[str] = []
     translation_file_names: List[str] = []
-    gold_standard_detok_file_names: List[str] = []
+    gold_standard_target_file_names: List[str] = []
     refs_patterns: List[str] = []
     translation_detok_file_names: List[str] = []
     translation_conf_file_names: List[str] = []
@@ -496,7 +496,7 @@ def test_checkpoint(
         refs_patterns.append("test.trg.detok*.txt")
         translation_detok_file_names.append(f"test.trg-predictions.detok.txt.{suffix_str}")
         translation_conf_file_names.append(f"test.trg-predictions.txt.{suffix_str}.confidences.tsv")
-        gold_standard_detok_file_names.append("test.trg.detok.txt")
+        gold_standard_target_file_names.append("test.trg.txt")
     else:
         # test data is split into separate files
         for src_iso in sorted(config.test_src_isos):
@@ -512,7 +512,7 @@ def test_checkpoint(
                     refs_patterns.append(f"{prefix}.trg.detok*.txt")
                     translation_detok_file_names.append(f"{prefix}.trg-predictions.detok.txt.{suffix_str}")
                     translation_conf_file_names.append(f"{prefix}.trg-predictions.txt.{suffix_str}.confidences.tsv")
-                    gold_standard_detok_file_names.append(f"{prefix}.trg.detok.txt")
+                    gold_standard_target_file_names.append(f"{prefix}.trg.txt")
 
     checkpoint_name = "averaged checkpoint" if step == -1 else f"checkpoint {step}"
 
@@ -522,7 +522,7 @@ def test_checkpoint(
     translation_paths: List[Path] = []
     for i in range(len(translation_file_names)):
         predictions_path = config.exp_dir / translation_file_names[i]
-        gold_standard_target_paths.append(config.exp_dir / gold_standard_detok_file_names[i])
+        gold_standard_target_paths.append(config.exp_dir / gold_standard_target_file_names[i])
         if force_infer or not predictions_path.is_file():
             source_paths.append(config.exp_dir / source_file_names[i])
             translation_paths.append(predictions_path)

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -478,6 +478,7 @@ def test_checkpoint(
     vref_file_names: List[str] = []
     source_file_names: List[str] = []
     translation_file_names: List[str] = []
+    gold_standard_detok_file_names: List[str] = []
     refs_patterns: List[str] = []
     translation_detok_file_names: List[str] = []
     translation_conf_file_names: List[str] = []
@@ -495,6 +496,7 @@ def test_checkpoint(
         refs_patterns.append("test.trg.detok*.txt")
         translation_detok_file_names.append(f"test.trg-predictions.detok.txt.{suffix_str}")
         translation_conf_file_names.append(f"test.trg-predictions.txt.{suffix_str}.confidences.tsv")
+        gold_standard_detok_file_names.append("test.trg.detok.txt")
     else:
         # test data is split into separate files
         for src_iso in sorted(config.test_src_isos):
@@ -510,14 +512,17 @@ def test_checkpoint(
                     refs_patterns.append(f"{prefix}.trg.detok*.txt")
                     translation_detok_file_names.append(f"{prefix}.trg-predictions.detok.txt.{suffix_str}")
                     translation_conf_file_names.append(f"{prefix}.trg-predictions.txt.{suffix_str}.confidences.tsv")
+                    gold_standard_detok_file_names.append(f"{prefix}.trg.detok.txt")
 
     checkpoint_name = "averaged checkpoint" if step == -1 else f"checkpoint {step}"
 
     source_paths: List[Path] = []
+    gold_standard_target_paths: List[Path] = []
     vref_paths: Optional[List[Path]] = [] if config.has_scripture_data else None
     translation_paths: List[Path] = []
     for i in range(len(translation_file_names)):
         predictions_path = config.exp_dir / translation_file_names[i]
+        gold_standard_target_paths.append(config.exp_dir / gold_standard_detok_file_names[i])
         if force_infer or not predictions_path.is_file():
             source_paths.append(config.exp_dir / source_file_names[i])
             translation_paths.append(predictions_path)
@@ -527,6 +532,7 @@ def test_checkpoint(
         LOGGER.info(f"Inferencing {checkpoint_name}")
         model.translate_test_files(
             source_paths,
+            gold_standard_target_paths,
             translation_paths,
             produce_multiple_translations,
             save_confidences,

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -27,14 +27,14 @@ class NMTTranslator(Translator):
 
     def translate(
         self,
-        sentences: Iterable[str],
-        src_iso: str,
-        trg_iso: str,
+        sentences: List[str],
+        src_isos: List[str],
+        trg_isos: List[str],
         produce_multiple_translations: bool = False,
         vrefs: Optional[Iterable[VerseRef]] = None,
     ) -> Generator[SentenceTranslationGroup, None, None]:
         yield from self._model.translate(
-            sentences, src_iso, trg_iso, produce_multiple_translations, vrefs, self._checkpoint
+            sentences, src_isos, trg_isos, produce_multiple_translations, vrefs, self._checkpoint
         )
 
     def __exit__(

--- a/silnlp/nmt/translate.py
+++ b/silnlp/nmt/translate.py
@@ -2,17 +2,16 @@ import argparse
 import logging
 import os
 import time
-from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, List, Optional, Tuple, Union
+from typing import Generator, List, Optional, Tuple, Union
 
-from machine.scripture import VerseRef, book_number_to_id, get_chapters
+from machine.scripture import book_number_to_id, get_chapters
 
 from ..common.environment import SIL_NLP_ENV
 from ..common.paratext import book_file_name_digits, get_project_dir
 from ..common.postprocesser import PostprocessConfig, PostprocessHandler
-from ..common.translator import SentenceTranslationGroup, Translator
+from ..common.translator import SentenceTranslationGroup, TranslationInputSentence, Translator
 from ..common.utils import get_git_revision_hash, show_attrs
 from .clearml_connection import TAGS_LIST, SILClearML
 from .config import CheckpointType, Config, NMTModel
@@ -27,15 +26,10 @@ class NMTTranslator(Translator):
 
     def translate(
         self,
-        sentences: List[str],
-        src_isos: List[str],
-        trg_isos: List[str],
+        sentences: List[TranslationInputSentence],
         produce_multiple_translations: bool = False,
-        vrefs: Optional[Iterable[VerseRef]] = None,
     ) -> Generator[SentenceTranslationGroup, None, None]:
-        yield from self._model.translate(
-            sentences, src_isos, trg_isos, produce_multiple_translations, vrefs, self._checkpoint
-        )
+        yield from self._model.translate(sentences, produce_multiple_translations, self._checkpoint)
 
     def __exit__(
         self, exc_type, exc_value, traceback  # pyright: ignore[reportUnknownParameterType, reportMissingParameterType]


### PR DESCRIPTION
This is a draft PR that adds support for multilingual inference (multi-source and multi-target) in SILNLP.  It turns out that the existing code already supports training with more than one language pair, so this focuses specifically on inference.  There is more work still to be done before this is ready to merge, but I wanted to get feedback before I got too deep into that extra work.

The biggest changes are in `SILTranslationPipeline` in `hugging_face_config.py`.  HuggingFace's `TranslationPipeline` is set up to have a fixed input language code and output language code and takes care of adding the various special tokens to the input and output tensors.  I have overridden some of the pipeline methods to manually construct the tensors, so that we can vary the language codes on a per-instance basis.  Right now, it only handles NLLB's format.

Most all of the other changes are simply to support this new method for creating the tensors (e.g. making sure that the source and target iso are always passed to the translate functions and not just derived from the model metadata).  Let me know if you see any red flags in the way I've implemented things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/928)
<!-- Reviewable:end -->
