### PR TITLE
only save scores.tsv when scoring ALL

### DIFF
--- a/silnlp/nmt/test.py
+++ b/silnlp/nmt/test.py
@@ -238,16 +238,17 @@ def score_pair(
                 ) from e
         other_scores["Confidence"] = gmean(confidences)
 
-    write_pair_verse_scores(
-        pair_sys,
-        pair_refs,
-        trg_iso,
-        predictions_detok_file_name,
-        scorers,
-        other_scores,
-        config,
-        confidences if "confidence" in scorers else None,
-    )
+    if book == "ALL":
+        write_pair_verse_scores(
+            pair_sys,
+            pair_refs,
+            trg_iso,
+            predictions_detok_file_name,
+            scorers,
+            other_scores,
+            config,
+            confidences if "confidence" in scorers else None,
+        )
 
     return PairScore(book, src_iso, trg_iso, bleu_score, len(pair_sys), ref_projects, other_scores, draft_index)
 


### PR DESCRIPTION
Fixes the issue in #958 where scores.tsv was not being saved properly with the presence of the `--score-by-book` flag. I confirmed that scoring multiple books now outputs a correct scores.tsv file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/965)
<!-- Reviewable:end -->
