### PR TITLE
Multilingual inference (separate pipeline for each language pair)

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1182,19 +1182,14 @@ class HuggingFaceNMTModel(NMTModel):
     ) -> None:
         tokenizer = self._config.get_tokenizer()
         model = self._create_inference_model(ckpt, tokenizer, self._config.test_src_lang, self._config.test_trg_lang)
-        pipeline = PretokenizedTranslationPipeline(
-            model=model,
-            tokenizer=tokenizer,
-            src_lang=self._config.test_src_lang,
-            tgt_lang=self._config.test_trg_lang,
-            device=0,
-        )
-        pipeline.model = torch.compile(pipeline.model)
+
         for input_path, translation_path, vref_path in zip(
             input_paths,
             translation_paths,
             cast(Iterable[Optional[Path]], repeat(None) if vref_paths is None else vref_paths),
         ):
+            pipeline = self._create_pipeline_for_test_file(input_path, model, tokenizer)
+
             length = count_lines(input_path)
             with ExitStack() as stack:
                 src_file = stack.enter_context(input_path.open("r", encoding="utf-8-sig"))
@@ -1225,6 +1220,28 @@ class HuggingFaceNMTModel(NMTModel):
                             translated_draft,
                             translation_draft_path,
                         )
+
+    def _create_pipeline_for_test_file(
+        self, input_path: Path, model: PreTrainedModel, tokenizer: PreTrainedTokenizer
+    ) -> "PretokenizedTranslationPipeline":
+        iso_specified_file_pattern = re.compile(r"^test\.([a-z]{2,3})\.([a-z]{2,3})\..*")
+        if iso_specified_file_pattern.match(input_path.name):
+            src_iso, trg_iso = iso_specified_file_pattern.match(input_path.name).groups()
+            src_lang = self._config.data["lang_codes"].get(src_iso, src_iso)
+            trg_lang = self._config.data["lang_codes"].get(trg_iso, trg_iso)
+        else:
+            src_lang = self._config.test_src_lang
+            trg_lang = self._config.test_trg_lang
+
+        pipeline = PretokenizedTranslationPipeline(
+            model=model,
+            tokenizer=tokenizer,
+            src_lang=src_lang,
+            tgt_lang=trg_lang,
+            device=0,
+        )
+        pipeline.model = torch.compile(pipeline.model)
+        return pipeline
 
     def _translate_test_sentences(
         self,

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1970,6 +1970,7 @@ class SilTranslationPipeline(TranslationPipeline):
         output = self.model.generate(
             **model_inputs,
             **generate_kwargs,
+            generation_config=config,
             output_scores=True,
             return_dict_in_generate=True,
         )

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1791,8 +1791,7 @@ class HuggingFaceNMTModel(NMTModel):
             model = model.to_bettertransformer()
         if model_name == self._config.model and len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
             model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None)
-        if self._config.model_prefix == "google/madlad400" or model_name == self._config.model:
-            model, tokenizer = self._configure_model(model, tokenizer, src_lang, trg_lang)
+        model, tokenizer = self._configure_model(model, tokenizer, src_lang, trg_lang)
 
         return model
 

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1182,13 +1182,14 @@ class HuggingFaceNMTModel(NMTModel):
     ) -> None:
         tokenizer = self._config.get_tokenizer()
         model = self._create_inference_model(ckpt, tokenizer, self._config.test_src_lang, self._config.test_trg_lang)
+        compiled_model = cast(PreTrainedModel, torch.compile(model))
 
         for input_path, translation_path, vref_path in zip(
             input_paths,
             translation_paths,
             cast(Iterable[Optional[Path]], repeat(None) if vref_paths is None else vref_paths),
         ):
-            pipeline = self._create_pipeline_for_test_file(input_path, model, tokenizer)
+            pipeline = self._create_pipeline_for_test_file(input_path, model, compiled_model, tokenizer)
 
             length = count_lines(input_path)
             with ExitStack() as stack:
@@ -1222,7 +1223,7 @@ class HuggingFaceNMTModel(NMTModel):
                         )
 
     def _create_pipeline_for_test_file(
-        self, input_path: Path, model: PreTrainedModel, tokenizer: PreTrainedTokenizer
+        self, input_path: Path, model: PreTrainedModel, compiled_model: PreTrainedModel, tokenizer: PreTrainedTokenizer
     ) -> "PretokenizedTranslationPipeline":
         iso_specified_file_pattern = re.compile(r"^test\.([a-z]{2,3})\.([a-z]{2,3})\..*")
         if iso_specified_file_pattern.match(input_path.name):
@@ -1240,7 +1241,7 @@ class HuggingFaceNMTModel(NMTModel):
             tgt_lang=trg_lang,
             device=0,
         )
-        pipeline.model = torch.compile(pipeline.model)
+        pipeline.model = compiled_model
         return pipeline
 
     def _translate_test_sentences(


### PR DESCRIPTION
This is a revised version of the earlier multilingual inference PR, but this version is more limited in its scope, assuming that every test file will represent a single language pair.  The major changes are

* A new `SilTranslationPipeline` is created for each test file
* If the language codes are part of the test file name (e.g. `test.en.fr.src.txt`), the language codes will be extracted from the file name
* Otherwise, they will come from the model's config
* The method `_configure_model` is now called for saved models (previously was only called for non-finetuned models and MADLAD)
* The model's generation config is explicitly passed to the `generate` method (this keeps Huggingface from overwriting the generation config during the pipeline for obscure reasons)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/987)
<!-- Reviewable:end -->
