### PR TITLE
Allow running experiment with no stages specified

### DIFF
--- a/silnlp/nmt/experiment.py
+++ b/silnlp/nmt/experiment.py
@@ -262,6 +262,11 @@ def main() -> None:
         show_attrs(cli_args=args)
         exit()
 
+    if not (args.preprocess or args.train or args.test or args.translate):
+        args.preprocess = True
+        args.train = True
+        args.test = True
+
     exp = SILExperiment(
         name=args.experiment,
         make_stats=args.stats,


### PR DESCRIPTION
Yesterday's change to the `experiment.py` parameters had an unexpected side effect wherein users could no longer run `experiment.py` without any of the `--preprocess`, `--train`, `--test`, or `--translate` parameters.  This PR restores this behavior, while still allowing users to run the "translate" step without any of the others.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/970)
<!-- Reviewable:end -->
