### PR TITLE
Rework some log messages during onboarding

### DIFF
--- a/silnlp/common/analyze.py
+++ b/silnlp/common/analyze.py
@@ -86,16 +86,14 @@ def get_corpus_stats(config: Config, exp_name: str, force_align: bool = False, d
                 pair_stats_path = alt_pair_stats_path
 
             if pair_stats_path.is_file():
-                LOGGER.info(f"\n\nFound alignment scores between {source} and {target} in file: {pair_stats_path}")
+                LOGGER.info(f"Found alignment scores between {source} and {target} in file: {pair_stats_path}")
                 pair_stats = pd.read_csv(pair_stats_path)
                 pair_stats["idx"] = corpus.index
                 pair_stats.set_index("idx", inplace=True)
                 corpus.insert(3, "score", pair_stats["score"])
             else:
                 aligner_id = config.data["aligner"]
-                LOGGER.info(
-                    f"\n\nComputing alignment beteween {source} and {target} using {get_aligner_name(aligner_id)}"
-                )
+                LOGGER.info(f"Computing alignment beteween {source} and {target} using {get_aligner_name(aligner_id)}")
                 add_alignment_scores(corpus, aligner_id)
                 corpus.to_csv(pair_stats_path, index=False)
 

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -134,7 +134,9 @@ def extract_corpora(
             # check if the number of lines in the file is correct (the same as vref.txt)
             LOGGER.info(f"# of Verses: {verse_count}")
             if verse_count != expected_verse_count:
-                LOGGER.warning(f"The number of verses is {verse_count}, but should be {expected_verse_count}.")
+                LOGGER.info(
+                    f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
+                )
             terms_count = extract_term_renderings(
                 project_dir, corpus_filename, SIL_NLP_ENV.mt_terms_dir, extract_surface_forms
             )


### PR DESCRIPTION
This PR lowers the verse counts warning in `extract_corpora` to just an informational message, and it removes some unneeded newlines in log messages during `analyze`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1000)
<!-- Reviewable:end -->
