### PR TITLE
Remove incorrect parameter passed into count_lines()

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -79,7 +79,7 @@ def extract_corpora(
 ) -> Path | None:
     # Process the projects that have data and tell the user.
     if len(projects) > 0:
-        expected_verse_count = count_lines(SIL_NLP_ENV.assets_dir / "vref.txt", True)
+        expected_verse_count = count_lines(SIL_NLP_ENV.assets_dir / "vref.txt")
         SIL_NLP_ENV.mt_scripture_dir.mkdir(exist_ok=True, parents=True)
         SIL_NLP_ENV.mt_terms_dir.mkdir(exist_ok=True, parents=True)
         for project in projects:


### PR DESCRIPTION
This fixes a bug that was introduced in this [PR](https://github.com/sillsdev/silnlp/pull/1052).  The bug would cause a crash during extract with the error message: `TypeError: 'bool' object is not callable`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1055)
<!-- Reviewable:end -->
