### PR TITLE
Prevent crashes and skip reference projects that fail to upload

### DIFF
--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -443,12 +443,22 @@ class OnboardingRequest:
         if not self.copy_from:
             self.setup_output()
             return
+        reference_projects_to_remove = []
         for project in [self.main_project] + self.reference_projects:
             if project == self.main_project:
                 LOGGER.info(f"Preparing and Uploading main project '{self.main_project.project_name}'")
             else:
                 LOGGER.info(f"Preparing and Uploading reference project '{project.project_name}'")
-            self.upload_project(project)
+            try:
+                self.upload_project(project)
+            except Exception as e:
+                if project != self.main_project:
+                    LOGGER.error(f"Error occurred while uploading reference project '{project.project_name}': {e}")
+                    LOGGER.error(f"Continuing with onboarding without reference project '{project.project_name}'.")
+                    reference_projects_to_remove.append(project)
+
+        for project in reference_projects_to_remove:
+            self.reference_projects.remove(project)
 
         self.setup_output()
 


### PR DESCRIPTION
This PR adds some error catching to skip reference projects that fail during the upload process and continue to onboard the successful uploads. An error message will be displayed explaining which reference project failed and what the exception message was.

This prevents one broken project (caused by something like a missing/broken `Settings.xml` file) from stopping the entire automated onboarding process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1059)
<!-- Reviewable:end -->
