### PR TITLE
Reduce wait time for hanging rclone transfers

### DIFF
--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -128,7 +128,7 @@ def check_transfers() -> None:
     LOGGER.info("Checking rclone transfer progress.")
     time.sleep(60)  # wait for the latest poll interval
     transfers_complete = False
-    for i in range(4):
+    for i in range(3):
         with open("/root/rclone_log.txt", "r", encoding="utf-8") as log_file:
             log_lines = log_file.readlines()
         for line in reversed(log_lines):
@@ -142,7 +142,7 @@ def check_transfers() -> None:
         else:
             LOGGER.info(line)
             LOGGER.info(f"rclone transfers are still in progress. Waiting {2**i} minutes.")
-        time.sleep(60 * (2**i))  # exponential backoff, max 8 minutes, total wait time 15 minutes
+        time.sleep(60 * (2**i))  # exponential backoff, max 4 minutes, total wait time 8 minutes
     if not transfers_complete:
         LOGGER.warning("rclone transfers could not be completed. Some data may be lost or corrupted.")
 

--- a/silnlp/common/environment.py
+++ b/silnlp/common/environment.py
@@ -128,7 +128,7 @@ def check_transfers() -> None:
     LOGGER.info("Checking rclone transfer progress.")
     time.sleep(60)  # wait for the latest poll interval
     transfers_complete = False
-    for i in range(3):
+    for i in range(7):
         with open("/root/rclone_log.txt", "r", encoding="utf-8") as log_file:
             log_lines = log_file.readlines()
         for line in reversed(log_lines):
@@ -141,8 +141,8 @@ def check_transfers() -> None:
             break
         else:
             LOGGER.info(line)
-            LOGGER.info(f"rclone transfers are still in progress. Waiting {2**i} minutes.")
-        time.sleep(60 * (2**i))  # exponential backoff, max 4 minutes, total wait time 8 minutes
+            LOGGER.info(f"rclone transfers are still in progress. Waiting another minute. Attempt {i+1} of 7.")
+        time.sleep(60)
     if not transfers_complete:
         LOGGER.warning("rclone transfers could not be completed. Some data may be lost or corrupted.")
 


### PR DESCRIPTION
This PR reduces the wait time for checking rclone transfers from a total of 15 minutes to a total of 8 minutes. Waiting the extra time seems to not fix any issue. This could potentially be reduced even further, as the error is usually caused by some file being left open by the Task and will not resolve itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/993)
<!-- Reviewable:end -->
