### PR TITLE
Check whether best quote convention is None

### DIFF
--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -194,7 +194,7 @@ class DenormalizeQuotationMarksPostprocessor:
         except ValueError as verr:
             raise NoDetectedQuoteConventionException([project_name]) from verr
 
-        if quote_convention_analysis is None:
+        if quote_convention_analysis is None or quote_convention_analysis.best_quote_convention is None:
             raise NoDetectedQuoteConventionException([project_name])
         LOGGER.info(
             f'Detected quote convention for project "{project_name}" is '


### PR DESCRIPTION
This fixes https://github.com/sillsdev/silnlp/issues/934 by adding a check for the best quote convention being `None`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/935)
<!-- Reviewable:end -->
