### PR TITLE
fix spbleu ram issue; loosen check for TestConfidenceFile

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -49,7 +49,7 @@ class ConfidenceFile(ABC, Generic[TVerseKey]):
 
     @classmethod
     def _get_confidence_file_type(cls, trg_draft_file_path: Path) -> type["ConfidenceFile"]:
-        if trg_draft_file_path.name.startswith("test.trg-predictions"):
+        if "trg-predictions" in trg_draft_file_path.name:
             return TestConfidenceFile
         ext = trg_draft_file_path.suffix.lower()
         if ext in {".usfm", ".sfm"}:
@@ -58,7 +58,7 @@ class ConfidenceFile(ABC, Generic[TVerseKey]):
             return TxtConfidenceFile
         raise ValueError(
             f"No confidence file type corresponds to trg_draft_file_path {trg_draft_file_path}. "
-            f"Expected a trg_draft_file_path starting with 'test.trg-predictions' or ending with .usfm/.sfm/.txt."
+            f"Expected a trg_draft_file_path containing 'trg-predictions' or ending with .usfm/.sfm/.txt."
         )
 
     @classmethod

--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -264,7 +264,6 @@ def write_pair_verse_scores(
 ) -> None:
     scorers = scorers.intersection(SUPPORTED_SENTENCE_SCORERS)
     other_scores = {k: v for k, v in other_scores.items() if k.lower() in scorers}
-    other_verse_scores: Dict[str, float] = {}
 
     with open(
         config.exp_dir / (predictions_detok_file_name + VERSE_SCORES_SUFFIX), "w", encoding="utf-8", newline="\n"
@@ -284,6 +283,7 @@ def write_pair_verse_scores(
             header += "\tReference"
         header += "\n"
         scores_file.write(header)
+        spbleu_metric = sacrebleu.metrics.BLEU(tokenize="flores200", lowercase=True) if "spbleu" in scorers else None
         for index, pred in enumerate(pair_sys):
             sentences: List[str] = []
             for ref in pair_refs:
@@ -297,8 +297,8 @@ def write_pair_verse_scores(
                 )
             other_verse_scores: Dict[str, float] = {}
             if "chrf3" in scorers:
-                chrf3_verse_score = sacrebleu.corpus_chrf(
-                    [pred], [sentences], char_order=6, beta=3, remove_whitespace=True
+                chrf3_verse_score = sacrebleu.sentence_chrf(
+                    pred, sentences, char_order=6, beta=3, remove_whitespace=True
                 )
                 other_verse_scores["chrF3"] = chrf3_verse_score.score
 
@@ -314,13 +314,8 @@ def write_pair_verse_scores(
                 )
                 other_verse_scores["chrF3++"] = chrfpp_verse_score.score
 
-            if "spbleu" in scorers:
-                spbleu_verse_score = sacrebleu.sentence_bleu(
-                    pred,
-                    sentences,
-                    lowercase=True,
-                    tokenize="flores200",
-                )
+            if "spbleu" in scorers and spbleu_metric is not None:
+                spbleu_verse_score = spbleu_metric.sentence_score(pred, sentences)
                 other_verse_scores["spBLEU"] = spbleu_verse_score.score
 
             if "meteor" in scorers:
@@ -329,7 +324,7 @@ def write_pair_verse_scores(
                     other_verse_scores["METEOR"] = meteor_verse_score
 
             if "ter" in scorers:
-                ter_verse_score = sacrebleu.corpus_ter([pred], [sentences])
+                ter_verse_score = sacrebleu.sentence_ter(pred, sentences)
                 if ter_verse_score.score >= 0:
                     other_verse_scores["TER"] = ter_verse_score.score
 


### PR DESCRIPTION
This PR fixes two bugs.

The first is #940, where the spbleu metric was reinitializing the Flores200 tokenizer on every iteration in the loop and consequently eating up all the RAM to the point of failure. I have moved intialization outside the loop to prevent that. The memory issue has gone away, and it has also had the side effect of drastically increasing the speed of the test step when spbleu is included. 

The second is #947, where multilingual drafting was not compatible with saving confidence scores. This was only due to the fact that the code to check for a valid filename for a TestConfidenceFile was too restrictive and did not account for filenames where the lang id is inserted toward the beginning. I have loosened the check just to look for the presence of "trg-predictions" in the trg draft file name and confirmed multilingual drafting experiments now complete successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/960)
<!-- Reviewable:end -->
