### PR TITLE
Automatically onboard partner projects

### DIFF
--- a/scripts/onboarding_requests.py
+++ b/scripts/onboarding_requests.py
@@ -131,10 +131,7 @@ def get_project_metadata(onboarding_request: dict) -> Tuple[Dict[str, str], str]
     main_project_name = ""
     form_data = onboarding_request["submission"]["formData"]
     if form_data.get("partnerOrganization") != "none":
-        add_comment(
-            onboarding_request["id"], "This request is for a partner organization. Skipping automatic onboarding."
-        )
-        return {}, ""
+        add_comment(onboarding_request["id"], "This request is for a partner organization.")
     project_keys = [
         "projectId",
         "sourceProjectA",


### PR DESCRIPTION
The EITL team has requested that projects from Partner Organizations should still be automatically onboarded. Previously, they were being skipped with a comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1047)
<!-- Reviewable:end -->
