### PR TITLE
Make `experiment --translate` more convenient

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -262,11 +262,6 @@ def main() -> None:
         show_attrs(cli_args=args)
         exit()
 
-    if not (args.preprocess or args.train or args.test):
-        args.preprocess = True
-        args.train = True
-        args.test = True
-
     exp = SILExperiment(
         name=args.experiment,
         make_stats=args.stats,
@@ -286,7 +281,7 @@ def main() -> None:
         score_by_book=args.score_by_book,
     )
 
-    if not args.save_checkpoints:
+    if args.train and not args.save_checkpoints:
         SIL_NLP_ENV.delete_path_on_exit(get_mt_exp_dir(args.experiment) / "run")
     exp.run()
 


### PR DESCRIPTION
This PR aims to make translating via the `experiment.py` script more convenient.  It includes two changes:

1. Removing the logic that calls "preprocess," "train," and "test" if only `--translate` is included
2. Only deleting the experiment's checkpoints when `--train` is included without `--save-checkpoints`

Even though translation by itself can be done with the `translate.py` script, it is important to be able to run translation via the `experiment.py` script without retraining to make replicating reported issues more straightforward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/968)
<!-- Reviewable:end -->
