### PR TITLE
Add a token occurrence log file

### DIFF
--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -162,12 +162,18 @@ class OnboardingProject:
 
         tokenization_stats_csv = stats_dir / "tokenization_stats.csv"
         tokenization_stats_xlsx = stats_dir / "tokenization_stats.xlsx"
+        token_occurrence_log = stats_dir / "token_occurrence.log"
         if tokenization_stats_csv.exists():
             shutil.move(str(tokenization_stats_csv), str(self.output_folder / "tokenization_stats.csv"))
         if tokenization_stats_xlsx.exists():
             shutil.move(
                 str(tokenization_stats_xlsx),
                 str(self.output_folder / "tokenization_stats.xlsx"),
+            )
+        if token_occurrence_log.exists():
+            shutil.move(
+                str(token_occurrence_log),
+                str(self.output_folder / "token_occurrence.log"),
             )
 
     def align_wrapper(

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -585,7 +585,8 @@ class HuggingFaceConfig(Config):
         sp_tokenizer = self._train_sp_tokenizer(files, vocab_size)
         sp_keys, tok_keys = sp_tokenizer.get_vocab().keys(), self._tokenizer.get_vocab().keys()
         missing_tokens = sorted(list(set(sp_keys) - set(tok_keys)))
-        TokenOccurrenceLogger(list(file_paths), self.exp_dir).log(missing_tokens)
+        with TokenOccurrenceLogger(list(file_paths), self.exp_dir) as token_occurrence_logger:
+            token_occurrence_logger.log(missing_tokens)
         return missing_tokens, sp_tokenizer
 
     def _find_missing_characters(self, corpus: List[Path]) -> List[str]:
@@ -602,7 +603,8 @@ class HuggingFaceConfig(Config):
 
         charset = set(filter(None, {char.strip() for char in charset}))
         missing_characters = sorted(list(charset - vocab))
-        TokenOccurrenceLogger(corpus, self.exp_dir).log(missing_characters)
+        with TokenOccurrenceLogger(corpus, self.exp_dir) as token_occurrence_logger:
+            token_occurrence_logger.log(missing_characters)
         return missing_characters
 
     def _build_vocabs(self, stats: bool = False) -> None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -585,7 +585,7 @@ class HuggingFaceConfig(Config):
         sp_tokenizer = self._train_sp_tokenizer(files, vocab_size)
         sp_keys, tok_keys = sp_tokenizer.get_vocab().keys(), self._tokenizer.get_vocab().keys()
         missing_tokens = sorted(list(set(sp_keys) - set(tok_keys)))
-        TokenOccurrenceLogger(list(file_paths)).log(missing_tokens)
+        TokenOccurrenceLogger(list(file_paths), self.exp_dir).log(missing_tokens)
         return missing_tokens, sp_tokenizer
 
     def _find_missing_characters(self, corpus: List[Path]) -> List[str]:
@@ -602,7 +602,7 @@ class HuggingFaceConfig(Config):
 
         charset = set(filter(None, {char.strip() for char in charset}))
         missing_characters = sorted(list(charset - vocab))
-        TokenOccurrenceLogger(corpus).log(missing_characters)
+        TokenOccurrenceLogger(corpus, self.exp_dir).log(missing_characters)
         return missing_characters
 
     def _build_vocabs(self, stats: bool = False) -> None:

--- a/silnlp/nmt/token_occurrence_logger.py
+++ b/silnlp/nmt/token_occurrence_logger.py
@@ -90,7 +90,6 @@ class TokenOccurrenceLogger:
 
         self._output_file.parent.mkdir(parents=True, exist_ok=True)
         self._output_file.touch(exist_ok=True)
-        self._log_message(f"Initialized TokenOccurrenceLogger.")
 
     def log(self, missing_tokens: List[str]) -> None:
         """Log details for each token in missing_tokens."""

--- a/silnlp/nmt/token_occurrence_logger.py
+++ b/silnlp/nmt/token_occurrence_logger.py
@@ -2,7 +2,7 @@ import logging
 import re
 import unicodedata
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, IO
 
 LOGGER = logging.getLogger(__name__)
 
@@ -79,6 +79,10 @@ class TokenOccurrenceLogger:
     - the token (repr) and the Unicode code point/name for every character it contains
     - for each corpus file: the total occurrence count and up to
       ``max_lines`` 1-based line numbers where the token was found
+
+    Use as a context manager to keep the log file open during logging operations:
+        with TokenOccurrenceLogger(file_paths, output_path) as logger:
+            logger.log(missing_tokens)
     """
 
     def __init__(
@@ -87,9 +91,21 @@ class TokenOccurrenceLogger:
         self._file_paths = file_paths
         self._output_path = output_path / "token_occurrence.log"
         self._max_lines = max_lines
+        self._file: Optional[IO] = None
 
-        self._output_file.parent.mkdir(parents=True, exist_ok=True)
-        self._output_file.touch(exist_ok=True)
+        self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._output_path.touch(exist_ok=True)
+
+    def __enter__(self) -> "TokenOccurrenceLogger":
+        """Open the log file for writing when entering the context."""
+        self._file = open(self._output_path, "a", encoding="utf-8")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Close the log file when exiting the context."""
+        if self._file:
+            self._file.close()
+            self._file = None
 
     def log(self, missing_tokens: List[str]) -> None:
         """Log details for each token in missing_tokens."""
@@ -116,6 +132,10 @@ class TokenOccurrenceLogger:
             self._log_message(f"  File: {file_path.name}\n  Occurrences: {total_count}\n  Lines: {lines_str}\n")
 
     def _log_message(self, message: str) -> None:
+        """Log a message to both the logger and the file.
+
+        The log file must be open when this is called (i.e., within a context manager).
+        """
         LOGGER.info(message)
-        with open(self._output_file, "a", encoding="utf-8") as f:
-            f.write(message + "\n")
+        if self._file:
+            self._file.write(message + "\n")

--- a/silnlp/nmt/token_occurrence_logger.py
+++ b/silnlp/nmt/token_occurrence_logger.py
@@ -44,9 +44,7 @@ def _build_search_pattern(token: str) -> Optional[re.Pattern]:
     return re.compile(escaped)
 
 
-def _count_file_occurrences(
-    file_path: Path, pattern: re.Pattern, max_lines: int
-) -> Tuple[int, List[int], bool]:
+def _count_file_occurrences(file_path: Path, pattern: re.Pattern, max_lines: int) -> Tuple[int, List[int], bool]:
     """Scan file_path for matches of pattern and return occurrence statistics.
 
     Returns:
@@ -83,9 +81,23 @@ class TokenOccurrenceLogger:
       ``max_lines`` 1-based line numbers where the token was found
     """
 
-    def __init__(self, file_paths: List[Path], max_lines: int = _MAX_LOGGED_OCCURRENCE_LINES) -> None:
+    def __init__(
+        self, file_paths: List[Path], output_path: Path, max_lines: int = _MAX_LOGGED_OCCURRENCE_LINES
+    ) -> None:
         self._file_paths = file_paths
+        self._output_path = output_path / "token_occurrence.log"
         self._max_lines = max_lines
+
+        self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._output_path.touch(exist_ok=True)
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            handlers=[
+                logging.FileHandler(self._output_path, mode="a", encoding="utf-8"),
+            ],
+            force=True,
+        )
 
     def log(self, missing_tokens: List[str]) -> None:
         """Log details for each token in missing_tokens."""
