### PR TITLE
Added warning for empty extracts

### DIFF
--- a/silnlp/common/bulk_extract_corpora.py
+++ b/silnlp/common/bulk_extract_corpora.py
@@ -15,8 +15,18 @@ from ..common.environment import SIL_NLP_ENV
 from .paratext import extract_project, extract_term_renderings
 
 
-def extract_directory_or_bundle(args: Tuple[Path, Path, Optional[Path], bytes, bool, int, bool]) -> Tuple[str, Optional[str]]:
-    input_path, corpus_output_path, terms_output_path, password, output_project_vrefs, expected_verse_count, extract_surface_forms = args
+def extract_directory_or_bundle(
+    args: Tuple[Path, Path, Optional[Path], bytes, bool, int, bool],
+) -> Tuple[str, Optional[str]]:
+    (
+        input_path,
+        corpus_output_path,
+        terms_output_path,
+        password,
+        output_project_vrefs,
+        expected_verse_count,
+        extract_surface_forms,
+    ) = args
     project = input_path.stem
     try:
         if input_path.suffix == ".p8z":

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from pathlib import Path
 from typing import List, Optional, Set
 
 from machine.scripture import ORIGINAL_VERSIFICATION, VerseRef, get_books
@@ -105,7 +106,7 @@ def extract_corpora(
     extract_surface_forms=False,
     parent_project: Optional[str] = None,
     versification_error_output_path: Optional[str] = None,
-) -> None:
+) -> Path | None:
     # Process the projects that have data and tell the user.
     if len(projects) > 0:
         expected_verse_count = get_expected_verse_count(books_to_include, books_to_exclude)
@@ -133,14 +134,16 @@ def extract_corpora(
             # check if the number of lines in the file is correct (the same as vref.txt)
             LOGGER.info(f"# of Verses: {verse_count}")
             if verse_count != expected_verse_count:
-                LOGGER.error(f"The number of verses is {verse_count}, but should be {expected_verse_count}.")
+                LOGGER.warning(f"The number of verses is {verse_count}, but should be {expected_verse_count}.")
             terms_count = extract_term_renderings(
                 project_dir, corpus_filename, SIL_NLP_ENV.mt_terms_dir, extract_surface_forms
             )
             LOGGER.info(f"# of Terms: {terms_count}")
             LOGGER.info("Done.")
+            return corpus_filename
     else:
         LOGGER.warning(f"Couldn't find any data to process for any project in {SIL_NLP_ENV.pt_projects_dir}.")
+        return None
 
 
 if __name__ == "__main__":

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -94,7 +94,7 @@ class OnboardingProject:
         versification_error_output_path = Path(self.output_folder / "versification_errors.txt")
         if not versification_error_output_path.exists():
             versification_error_output_path.parent.mkdir(parents=True, exist_ok=True)
-        extract_corpora(
+        extract_path = extract_corpora(
             projects={self.project_name},
             books_to_include=extract_config.get("include", []),
             books_to_exclude=extract_config.get("exclude", []),
@@ -105,6 +105,7 @@ class OnboardingProject:
             parent_project=extract_config.get("parent_project", None),
             versification_error_output_path=versification_error_output_path,
         )
+        self.extract_file = extract_path
 
     def wildebeest_analysis_wrapper(self, wildebeest_config: dict) -> None:
         wildebeest_output_dir = Path(self.output_folder / "wildebeest")
@@ -436,10 +437,22 @@ class OnboardingRequest:
             close_logger()
 
         set_logger(self.main_project.log_file_path)
+
+        if self.main_project.get_extract_path() is None and (self.stats or self.align):
+            LOGGER.error(
+                f"Main Project, {self.main_project.project_name}, has no extract file. Skipping stats and alignments."
+            )
+            close_logger()
+            return
+
         if self.stats:
             self.main_project.calculate_tokenization_stats(
                 self.config.get("stats", None),
-                [ref_project.get_extract_path().stem for ref_project in self.reference_projects],
+                [
+                    ref_project.get_extract_path().stem
+                    for ref_project in self.reference_projects
+                    if ref_project.get_extract_path() is not None
+                ],
                 [ref_project.get_extract_iso_code() for ref_project in self.reference_projects],
             )
 
@@ -515,6 +528,11 @@ class OnboardingRequest:
         set_logger(onboarding_project.log_file_path)
         if self.extract_corpora:
             onboarding_project.extract_corpora_wrapper(self.config.get("extract_corpora", {}))
+            if onboarding_project.get_extract_path() is None:
+                LOGGER.error(
+                    f"No extract file was created for {onboarding_project.project_name}. Stopping onboarding of this project."
+                )
+                return
 
         if self.collect_verse_counts:
             onboarding_project.collect_verse_counts_wrapper(self.config.get("verse_counts", {}))

--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -144,7 +144,15 @@ def extract_project(
                 output_stream.write(line + "\n")
                 if output_vref_stream is not None:
                     output_vref_stream.write(("" if project_vref is None else str(project_vref)) + "\n")
-                segment_count += 1
+                stripped_line = line.strip()
+                if len(stripped_line) > 0 and stripped_line != "<range>" and stripped_line != "...":
+                    segment_count += 1
+        if segment_count == 0:
+            if output_filename.is_file():
+                output_filename.unlink()
+            if output_vref_filename.is_file():
+                output_vref_filename.unlink()
+            return None, segment_count
         return output_filename, segment_count
     except Exception:
         if output_filename.is_file():


### PR DESCRIPTION
- If an extract file would be empty or only contain `...`, then the extract file is deleted and a warning is logged. 
- Segments are now only counted if they contain content, meaning the warning will be more common. 
- `extract_corpora` will return the path to the extract file if it is created.
- `onboard_project` will stop onboarding a project if there is no extract file, rather than failing later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/983)
<!-- Reviewable:end -->
