### PR TITLE
Use re-merged scripture refs for confidence files

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -509,7 +509,9 @@ class Translator(AbstractContextManager["Translator"], ABC):
                     f.write(usfm_out)
 
                 if save_confidences and config.get_postprocess_suffix() == "":
-                    generate_confidence_files(translated_draft, trg_draft_file_path, scripture_refs=scripture_refs)
+                    generate_confidence_files(
+                        translated_draft, trg_draft_file_path, scripture_refs=translated_text_rows.get_scripture_refs()
+                    )
 
     def translate_docx(
         self,


### PR DESCRIPTION
This PR fixes https://github.com/sillsdev/silnlp/issues/957 by passing the correct list of scripture refs to the confidence file generation functions.  If there were long non-scripture segments, they may have been split into smaller sections for translation and later re-merged after being translated.  The expanded list of corresponding scripture refs was being mistakenly passed to the confidence file generation functions.  This makes a change to pass the re-merged scripture refs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/967)
<!-- Reviewable:end -->