@@ -104,9 +116,7 @@ class TokenOccurrenceLogger:
             self._log_file_occurrences(file_path, pattern)
 
     def _log_file_occurrences(self, file_path: Path, pattern: re.Pattern) -> None:
-        total_count, occurrence_lines, truncated = _count_file_occurrences(
-            file_path, pattern, self._max_lines
-        )
+        total_count, occurrence_lines, truncated = _count_file_occurrences(file_path, pattern, self._max_lines)
         if total_count > 0:
             lines_str = str(occurrence_lines)
             if truncated:

--- a/silnlp/nmt/token_occurrence_logger.py
+++ b/silnlp/nmt/token_occurrence_logger.py
@@ -88,27 +88,20 @@ class TokenOccurrenceLogger:
         self._output_path = output_path / "token_occurrence.log"
         self._max_lines = max_lines
 
-        self._output_path.parent.mkdir(parents=True, exist_ok=True)
-        self._output_path.touch(exist_ok=True)
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[
-                logging.FileHandler(self._output_path, mode="a", encoding="utf-8"),
-            ],
-            force=True,
-        )
+        self._output_file.parent.mkdir(parents=True, exist_ok=True)
+        self._output_file.touch(exist_ok=True)
+        self._log_message(f"Initialized TokenOccurrenceLogger.")
 
     def log(self, missing_tokens: List[str]) -> None:
         """Log details for each token in missing_tokens."""
         if not missing_tokens:
             return
-        LOGGER.info("Adding %d new token(s) to the tokenizer:", len(missing_tokens))
+        self._log_message(f"\nLogging occurrence details for {len(missing_tokens)} missing tokens...")
         for token in missing_tokens:
             self._log_token(token)
 
     def _log_token(self, token: str) -> None:
-        LOGGER.info("  Token: %s  Unicode: [%s]", repr(token), _get_unicode_details(token))
+        self._log_message(f"\nToken: {repr(token)}\nUnicode: [{_get_unicode_details(token)}]\n")
         pattern = _build_search_pattern(token)
         if pattern is None:
             return
@@ -121,9 +114,9 @@ class TokenOccurrenceLogger:
             lines_str = str(occurrence_lines)
             if truncated:
                 lines_str += f" (showing first {self._max_lines} of more)"
-            LOGGER.info(
-                "    File: %s  Occurrences: %d  Lines: %s",
-                file_path.name,
-                total_count,
-                lines_str,
-            )
+            self._log_message(f"  File: {file_path.name}\n  Occurrences: {total_count}\n  Lines: {lines_str}\n")
+
+    def _log_message(self, message: str) -> None:
+        LOGGER.info(message)
+        with open(self._output_file, "a", encoding="utf-8") as f:
+            f.write(message + "\n")


### PR DESCRIPTION
This PR adds a `token_occurrence.log` file in the experiment directory to store the outputs of the `TokenOccurrenceLogger` class. During onboarding, the log file is copied to the project's request directory for easier access.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1056)
<!-- Reviewable:end -->
