### PR TITLE
Remove `--include` and `--exclude` from extract_corpora

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -18,35 +18,9 @@ from .paratext import (
 LOGGER = logging.getLogger(__package__ + ".extract_corpora")
 
 
-def get_expected_verse_count(include: List[str], exclude: List[str]) -> int:
-    include_books_set = get_books(include) if len(include) > 0 else None
-    exclude_books_set = get_books(exclude) if len(exclude) > 0 else None
-
-    def filter_lines(verse_ref_str: str) -> bool:
-        if include_books_set is None and exclude_books_set is None:
-            return True
-
-        vref = VerseRef.from_string(verse_ref_str.strip(), ORIGINAL_VERSIFICATION)
-        if exclude_books_set is not None and vref.book_num in exclude_books_set:
-            return False
-
-        if include_books_set is not None and vref.book_num in include_books_set:
-            return True
-
-        return include_books_set is None
-
-    return count_lines(SIL_NLP_ENV.assets_dir / "vref.txt", filter_lines)
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="Extracts text corpora from Paratext projects")
     parser.add_argument("projects", nargs="+", metavar="name", help="Paratext project")
-    parser.add_argument(
-        "--include", metavar="books", nargs="+", default=[], help="The books to include; e.g., 'NT', 'OT', 'GEN'"
-    )
-    parser.add_argument(
-        "--exclude", metavar="books", nargs="+", default=[], help="The books to exclude; e.g., 'NT', 'OT', 'GEN'"
-    )
     parser.add_argument("--parent-project", default=None, help="The parent Paratext project")
     parser.add_argument(
         "--versification-error-output-path",
@@ -81,8 +55,6 @@ def main() -> None:
             projects_found.add(project)
     extract_corpora(
         projects=projects_found,
-        books_to_include=args.include,
-        books_to_exclude=args.exclude,
         include_markers=args.markers,
         extract_lemmas=args.lemmas,
         extract_project_vrefs=args.project_vrefs,
@@ -98,8 +70,6 @@ def main() -> None:
 
 def extract_corpora(
     projects: Set[str],
-    books_to_include=[],
-    books_to_exclude=[],
     include_markers=False,
     extract_lemmas=False,
     extract_project_vrefs=False,
@@ -109,7 +79,7 @@ def extract_corpora(
 ) -> Path | None:
     # Process the projects that have data and tell the user.
     if len(projects) > 0:
-        expected_verse_count = get_expected_verse_count(books_to_include, books_to_exclude)
+        expected_verse_count = count_lines(SIL_NLP_ENV.assets_dir / "vref.txt", True)
         SIL_NLP_ENV.mt_scripture_dir.mkdir(exist_ok=True, parents=True)
         SIL_NLP_ENV.mt_terms_dir.mkdir(exist_ok=True, parents=True)
         for project in projects:
@@ -123,8 +93,6 @@ def extract_corpora(
             corpus_filename, verse_count = extract_project(
                 project_dir,
                 SIL_NLP_ENV.mt_scripture_dir,
-                books_to_include,
-                books_to_exclude,
                 include_markers,
                 extract_lemmas,
                 extract_project_vrefs,

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -60,8 +60,6 @@ class OnboardingProject:
         versification_error_output_path = Path(self.output_folder / f"versification_errors_{self.project_name}.txt")
         extract_path = extract_corpora(
             projects={self.project_name},
-            books_to_include=extract_config.get("include", []),
-            books_to_exclude=extract_config.get("exclude", []),
             include_markers=extract_config.get("markers", False),
             extract_lemmas=extract_config.get("lemmas", False),
             extract_project_vrefs=extract_config.get("project-vrefs", False),

--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -78,8 +78,6 @@ def get_iso(project_dir: Path) -> str:
 def extract_project(
     project_dir: Path,
     output_dir: Path,
-    include_books: List[str] = [],
-    exclude_books: List[str] = [],
     include_markers: bool = False,
     extract_lemmas: bool = False,
     output_project_vrefs: bool = False,
@@ -98,31 +96,6 @@ def extract_project(
         )
 
     output_basename = f"{iso}-{project_dir.name}"
-    if len(include_books) > 0 or len(exclude_books) > 0:
-        output_basename += "_"
-        include_books_set: Optional[Set[int]] = None
-        if len(include_books) > 0:
-            include_books_set = get_books(include_books)
-            for text in include_books:
-                output_basename += f"+{text}"
-        exclude_books_set: Optional[Set[int]] = None
-        if len(exclude_books) > 0:
-            exclude_books_set = get_books(exclude_books)
-            for text in exclude_books:
-                output_basename += f"-{text}"
-
-        def filter_corpus(text: Text) -> bool:
-            book_num = book_id_to_number(text.id)
-            if exclude_books_set is not None and book_num in exclude_books_set:
-                return False
-
-            if include_books_set is not None and book_num in include_books_set:
-                return True
-
-            return include_books_set is None
-
-        ref_corpus = ref_corpus.filter_texts(filter_corpus)
-        project_corpus = project_corpus.filter_texts(filter_corpus)
 
     if include_markers:
         output_basename += "-m"


### PR DESCRIPTION
This PR removes the `--include` and `--exclude` options and their functionality from `extract_corpora`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1052)
<!-- Reviewable:end -->
