### PR TITLE
revert merged commit, add value error for vocab mismatch

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1907,7 +1907,7 @@ class HuggingFaceNMTModel(NMTModel):
             if model.generation_config is not None:
                 model.generation_config.forced_bos_token_id = forced_bos_token_id
 
-        if len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
+        if len(tokenizer) > model.get_input_embeddings().weight.size(dim=0):
             raise ValueError(
                 f"Tokenizer vocab size ({len(tokenizer)}) does not match the model's embedding vocab size "
                 f"({model.get_input_embeddings().weight.size(dim=0)}). Ensure you are using the correct "

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1907,7 +1907,7 @@ class HuggingFaceNMTModel(NMTModel):
             if model.generation_config is not None:
                 model.generation_config.forced_bos_token_id = forced_bos_token_id
 
-        if len(tokenizer) > model.get_input_embeddings().weight.size(dim=0):
+        if len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
             raise ValueError(
                 f"Tokenizer vocab size ({len(tokenizer)}) does not match the model's embedding vocab size "
                 f"({model.get_input_embeddings().weight.size(dim=0)}). Ensure you are using the correct "

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1856,8 +1856,6 @@ class HuggingFaceNMTModel(NMTModel):
             model: PreTrainedModel = self._pretrained_model_provider.create_model_for_inference(model_name)
         if self._config.infer.get("better_transformer"):
             model = model.to_bettertransformer()
-        if model_name == self._config.model and len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
-            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None)
         model, tokenizer = self._configure_model(model, tokenizer, src_lang, trg_lang)
 
         if model.generation_config is not None and (
@@ -1907,7 +1905,7 @@ class HuggingFaceNMTModel(NMTModel):
             if model.generation_config is not None:
                 model.generation_config.forced_bos_token_id = forced_bos_token_id
 
-        if len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
+        if len(tokenizer) > model.get_input_embeddings().weight.size(dim=0):
             raise ValueError(
                 f"Tokenizer vocab size ({len(tokenizer)}) does not match the model's embedding vocab size "
                 f"({model.get_input_embeddings().weight.size(dim=0)}). Ensure you are using the correct "

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1039,7 +1039,7 @@ class HuggingFaceNMTModel(NMTModel):
             embeddings = model.get_input_embeddings()
             embeddings.weight.data[old_num_tokens:, :] = unk_embedding
             model.tie_weights()
-        elif len(tokenizer) != old_num_tokens:
+        elif len(tokenizer) > old_num_tokens:
             model.resize_token_embeddings(
                 len(tokenizer), pad_to_multiple_of=8 if training_args.fp16 or training_args.bf16 else None
             )

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1856,6 +1856,8 @@ class HuggingFaceNMTModel(NMTModel):
             model: PreTrainedModel = self._pretrained_model_provider.create_model_for_inference(model_name)
         if self._config.infer.get("better_transformer"):
             model = model.to_bettertransformer()
+        if model_name == self._config.model and len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
+            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None)
         model, tokenizer = self._configure_model(model, tokenizer, src_lang, trg_lang)
 
         if model.generation_config is not None and (
@@ -1906,11 +1908,11 @@ class HuggingFaceNMTModel(NMTModel):
                 model.generation_config.forced_bos_token_id = forced_bos_token_id
 
         if len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
-            LOGGER.warning(
-                f"Tokenizer vocab size ({len(tokenizer)}) does not match model's input embedding vocab size "
-                f"({model.get_input_embeddings().weight.size(dim=0)}). Resizing model embeddings."
+            raise ValueError(
+                f"Tokenizer vocab size ({len(tokenizer)}) does not match the model's embedding vocab size "
+                f"({model.get_input_embeddings().weight.size(dim=0)}). Ensure you are using the correct "
+                f"tokenizer for this checkpoint."
             )
-            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None)
 
         return model, tokenizer
 


### PR DESCRIPTION
This replaces the previous fix for issue #1033 by now throwing a value error if the tokenizer vocab size does not match the checkpoint vocab size.

In removing some of the previous changes and going back to how the repo was before, I see that
```
if model_name == self._config.model and len(tokenizer) != model.get_input_embeddings().weight.size(dim=0):
            model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8 if self._mixed_precision else None)
```
was already present before. What's the motivation for needing to resize the base model vocab at inference? Should I remove this as well?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1053)
<!-- Reviewable:end -->
