### PR TITLE
Add max cache size of 15GB for rclone

### DIFF
--- a/silnlp/nmt/clearml_connection.py
+++ b/silnlp/nmt/clearml_connection.py
@@ -81,7 +81,7 @@ class SILClearML:
                     'sed -i -e "s#access_key_id = x*#access_key_id = $MINIO_ACCESS_KEY#" ~/.config/rclone/rclone.conf',
                     'sed -i -e "s#secret_access_key = x*#secret_access_key = $MINIO_SECRET_KEY#" ~/.config/rclone/rclone.conf',
                     'sed -i -e "s#endpoint = .*#endpoint = $MINIO_ENDPOINT_URL#" ~/.config/rclone/rclone.conf',
-                    "rclone mount --daemon --no-check-certificate --log-file=/root/rclone_log.txt --log-level=DEBUG --vfs-cache-mode full --use-server-modtime miniosilnlp:nlp-research /root/M",
+                    "rclone mount --daemon --no-check-certificate --log-file=/root/rclone_log.txt --log-level=DEBUG --vfs-cache-mode full --vfs-cache-max-size 15G --use-server-modtime miniosilnlp:nlp-research /root/M",
                 ],
             )
             if self.commit:


### PR DESCRIPTION
This PR limits the cache size for rclone on ClearML to 15GB, which should fix high RAM usage during the test step mentioned in Issue #940.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/956)
<!-- Reviewable:end -->
