### PR TITLE
Change line count warning to error in extract_corpora

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -106,9 +106,9 @@ def extract_corpora(
                 LOGGER.info(
                     f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
                 )
-            if line_count > expected_verse_count:
-                LOGGER.warning(
-                    f"The number of lines in the corpus file is {line_count}, which is greater than the expected {expected_verse_count}."
+            if line_count != expected_verse_count:
+                LOGGER.error(
+                    f"The number of lines in the corpus file is {line_count}, which is not equal to the expected {expected_verse_count}."
                 )
             terms_count = extract_term_renderings(
                 project_dir, corpus_filename, environment.mt_terms_dir, extract_surface_forms, environment

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -107,7 +107,7 @@ def extract_corpora(
                     f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
                 )
             if line_count != expected_verse_count:
-                LOGGER.error(
+                raise ValueError(
                     f"The number of lines in the corpus file is {line_count}, which is not equal to the expected {expected_verse_count}."
                 )
             terms_count = extract_term_renderings(


### PR DESCRIPTION
This PR elevates a warning in `extract_corpora` to an Exception when the line count is not equal to the `expected_verse_count`, which is the length of a full extract. The former warning also only was output when the line_count was greater than `expected_verse_count`, now it will be raised when the line_count is not equal to the `expected_verse_count`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1084)
<!-- Reviewable:end -->
