### PR TITLE
Rename OnboardingRequests to _OnboardingRequests

### DIFF
--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -271,7 +271,7 @@ class OnboardingProject:
         align_config: Config = create_config(exp_dir=align_output_dir, config=align_config)
         collect_verse_counts_directory = Path(self.output_folder / "verse_counts")
         shutil.copytree(collect_verse_counts_directory, align_output_dir, dirs_exist_ok=True)
-        exp_name = f"OnboardingRequests/{self.project_name}/alignments"
+        exp_name = f"{self.output_folder.stem}/{self.project_name}/alignments"
         analyze(config=align_config, exp_name=exp_name, create_summaries=True)
 
     def check_for_project_errors(self) -> None:
@@ -342,7 +342,7 @@ class OnboardingProject:
             self.local_project_path = new_local_project_path
 
     def setup_output(self) -> None:
-        self.output_folder = Path(SIL_NLP_ENV.mt_experiments_dir / "OnboardingRequests" / self.project_name)
+        self.output_folder = Path(SIL_NLP_ENV.mt_experiments_dir / "_OnboardingRequests" / self.project_name)
         self.output_folder.mkdir(parents=True, exist_ok=True)
         log_file = open(
             self.output_folder / f"{self.project_name}_onboarding.log",


### PR DESCRIPTION
This change puts the onboarding output folder at the top of the list in File Explorer, making it easier to find. This was requested by the EITL team for convenience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/974)
<!-- Reviewable:end -->
