### PR TITLE
Refactor and fix bug with generating resource hashes

### DIFF
--- a/scripts/onboarding_requests.py
+++ b/scripts/onboarding_requests.py
@@ -190,17 +190,14 @@ def append_datestamp(project_name: str) -> str:
     return f"{project_name}_{datestamp}"
 
 
-def rename_project(project_name: str, datestamp: bool, copy_from: Path | None) -> str:
-    is_resource = False
+def rename_project(project_name: str, datestamp: bool) -> str:
+    resource = False
     if project_name.endswith("_Resource"):
-        is_resource = True
-        resource_hash_path = copy_from / Path(f"{project_name}/.resource_hash") if copy_from else None
-        if resource_hash_path and not resource_hash_path.exists():
-            resource_hash_path.touch()
+        resource = True
         project_name = project_name.replace("_Resource", "")
     if "-" in project_name:
         project_name = project_name.replace("-", "_")
-    if datestamp and not is_resource:
+    if datestamp and not resource:
         project_name = append_datestamp(project_name)
     return project_name
 
@@ -237,9 +234,7 @@ def process_request(request):
             request["id"],
             f"This request is being automatically onboarded.\nClearML task: {task_name}.\nLink: {task.get_output_log_web_page()}",
         )
-        adjusted_name = rename_project(
-            main_project_name, True, Path(f"{OnboardingEnvironment.ONBOARDING_PATH}/{main_project_name}_Request")
-        )
+        adjusted_name = rename_project(main_project_name, True)
         add_comment(
             request["id"],
             f"Results will be stored in {OnboardingEnvironment.ONBOARDING_REQUESTS_BUCKET_DIR}/{adjusted_name}",

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -283,7 +283,7 @@ class OnboardingProject:
 
         self.check_for_project_errors()
 
-        self.project_name = rename_project(project_name=self.project_name, datestamp=datestamp, copy_from=copy_from)
+        self.project_name = self.rename_project(project_name=self.project_name, datestamp=datestamp)
 
         self.local_project_path = copy_project(
             project_name=self.project_name, local_project_path=self.local_project_path
@@ -296,8 +296,11 @@ class OnboardingProject:
         self.resource = resource_hash_path.exists()
         return self.resource
 
-    def generate_resource_hash(self) -> str:
-        resource_path = SIL_NLP_ENV.pt_projects_dir / self.project_name
+    def generate_resource_hash(self, resource_path: Path) -> str:
+        resource_hash_path = resource_path / ".resource_hash"
+        if resource_hash_path.exists():
+            with open(resource_hash_path, "r") as f:
+                return f.read().strip()
         resource_hash = hashlib.sha256()
         for root, dirs, files in os.walk(resource_path):
             dirs.sort()
@@ -312,28 +315,47 @@ class OnboardingProject:
                         resource_hash.update(chunk)
 
         resource_hash = resource_hash.hexdigest()
-        with open(resource_path / ".resource_hash", "w") as f:
+        resource_hash_path = resource_path / ".resource_hash"
+        resource_hash_path.parent.touch(exist_ok=True)
+        with open(resource_hash_path, "w") as f:
             f.write(resource_hash)
         return resource_hash
 
     def check_resource_hash(self) -> bool:
-        new_resource_hash = self.generate_resource_hash()
+        new_resource_hash = self.generate_resource_hash(self.local_project_path)
         old_resource_path = SIL_NLP_ENV.pt_projects_dir / self.project_name
-        old_resource_hash_path = old_resource_path / ".resource_hash"
-        old_resource_hash = None
-        if old_resource_hash_path.exists():
-            old_resource_hash = old_resource_hash_path.read_text().strip()
+        if not old_resource_path.exists():
+            return False
+        old_resource_hash = self.generate_resource_hash(SIL_NLP_ENV.pt_projects_dir / self.project_name)
         return new_resource_hash == old_resource_hash
 
     def update_resource(self) -> None:
         old_resource_path = SIL_NLP_ENV.pt_projects_dir / self.project_name
-
-        new_resource_name = append_datestamp(old_resource_path.name)
-        new_resource_path = old_resource_path.parent / new_resource_name
+        if not old_resource_path.exists():
+            LOGGER.info(
+                f"Resource '{self.project_name}' does not exist in the Paratext projects directory. Uploading new resource."
+            )
+            return
+        datestamped_resource_name = append_datestamp(old_resource_path.name)
+        new_resource_path = old_resource_path.parent / datestamped_resource_name
+        LOGGER.info(
+            f"Resource '{self.project_name}' is outdated, updating resource in the Paratext projects directory. The old version will be renamed to {datestamped_resource_name}."
+        )
         old_resource_path.rename(new_resource_path)
 
     def set_output_folder(self, output_folder: Path) -> None:
         self.output_folder = output_folder
+
+    def rename_project(self, project_name: str, datestamp: bool) -> str:
+        self.resource = False
+        if project_name.endswith("_Resource"):
+            self.resource = True
+            project_name = project_name.replace("_Resource", "")
+        if "-" in project_name:
+            project_name = project_name.replace("-", "_")
+        if datestamp and not self.resource:
+            project_name = append_datestamp(project_name)
+        return project_name
 
 
 class OnboardingRequest:
@@ -455,9 +477,6 @@ class OnboardingRequest:
             LOGGER.info(f"Resource '{onboarding_project.project_name}' is up to date. Skipping uploading.")
             return
         elif onboarding_project.is_resource():
-            LOGGER.info(
-                f"Resource '{onboarding_project.project_name}' is outdated. Uploading new version of the resource."
-            )
             onboarding_project.update_resource()
 
         if self.copy_from:
@@ -625,21 +644,6 @@ def append_datestamp(project_name: str) -> str:
     now = datetime.now()
     datestamp = now.strftime("%Y_%m_%d")
     return f"{project_name}_{datestamp}"
-
-
-def rename_project(project_name: str, datestamp: bool, copy_from: Path | None) -> str:
-    is_resource = False
-    if project_name.endswith("_Resource"):
-        is_resource = True
-        resource_hash_path = copy_from / Path(f"{project_name}/.resource_hash") if copy_from else None
-        if resource_hash_path and not resource_hash_path.exists():
-            resource_hash_path.touch()
-        project_name = project_name.replace("_Resource", "")
-    if "-" in project_name:
-        project_name = project_name.replace("-", "_")
-    if datestamp and not is_resource:
-        project_name = append_datestamp(project_name)
-    return project_name
 
 
 def main() -> None:


### PR DESCRIPTION
This PR refactors when the resource hash is generated for a PT Resource. The old version contained a bug that would cause a crash with the `.resource_hash` not being found. It also fixes another bug where the `generate_resource_hash` would only generate a hash for the version on the bucket.

Now, it will always generate a hash and store it in the `.resource_hash` file for both the version being onboarded and the version on the bucket, if it exists and the `.resource_hash` file does not exist.

Here are the 3 different results of comparing the hashes:
- If the hashes are the same, the onboarding version will not be uploaded. If it is different,
- If the hashes are different, the bucket version will be renamed with a current datestamp and the onboarding version will be uploaded with no datestamp
- If the Resource does not exist on the bucket already, the onboarding version will be uploaded.

This rework/fix should be both more accurate and not require old resources to always be reuploaded because they do not have a `.resource_hash` file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1057)
<!-- Reviewable:end -->
