### PR TITLE
Update english standard alignments

### DIFF
--- a/silnlp/assets/standard_alignments.yml
+++ b/silnlp/assets/standard_alignments.yml
@@ -1,6 +1,6 @@
 default:
-- eng-BSB
-- eng-NIV11R
+- en-BSB
+- en-NIV11R
 - en-NLT07
 - fr-BDS
 - es-NVI_S
@@ -17,14 +17,14 @@ ben:
 eng:
 - en-CEVUS06
 - en-ESVUS16
-- eng-GNBDC
-- eng-GNTD
+- en-GNBDC
+- en-GNTD
 - en-LSV
 - en-NASB
 - en-NET08
 - en-NIV84
 - en-NIrV
-- eng-NRSV
+- en-NRSV
 - en-WEB
 fra:
 - fra-TOB


### PR DESCRIPTION
This PR updates all standard alignments that began with `eng-` to `en-`, since the `en-` prefix is the newer version that is used when those projects are extracted automatically. `eng-` is from older projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1076)
<!-- Reviewable:end -->
