### PR TITLE
Fix ZeroDivisionError in book usability calculation

### DIFF
--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -116,7 +116,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
 
     def __init__(self, path: Path):
         super().__init__(path)
-        self._book_confidences: Optional[Dict[str, float]] = None
+        self.__book_confidences: Optional[Dict[str, float]] = None
 
     def get_chapters_path(self) -> Path:
         return self._path.with_suffix(".chapters.tsv")
@@ -125,13 +125,13 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
         return self._path.parent / "confidences.books.tsv"
 
     @property
-    def book_confidences(self) -> Dict[str, float]:
-        if self._book_confidences is None:
-            self._book_confidences = {}
+    def _book_confidences(self) -> Dict[str, float]:
+        if self.__book_confidences is None:
+            self.__book_confidences = {}
             if self.get_books_path().is_file():
                 for book, confidence in self._book_confidence_iterator():
-                    self._book_confidences[book] = confidence
-        return self._book_confidences
+                    self.__book_confidences[book] = confidence
+        return self.__book_confidences
 
     def _parse_verse_key(self, raw_key: str) -> VerseRef:
         return VerseRef.from_string(raw_key)
@@ -185,10 +185,10 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
             book_confidences.append(confidence)
 
         current_book = scripture_refs[0].book
-        self.book_confidences[current_book] = gmean(book_confidences)
+        self._book_confidences[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in self.book_confidences.items():
+            for book, confidence in self._book_confidences.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
     def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
@@ -202,7 +202,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 yield (book, confidence)
 
     def get_book_confidence(self, book: str) -> Optional[float]:
-        return self.book_confidences.get(book)
+        return self._book_confidences.get(book)
 
 
 class TxtConfidenceFile(ConfidenceFile[int]):

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -114,11 +114,23 @@ class ConfidenceFile(ABC, Generic[TVerseKey]):
 
 class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
 
+    def __init__(self, path: Path):
+        super().__init__(path)
+        self._book_confidences: Optional[Dict[str, float]] = None
+
     def get_chapters_path(self) -> Path:
         return self._path.with_suffix(".chapters.tsv")
 
     def get_books_path(self) -> Path:
         return self._path.parent / "confidences.books.tsv"
+
+    def _load_book_confidences(self) -> Dict[str, float]:
+        if self._book_confidences is None:
+            self._book_confidences = {}
+            if self.get_books_path().is_file():
+                for book, confidence in self._book_confidence_iterator():
+                    self._book_confidences[book] = confidence
+        return self._book_confidences
 
     def _parse_verse_key(self, raw_key: str) -> VerseRef:
         return VerseRef.from_string(raw_key)
@@ -171,19 +183,16 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 continue
             book_confidences.append(confidence)
 
-        existing_books: Dict[str, float] = {}
-        if self.get_books_path().exists():
-            for book, confidence in self.book_confidence_iterator():
-                existing_books[book] = confidence
+        book_confidences_dict = self._load_book_confidences()
 
         current_book = scripture_refs[0].book
-        existing_books[current_book] = gmean(book_confidences)
+        book_confidences_dict[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in existing_books.items():
+            for book, confidence in book_confidences_dict.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
-    def book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
+    def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
         with open(self.get_books_path(), "r", encoding="utf-8") as f:
             headers = f.readline().strip().split("\t")
             confidence_index = headers.index("Confidence")
@@ -193,16 +202,8 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 confidence = float(cols[confidence_index])
                 yield (book, confidence)
 
-    def get_book_confidences(self) -> List[Tuple[str, float]]:
-        return list(self.book_confidence_iterator())
-
     def get_book_confidence(self, book: str) -> Optional[float]:
-        if not self.get_books_path().is_file():
-            return None
-        for file_book, confidence in self.book_confidence_iterator():
-            if file_book == book:
-                return confidence
-        return None
+        return self._load_book_confidences().get(book)
 
 
 class TxtConfidenceFile(ConfidenceFile[int]):

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -124,7 +124,8 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
     def get_books_path(self) -> Path:
         return self._path.parent / "confidences.books.tsv"
 
-    def _load_book_confidences(self) -> Dict[str, float]:
+    @property
+    def book_confidences(self) -> Dict[str, float]:
         if self._book_confidences is None:
             self._book_confidences = {}
             if self.get_books_path().is_file():
@@ -183,13 +184,11 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 continue
             book_confidences.append(confidence)
 
-        self._load_book_confidences()
-
         current_book = scripture_refs[0].book
-        self._book_confidences[current_book] = gmean(book_confidences)
+        self.book_confidences[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in self._book_confidences.items():
+            for book, confidence in self.book_confidences.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
     def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
@@ -203,7 +202,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 yield (book, confidence)
 
     def get_book_confidence(self, book: str) -> Optional[float]:
-        return self._load_book_confidences().get(book)
+        return self.book_confidences.get(book)
 
 
 class TxtConfidenceFile(ConfidenceFile[int]):

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -116,7 +116,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
 
     def __init__(self, path: Path):
         super().__init__(path)
-        self.__book_confidences: Optional[Dict[str, float]] = None
+        self._book_confidences: Optional[Dict[str, float]] = None
 
     def get_chapters_path(self) -> Path:
         return self._path.with_suffix(".chapters.tsv")
@@ -125,13 +125,13 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
         return self._path.parent / "confidences.books.tsv"
 
     @property
-    def _book_confidences(self) -> Dict[str, float]:
-        if self.__book_confidences is None:
-            self.__book_confidences = {}
+    def book_confidences(self) -> Dict[str, float]:
+        if self._book_confidences is None:
+            self._book_confidences = {}
             if self.get_books_path().is_file():
                 for book, confidence in self._book_confidence_iterator():
-                    self.__book_confidences[book] = confidence
-        return self.__book_confidences
+                    self._book_confidences[book] = confidence
+        return self._book_confidences
 
     def _parse_verse_key(self, raw_key: str) -> VerseRef:
         return VerseRef.from_string(raw_key)
@@ -185,10 +185,10 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
             book_confidences.append(confidence)
 
         current_book = scripture_refs[0].book
-        self._book_confidences[current_book] = gmean(book_confidences)
+        self.book_confidences[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in self._book_confidences.items():
+            for book, confidence in self.book_confidences.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
     def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
@@ -202,7 +202,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 yield (book, confidence)
 
     def get_book_confidence(self, book: str) -> Optional[float]:
-        return self._book_confidences.get(book)
+        return self.book_confidences.get(book)
 
 
 class TxtConfidenceFile(ConfidenceFile[int]):

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -183,13 +183,13 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 continue
             book_confidences.append(confidence)
 
-        book_confidences_dict = self._load_book_confidences()
+        self._load_book_confidences()
 
         current_book = scripture_refs[0].book
-        book_confidences_dict[current_book] = gmean(book_confidences)
+        self._book_confidences[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in book_confidences_dict.items():
+            for book, confidence in self._book_confidences.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
     def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -116,7 +116,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
 
     def __init__(self, path: Path):
         super().__init__(path)
-        self._book_confidences: Optional[Dict[str, float]] = None
+        self._book_confidences_cache: Optional[Dict[str, float]] = None
 
     def get_chapters_path(self) -> Path:
         return self._path.with_suffix(".chapters.tsv")
@@ -125,13 +125,13 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
         return self._path.parent / "confidences.books.tsv"
 
     @property
-    def book_confidences(self) -> Dict[str, float]:
-        if self._book_confidences is None:
-            self._book_confidences = {}
+    def _book_confidences(self) -> Dict[str, float]:
+        if self._book_confidences_cache is None:
+            self._book_confidences_cache = {}
             if self.get_books_path().is_file():
                 for book, confidence in self._book_confidence_iterator():
-                    self._book_confidences[book] = confidence
-        return self._book_confidences
+                    self._book_confidences_cache[book] = confidence
+        return self._book_confidences_cache
 
     def _parse_verse_key(self, raw_key: str) -> VerseRef:
         return VerseRef.from_string(raw_key)
@@ -185,10 +185,10 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
             book_confidences.append(confidence)
 
         current_book = scripture_refs[0].book
-        self.book_confidences[current_book] = gmean(book_confidences)
+        self._book_confidences[current_book] = gmean(book_confidences)
         with self.get_books_path().open("w", encoding="utf-8", newline="\n") as book_confidences_file:
             book_confidences_file.write("Book\tConfidence\n")
-            for book, confidence in self.book_confidences.items():
+            for book, confidence in self._book_confidences.items():
                 book_confidences_file.write(f"{book}\t{confidence}\n")
 
     def _book_confidence_iterator(self) -> Generator[Tuple[str, float], None, None]:
@@ -202,7 +202,7 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
                 yield (book, confidence)
 
     def get_book_confidence(self, book: str) -> Optional[float]:
-        return self.book_confidences.get(book)
+        return self._book_confidences.get(book)
 
 
 class TxtConfidenceFile(ConfidenceFile[int]):

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -196,6 +196,14 @@ class UsfmConfidenceFile(ConfidenceFile[VerseRef]):
     def get_book_confidences(self) -> List[Tuple[str, float]]:
         return list(self.book_confidence_iterator())
 
+    def get_book_confidence(self, book: str) -> Optional[float]:
+        if not self.get_books_path().is_file():
+            return None
+        for file_book, confidence in self.book_confidence_iterator():
+            if file_book == book:
+                return confidence
+        return None
+
 
 class TxtConfidenceFile(ConfidenceFile[int]):
 

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -72,7 +72,6 @@ class ChapterScores:
 class BookScores:
     scores: Dict[str, Score] = field(default_factory=dict)
     verse_usabilities: Dict[str, List[float]] = field(default_factory=lambda: defaultdict(list))
-    seen_files: Set[Path] = field(default_factory=set)
 
     def add_score(self, book: str, score: Score) -> None:
         self.scores[book] = score
@@ -87,15 +86,16 @@ class BookScores:
         return self.verse_usabilities.get(book, [])
 
     def add_scores_from_confidence_file(
-        self, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
+        self, book: str, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
     ) -> None:
         books_path = confidence_file.get_books_path()
-        if books_path.is_file() and books_path not in self.seen_files:
-            self.seen_files.add(books_path)
-            for book, confidence in confidence_file.book_confidence_iterator():
-                projected_chrf3 = slope * confidence + intercept
-                score = Score(confidence, projected_chrf3)
-                self.add_score(book, score)
+        if books_path.is_file():
+            for file_book, confidence in confidence_file.book_confidence_iterator():
+                if file_book == book:
+                    projected_chrf3 = slope * confidence + intercept
+                    score = Score(confidence, projected_chrf3)
+                    self.add_score(book, score)
+                    break
 
 
 @dataclass
@@ -224,7 +224,7 @@ def project_chrf3(
             chapter_scores.add_scores_from_confidence_file(
                 file_verse_scores[0].vref.book, confidence_file, slope, intercept
             )
-            book_scores.add_scores_from_confidence_file(confidence_file, slope, intercept)
+            book_scores.add_scores_from_confidence_file(file_verse_scores[0].vref.book, confidence_file, slope, intercept)
         elif isinstance(confidence_file, TxtConfidenceFile):
             file_sequence_scores = SequenceScore.get_scores_from_confidence_file(confidence_file, slope, intercept)
             if not file_sequence_scores:
@@ -396,6 +396,9 @@ def compute_chapter_usability(
         for book in sorted(chapter_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             for chapter in sorted(chapter_scores.scores[book]):
                 chapter_usabilities = chapter_scores.get_verse_usabilities(book, chapter)
+                if not chapter_usabilities:
+                    LOGGER.warning(f"{book} {chapter} has no verse usabilities. Skipping chapter usability calculation.")
+                    continue
                 avg_prob = sum(chapter_usabilities) / len(chapter_usabilities)
                 label = ChapterThresholds.return_label(avg_prob)
                 if not chapter_scores.get_score(book, chapter):
@@ -415,6 +418,9 @@ def compute_book_usability(
         for book in sorted(book_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             # book/chapter usabilties are calculated from verse avg, not from book/chapter projected chrf3
             book_usabilities = book_scores.get_verse_usabilities(book)
+            if not book_usabilities:
+                LOGGER.warning(f"{book} has no verse usabilities. Skipping book usability calculation.")
+                continue
             avg_prob = sum(book_usabilities) / len(book_usabilities)
             label = BookThresholds.return_label(avg_prob)
             if not book_scores.get_score(book):

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -88,14 +88,10 @@ class BookScores:
     def add_scores_from_confidence_file(
         self, book: str, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
     ) -> None:
-        books_path = confidence_file.get_books_path()
-        if books_path.is_file():
-            for file_book, confidence in confidence_file.book_confidence_iterator():
-                if file_book == book:
-                    projected_chrf3 = slope * confidence + intercept
-                    score = Score(confidence, projected_chrf3)
-                    self.add_score(book, score)
-                    break
+        confidence = confidence_file.get_book_confidence(book)
+        if confidence is not None:
+            projected_chrf3 = slope * confidence + intercept
+            self.add_score(book, Score(confidence, projected_chrf3))
 
 
 @dataclass
@@ -224,7 +220,9 @@ def project_chrf3(
             chapter_scores.add_scores_from_confidence_file(
                 file_verse_scores[0].vref.book, confidence_file, slope, intercept
             )
-            book_scores.add_scores_from_confidence_file(file_verse_scores[0].vref.book, confidence_file, slope, intercept)
+            book_scores.add_scores_from_confidence_file(
+                file_verse_scores[0].vref.book, confidence_file, slope, intercept
+            )
         elif isinstance(confidence_file, TxtConfidenceFile):
             file_sequence_scores = SequenceScore.get_scores_from_confidence_file(confidence_file, slope, intercept)
             if not file_sequence_scores:
@@ -397,7 +395,9 @@ def compute_chapter_usability(
             for chapter in sorted(chapter_scores.scores[book]):
                 chapter_usabilities = chapter_scores.get_verse_usabilities(book, chapter)
                 if not chapter_usabilities:
-                    LOGGER.warning(f"{book} {chapter} has no verse usabilities. Skipping chapter usability calculation.")
+                    LOGGER.warning(
+                        f"{book} {chapter} has no verse usabilities. Skipping chapter usability calculation."
+                    )
                     continue
                 avg_prob = sum(chapter_usabilities) / len(chapter_usabilities)
                 label = ChapterThresholds.return_label(avg_prob)


### PR DESCRIPTION
BookScores.add_scores_from_confidence_file was loading ALL books from the shared confidences.books.tsv file, including books not inferenced in the current run. This caused empty verse_usabilities lists and a division by zero in compute_book_usability.

Changes:
- Filter add_scores_from_confidence_file to only load the current book being inferenced, not all books in the shared file
- Remove seen_files tracking (no longer needed since we filter by book)
- Add empty list guards in compute_book_usability and compute_chapter_usability to skip books/chapters with no verse usabilities instead of dividing by zero


I ran the experiment where this was failing before and confirmed that this fixes the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1068)
<!-- Reviewable:end -->
