### PR TITLE
store slope and intercept in json object

### DIFF
--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 from abc import ABC
 from collections import defaultdict
@@ -196,7 +197,18 @@ def project_chrf3(
             f"The number of chrF3 scores ({len(chrf3_scores)}) and confidence scores ({len(confidence_scores)}) "
             f"in {verse_test_scores_path} do not match."
         )
+
     slope, intercept = linregress(confidence_scores, chrf3_scores)[:2]
+    slope = round(slope, 4)
+    intercept = round(intercept, 4)
+    linregress_data = {"version": "0.1", "slope": slope, "intercept": intercept}
+    LOGGER.info(f"Linear regression data:\n{json.dumps(linregress_data, indent=2)}")
+    output_dir = confidence_files[0].get_path().parent
+    output_file = output_dir / "linregress.json"
+    with open(output_file, "w", encoding="utf-8") as f:
+        LOGGER.info(f"Saving linear regression data to {output_file}")
+        json.dump(linregress_data, f, indent=2)
+
     verse_scores: List[VerseScore] = []
     chapter_scores: ChapterScores = ChapterScores()
     book_scores: BookScores = BookScores()


### PR DESCRIPTION
This addresses #964. The quality_estimation.py script now outputs a json object that contains a version number, the slope value, and the intercept value. This is stored in a file called `linregress.json` in the same directory as the confidence files, and it is also logged to the console.

Example output:
```
{
  "version": "0.1",
  "slope": 109.6145,
  "intercept": -14.0633
}
```

I have the version number set to "0.1". If we merge this in now, I could see us needing to update this again in the next quarter if the NT drafting project determines we need some additional information (e.g. correlation info, std error, book level adjustments) to make this more helpful to teams. If we don't want to have two versions, we could either hold off on merging this, or just leave off including the version number for now and only add the version number when we're fully ready for production. Thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/981)
<!-- Reviewable:end -->
