### PR TITLE
Fix bug in token counting

### DIFF
--- a/silnlp/nmt/token_occurrence_logger.py
+++ b/silnlp/nmt/token_occurrence_logger.py
@@ -44,9 +44,7 @@ def _build_search_pattern(token: str) -> Optional[re.Pattern]:
     return re.compile(escaped)
 
 
-def _count_file_occurrences(
-    file_path: Path, pattern: re.Pattern, max_lines: int
-) -> Tuple[int, List[int], bool]:
+def _count_file_occurrences(file_path: Path, pattern: re.Pattern, max_lines: int) -> Tuple[int, List[int], bool]:
     """Scan file_path for matches of pattern and return occurrence statistics.
 
     Returns:
@@ -68,7 +66,6 @@ def _count_file_occurrences(
                         occurrence_lines.append(line_num)
                     else:
                         truncated = True
-                        break
     except OSError:
         pass
     return total_count, occurrence_lines, truncated
@@ -104,9 +101,7 @@ class TokenOccurrenceLogger:
             self._log_file_occurrences(file_path, pattern)
 
     def _log_file_occurrences(self, file_path: Path, pattern: re.Pattern) -> None:
-        total_count, occurrence_lines, truncated = _count_file_occurrences(
-            file_path, pattern, self._max_lines
-        )
+        total_count, occurrence_lines, truncated = _count_file_occurrences(file_path, pattern, self._max_lines)
         if total_count > 0:
             lines_str = str(occurrence_lines)
             if truncated:


### PR DESCRIPTION
This PR fixes a bug in the new token occurrence counting.  The log messages print a maximum of 10 matching line.  There was a bug where the total number of occurrences was not being counted correctly as the count was stopped after reaching 10 matching lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1058)
<!-- Reviewable:end -->
