### PR TITLE
Add line count message and warning to extract_corpora

### DIFF
--- a/silnlp/common/bulk_extract_corpora.py
+++ b/silnlp/common/bulk_extract_corpora.py
@@ -35,13 +35,13 @@ def extract_directory_or_bundle(
                 with ZipFile(input_path, "r") as bundle_file:
                     bundle_file.extractall(project_dir, pwd=password)
 
-                corpus_path, verse_count = extract_project(
+                corpus_path, verse_count, line_count = extract_project(
                     project_dir, corpus_output_path, output_project_vrefs=output_project_vrefs
                 )
                 if terms_output_path is not None:
                     extract_term_renderings(project_dir, corpus_path, terms_output_path, extract_surface_forms)
         else:
-            corpus_path, verse_count = extract_project(
+            corpus_path, verse_count, line_count = extract_project(
                 input_path, corpus_output_path, output_project_vrefs=output_project_vrefs
             )
             if terms_output_path is not None:

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -90,7 +90,7 @@ def extract_corpora(
                 LOGGER.info(f"Identified parent project {parent_project_dir.name}.")
 
             check_versification(project_dir, parent_project_dir, versification_error_output_path)
-            corpus_filename, verse_count = extract_project(
+            corpus_filename, verse_count, line_count = extract_project(
                 project_dir,
                 SIL_NLP_ENV.mt_scripture_dir,
                 include_markers,
@@ -101,9 +101,14 @@ def extract_corpora(
             LOGGER.info(f"Extracted corpus file: {corpus_filename}")
             # check if the number of lines in the file is correct (the same as vref.txt)
             LOGGER.info(f"# of Verses: {verse_count}")
+            LOGGER.info(f"# of Lines: {line_count}")
             if verse_count != expected_verse_count:
                 LOGGER.info(
                     f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
+                )
+            if line_count > expected_verse_count:
+                LOGGER.warning(
+                    f"The number of lines in the corpus file is {line_count}, which is greater than the expected {expected_verse_count}."
                 )
             terms_count = extract_term_renderings(
                 project_dir, corpus_filename, SIL_NLP_ENV.mt_terms_dir, extract_surface_forms

--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -82,7 +82,7 @@ def extract_project(
     extract_lemmas: bool = False,
     output_project_vrefs: bool = False,
     parent_project_dir: Optional[Path] = None,
-) -> Tuple[Path, int]:
+) -> Tuple[Path, int, int]:
     iso = get_iso(project_dir)
 
     ref_corpus: TextCorpus = create_versification_ref_corpus()
@@ -105,7 +105,8 @@ def extract_project(
     output_vref_filename = output_dir / f"{output_basename}.vref.txt"
 
     try:
-        segment_count = 0
+        verse_count = 0
+        line_count = 0
         with ExitStack() as stack:
             output_stream = stack.enter_context(output_filename.open("w", encoding="utf-8", newline="\n"))
             output = stack.enter_context(extract_scripture_corpus(project_corpus, ref_corpus))
@@ -118,15 +119,17 @@ def extract_project(
                 if output_vref_stream is not None:
                     output_vref_stream.write(("" if project_vref is None else str(project_vref)) + "\n")
                 stripped_line = line.strip()
-                if len(stripped_line) > 0 and stripped_line != "<range>" and stripped_line != "...":
-                    segment_count += 1
-        if segment_count == 0:
+                if stripped_line != "<range>":
+                    line_count += 1
+                    if len(stripped_line) > 0 and stripped_line != "...":
+                        verse_count += 1
+        if verse_count == 0:
             if output_filename.is_file():
                 output_filename.unlink()
             if output_vref_filename.is_file():
                 output_vref_filename.unlink()
-            return None, segment_count
-        return output_filename, segment_count
+            return None, verse_count, line_count
+        return output_filename, verse_count, line_count
     except Exception:
         if output_filename.is_file():
             output_filename.unlink()


### PR DESCRIPTION
This PR adds two log messages to `extract_corpora`. The first is a message of the number of lines, which includes empty verses and full verses. The next is a warning message if the number of lines is greater than a full project (41899).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1066)
<!-- Reviewable:end -->
