### PR TITLE
Compute transition scores on CPU

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1885,14 +1885,15 @@ class SilTranslationPipeline(TranslationPipeline):
 
     @staticmethod
     def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
-        output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
-    ) -> Tuple[Tuple[Tensor, ...], Optional[Tensor]]:
+        output_ids: Tensor, output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
+    ) -> Tuple[Tensor, Tuple[Tensor, ...], Optional[Tensor]]:
         if max(len(score) for score in output_scores) > 200:
             return (
+                output_ids.to("cpu"),
                 tuple(score.to("cpu") for score in output_scores),
                 beam_indices.to("cpu") if beam_indices is not None else None,
             )
-        return output_scores, beam_indices
+        return output_ids, output_scores, beam_indices
 
     def postprocess(self, model_outputs, return_type=None, clean_up_tokenization_spaces=False):
         if self.tokenizer is None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1844,16 +1844,26 @@ class SilTranslationPipeline(TranslationPipeline):
             return_dict_in_generate=True,
         )
 
-        raw_beam_indices = output.beam_indices if "beam_indices" in output else None
-        output_ids, output_scores, beam_indices = self._move_scores_and_beam_indices_to_cpu_for_long_sequences(
-            output.sequences, output.scores, raw_beam_indices
-        )
-        transition_scores = self.model.compute_transition_scores(
-            output_ids,
-            output_scores,
-            beam_indices,
-            normalize_logits=True,
-        )
+        output_ids = output.sequences
+        output_scores = output.scores
+        beam_indices = output.beam_indices if "beam_indices" in output else None
+        try:
+            transition_scores = self.model.compute_transition_scores(
+                output_ids,
+                output_scores,
+                beam_indices,
+                normalize_logits=True,
+            )
+        except Exception:
+            output_ids = output_ids.to("cpu")
+            output_scores = tuple(score.to("cpu") for score in output_scores)
+            beam_indices = beam_indices.to("cpu") if beam_indices is not None else None
+            transition_scores = self.model.compute_transition_scores(
+                output_ids,
+                output_scores,
+                beam_indices,
+                normalize_logits=True,
+            )
         sequences_scores = getattr(output, "sequences_scores", None)
 
         out_b, seq_len = output_ids.shape
@@ -1882,18 +1892,6 @@ class SilTranslationPipeline(TranslationPipeline):
             "scores": token_logprobs,
             "sequences_scores": sequences_scores,
         }
-
-    @staticmethod
-    def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
-        output_ids: Tensor, output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
-    ) -> Tuple[Tensor, Tuple[Tensor, ...], Optional[Tensor]]:
-        if max(len(score) for score in output_scores) > 125:
-            return (
-                output_ids.to("cpu"),
-                tuple(score.to("cpu") for score in output_scores),
-                beam_indices.to("cpu") if beam_indices is not None else None,
-            )
-        return output_ids, output_scores, beam_indices
 
     def postprocess(self, model_outputs, return_type=None, clean_up_tokenization_spaces=False):
         if self.tokenizer is None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1887,7 +1887,7 @@ class SilTranslationPipeline(TranslationPipeline):
     def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
         output_ids: Tensor, output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
     ) -> Tuple[Tensor, Tuple[Tensor, ...], Optional[Tensor]]:
-        if max(len(score) for score in output_scores) > 200:
+        if max(len(score) for score in output_scores) > 150:
             return (
                 output_ids.to("cpu"),
                 tuple(score.to("cpu") for score in output_scores),

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1887,7 +1887,7 @@ class SilTranslationPipeline(TranslationPipeline):
     def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
         output_ids: Tensor, output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
     ) -> Tuple[Tensor, Tuple[Tensor, ...], Optional[Tensor]]:
-        if max(len(score) for score in output_scores) > 150:
+        if max(len(score) for score in output_scores) > 125:
             return (
                 output_ids.to("cpu"),
                 tuple(score.to("cpu") for score in output_scores),

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1845,8 +1845,10 @@ class SilTranslationPipeline(TranslationPipeline):
         )
 
         output_ids = output.sequences.to("cpu")
-        output_scores = tuple(score.to("cpu") for score in output.scores)
-        beam_indices = output.beam_indices.to("cpu") if "beam_indices" in output else None
+        raw_beam_indices = output.beam_indices if "beam_indices" in output else None
+        output_scores, beam_indices = self._move_scores_and_beam_indices_to_cpu_for_long_sequences(
+            output.scores, raw_beam_indices
+        )
         transition_scores = self.model.compute_transition_scores(
             output_ids,
             output_scores,
@@ -1881,6 +1883,18 @@ class SilTranslationPipeline(TranslationPipeline):
             "scores": token_logprobs,
             "sequences_scores": sequences_scores,
         }
+    
+    @staticmethod
+    def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
+        output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
+    ) -> Tuple[Tuple[Tensor, ...], Optional[Tensor]]:
+        if max(len(score) for score in output_scores) > 200:
+            return (
+                tuple(score.to("cpu") for score in output_scores),
+                beam_indices.to("cpu") if beam_indices is not None else None,
+            )
+        return output_scores, beam_indices
+
 
     def postprocess(self, model_outputs, return_type=None, clean_up_tokenization_spaces=False):
         if self.tokenizer is None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1844,10 +1844,9 @@ class SilTranslationPipeline(TranslationPipeline):
             return_dict_in_generate=True,
         )
 
-        output_ids = output.sequences.to("cpu")
         raw_beam_indices = output.beam_indices if "beam_indices" in output else None
-        output_scores, beam_indices = self._move_scores_and_beam_indices_to_cpu_for_long_sequences(
-            output.scores, raw_beam_indices
+        output_ids, output_scores, beam_indices = self._move_scores_and_beam_indices_to_cpu_for_long_sequences(
+            output.sequences, output.scores, raw_beam_indices
         )
         transition_scores = self.model.compute_transition_scores(
             output_ids,
@@ -1883,7 +1882,7 @@ class SilTranslationPipeline(TranslationPipeline):
             "scores": token_logprobs,
             "sequences_scores": sequences_scores,
         }
-    
+
     @staticmethod
     def _move_scores_and_beam_indices_to_cpu_for_long_sequences(
         output_scores: Tuple[Tensor, ...], beam_indices: Optional[Tensor]
@@ -1894,7 +1893,6 @@ class SilTranslationPipeline(TranslationPipeline):
                 beam_indices.to("cpu") if beam_indices is not None else None,
             )
         return output_scores, beam_indices
-
 
     def postprocess(self, model_outputs, return_type=None, clean_up_tokenization_spaces=False):
         if self.tokenizer is None:

--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -1844,11 +1844,12 @@ class SilTranslationPipeline(TranslationPipeline):
             return_dict_in_generate=True,
         )
 
-        output_ids = output.sequences
-        beam_indices = getattr(output, "beam_indices", None)
+        output_ids = output.sequences.to("cpu")
+        output_scores = tuple(score.to("cpu") for score in output.scores)
+        beam_indices = output.beam_indices.to("cpu") if "beam_indices" in output else None
         transition_scores = self.model.compute_transition_scores(
             output_ids,
-            output.scores,
+            output_scores,
             beam_indices,
             normalize_logits=True,
         )


### PR DESCRIPTION
This PR moves the computation of transition scores in `SilTranslationPipeline` to the CPU.  The scores form a large tuple whose size is `num_generated_tokens × batch_size × num_beams × vocab_size` that can occupy a lot of the GPU's RAM.  The tradeoff is that inference now takes 1.5-2x longer, since we're using the CPU.

We should discuss further whether this is a good tradeoff to make.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1087)
<!-- Reviewable:end -->
