### PR TITLE
Fix line number miscounting

### DIFF
--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -106,9 +106,9 @@ def extract_corpora(
                 LOGGER.info(
                     f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
                 )
-            if line_count > expected_verse_count:
-                LOGGER.warning(
-                    f"The number of lines in the corpus file is {line_count}, which is greater than the expected {expected_verse_count}."
+            if line_count != expected_verse_count:
+                LOGGER.error(
+                    f"The number of lines in the corpus file is {line_count}, which is not equal to the expected {expected_verse_count}."
                 )
             terms_count = extract_term_renderings(
                 project_dir, corpus_filename, environment.mt_terms_dir, extract_surface_forms, environment

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -107,7 +107,7 @@ def extract_corpora(
                     f"The number of completed verses is {verse_count} (out of the expected {expected_verse_count})."
                 )
             if line_count != expected_verse_count:
-                LOGGER.error(
+                raise ValueError(
                     f"The number of lines in the corpus file is {line_count}, which is not equal to the expected {expected_verse_count}."
                 )
             terms_count = extract_term_renderings(

--- a/silnlp/common/paratext.py
+++ b/silnlp/common/paratext.py
@@ -114,11 +114,10 @@ def extract_project(
                 output_stream.write(line + "\n")
                 if output_vref_stream is not None:
                     output_vref_stream.write(("" if project_vref is None else str(project_vref)) + "\n")
+                line_count += 1
                 stripped_line = line.strip()
-                if stripped_line != "<range>":
-                    line_count += 1
-                    if len(stripped_line) > 0 and stripped_line != "...":
-                        verse_count += 1
+                if stripped_line != "<range>" and len(stripped_line) > 0 and stripped_line != "...":
+                    verse_count += 1
         if verse_count == 0:
             if output_filename.is_file():
                 output_filename.unlink()


### PR DESCRIPTION
This fixes an issue with miscounting the number of lines in an extract file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1085)
<!-- Reviewable:end -->
