### PR TITLE
Allow Multiple Main Projects for Onboarding

### DIFF
--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -785,7 +785,7 @@ def main() -> None:
             args.clearml_tag,
             *project_names,
         ]
-        task_name = f"Onboarding - {onboarding_request.main_project.project_name}"
+        task_name = f"Onboarding - {', '.join([req.main_project.project_name for req in onboarding_requests])}"
         clearml = SILClearML(task_name, args.clearml_queue, tag=args.clearml_tag, skip_config=True)
 
     for onboarding_request in onboarding_requests:


### PR DESCRIPTION
This PR updates onboard_project to allow the user to list multiple main projects to be onboarded, which restores functionality that used to be present before the addition of `--ref-projects`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/979)
<!-- Reviewable:end -->
