### PR TITLE
Add incremental draft generation support to postprocess.py

### DIFF
--- a/silnlp/common/postprocess_draft.py
+++ b/silnlp/common/postprocess_draft.py
@@ -49,7 +49,8 @@ def main() -> None:
         "--denormalize-quotation-marks",
         default=False,
         action="store_true",
-        help="For files in USFM format, attempt to change the draft's quotation marks to match the target project's quote convention",
+        help="For files in USFM format, attempt to change the draft's quotation marks to match "
+        + "the target project's quote convention",
     )
     parser.add_argument(
         "--target-quote-convention",

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -11,6 +11,10 @@ from machine.corpora import (
     UpdateUsfmParserHandler,
     UpdateUsfmRow,
     UpdateUsfmTextBehavior,
+    UsfmStylesheet,
+    UsfmToken,
+    UsfmTokenizer,
+    UsfmTokenType,
     UsfmUpdateBlockHandler,
     parse_usfm,
 )
@@ -71,22 +75,6 @@ class PlaceMarkersPostprocessor:
     def get_update_block_handlers(self) -> Sequence[UsfmUpdateBlockHandler]:
         return self._update_block_handlers
 
-    def _create_remark(self) -> str:
-        behavior_map: Dict[UpdateUsfmMarkerBehavior, List[str]] = {
-            UpdateUsfmMarkerBehavior.PRESERVE: [],
-            UpdateUsfmMarkerBehavior.STRIP: [],
-        }
-        behavior_map[self._paragraph_behavior].append("paragraph break positions")
-        behavior_map[self._embed_behavior].append("embed markers")
-        behavior_map[self._style_behavior].append("style markers")
-
-        remark_sentences = [
-            self._create_remark_sentence_for_behavior(behavior, items)
-            for behavior, items in behavior_map.items()
-            if len(items) > 0
-        ]
-        return " ".join(remark_sentences)
-
     def create_paragraph_remark(self) -> str:
         return self._create_remark_sentence_for_behavior(self._paragraph_behavior, ["paragraph break positions"])
 
@@ -104,11 +92,9 @@ class PlaceMarkersPostprocessor:
         self,
         usfm: str,
         rows: List[UpdateUsfmRow],
-        remarks: Optional[List[str]] = None,
+        remarks: Optional[List[Tuple[int, str]]] = None,
+        stylesheet: str | UsfmStylesheet = "usfm.sty",
     ) -> str:
-        if remarks is None:
-            remarks = []
-
         handler = UpdateUsfmParserHandler(
             rows=rows,
             text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
@@ -116,10 +102,10 @@ class PlaceMarkersPostprocessor:
             embed_behavior=self._embed_behavior,
             style_behavior=self._style_behavior,
             update_block_handlers=self._update_block_handlers,
-            remarks=remarks + [self._create_remark()],
+            remarks=remarks or [],
         )
-        parse_usfm(usfm, handler)
-        return handler.get_usfm()
+        parse_usfm(usfm, handler, stylesheet)
+        return handler.get_usfm(stylesheet)
 
 
 class UnknownQuoteConventionException(Exception):
@@ -219,10 +205,10 @@ class DenormalizeQuotationMarksPostprocessor:
             )
         ]
 
-    def _get_best_chapter_strategies(self, usfm: str) -> List[QuotationMarkUpdateStrategy]:
+    def _get_best_chapter_strategies(self, usfm: str, stylesheet: UsfmStylesheet) -> List[QuotationMarkUpdateStrategy]:
         quotation_mark_update_first_pass = QuotationMarkDenormalizationFirstPass(self._target_quote_convention)
 
-        parse_usfm(usfm, quotation_mark_update_first_pass)
+        parse_usfm(usfm, quotation_mark_update_first_pass, stylesheet)
 
         # sil-machine's get_chapters() currently mislabels chapter numbers, temp workaround until machine.py is fixed
         strategy_by_chapter: Dict[int, QuotationMarkUpdateStrategy] = {}
@@ -261,32 +247,54 @@ class DenormalizeQuotationMarksPostprocessor:
             for chapter_num, strategy in enumerate(chapter_strategies, 1)
         }
 
-    def _merge_remarks(
-        self,
-        remarks: Optional[List[Tuple[int, str]]],
-        chapter_strategies: List[QuotationMarkUpdateStrategy],
-    ) -> List[Tuple[int, str]]:
-        if not remarks:
-            return []
-        chapter_remarks = self._create_chapter_remarks(chapter_strategies)
-        merged: List[Tuple[int, str]] = []
-        for chapter_num, remark in remarks:
-            quotation_remark = chapter_remarks.get(chapter_num)
-            merged.append((chapter_num, f"{remark} {quotation_remark}" if quotation_remark else remark))
-        return merged
+    @staticmethod
+    def _append_sentences_to_last_rem(tokens: List[UsfmToken], chapter_sentences: Dict[int, str]) -> None:
+        # Append each chapter's quotation sentence to the last \rem in that chapter (the draft remark, which is
+        # always inserted after any pre-existing rems). The machine handler can't merge into an existing \rem, so
+        # this is done at the token level. Chapters with no \rem (and book-level chapter 0) are left untouched.
+        last_rem_index_by_chapter: Dict[int, int] = {}
+        current_chapter = 0
+        for index, token in enumerate(tokens):
+            if token.type == UsfmTokenType.CHAPTER:
+                data = str(token.data).strip() if token.data is not None else ""
+                if data.isdigit():
+                    current_chapter = int(data)
+            elif token.type == UsfmTokenType.PARAGRAPH and token.marker == "rem":
+                last_rem_index_by_chapter[current_chapter] = index
 
-    def postprocess_usfm(
-        self,
-        usfm: str,
-        remarks: Optional[List[Tuple[int, str]]] = None,
-    ) -> str:
-        best_chapter_strategies = self._get_best_chapter_strategies(usfm)
+        # Apply deepest index first so inserting a TEXT token can't shift an earlier chapter's recorded index.
+        for chapter_num in sorted(last_rem_index_by_chapter, reverse=True):
+            if chapter_num == 0:
+                continue
+            sentence = chapter_sentences.get(chapter_num)
+            if not sentence:
+                continue
+            next_index = last_rem_index_by_chapter[chapter_num] + 1
+            if next_index < len(tokens) and tokens[next_index].type == UsfmTokenType.TEXT:
+                existing_text = tokens[next_index].text or ""
+                separator = "" if existing_text == "" or existing_text.endswith(" ") else " "
+                tokens[next_index].text = existing_text + separator + sentence
+            else:
+                tokens.insert(next_index, UsfmToken(UsfmTokenType.TEXT, text=sentence))
+
+    def postprocess_usfm(self, usfm: str, stylesheet: str | UsfmStylesheet = "usfm.sty") -> str:
+        # The draft \rem is written by the draft-building step (translator's update_usfm, or the existing draft
+        # file); this step only denormalizes the quotation marks and appends its note to that existing \rem.
+        if isinstance(stylesheet, str):
+            stylesheet = UsfmStylesheet(stylesheet)
+
+        best_chapter_strategies = self._get_best_chapter_strategies(usfm, stylesheet)
+        chapter_sentences = self._create_chapter_remarks(best_chapter_strategies)
+
         handler = UpdateUsfmParserHandler(
             update_block_handlers=self._create_update_block_handlers(best_chapter_strategies),
-            remarks=self._merge_remarks(remarks, best_chapter_strategies),
         )
-        parse_usfm(usfm, handler)
-        return handler.get_usfm()
+        parse_usfm(usfm, handler, stylesheet)
+
+        tokenizer = UsfmTokenizer(stylesheet)
+        out_tokens = tokenizer.tokenize(handler.get_usfm(stylesheet))
+        self._append_sentences_to_last_rem(out_tokens, chapter_sentences)
+        return tokenizer.detokenize(out_tokens)
 
 
 class PostprocessConfig:
@@ -341,6 +349,13 @@ class PostprocessConfig:
 
     def is_marker_placement_required(self) -> bool:
         return self._config["paragraph_behavior"] == "place" or self._config["include_style_markers"]
+
+    def is_marker_processing_required(self) -> bool:
+        return (
+            self._config["paragraph_behavior"] != "end"
+            or self._config["include_style_markers"]
+            or self._config["include_embeds"]
+        )
 
     def is_quotation_mark_denormalization_required(self) -> bool:
         return self._config["denormalize_quotation_marks"]

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -245,9 +245,6 @@ class DenormalizeQuotationMarksPostprocessor:
 
     @staticmethod
     def _append_sentences_to_last_rem(tokens: List[UsfmToken], chapter_sentences: Dict[int, str]) -> None:
-        # Append each chapter's quotation sentence to the last \rem in that chapter (the draft remark, which is
-        # always inserted after any pre-existing rems). The machine handler can't merge into an existing \rem, so
-        # this is done at the token level. Chapters with no \rem (and book-level chapter 0) are left untouched.
         last_rem_index_by_chapter: Dict[int, int] = {}
         current_chapter = 0
         for index, token in enumerate(tokens):
@@ -258,7 +255,6 @@ class DenormalizeQuotationMarksPostprocessor:
             elif token.type == UsfmTokenType.PARAGRAPH and token.marker == "rem":
                 last_rem_index_by_chapter[current_chapter] = index
 
-        # Apply deepest index first so inserting a TEXT token can't shift an earlier chapter's recorded index.
         for chapter_num in sorted(last_rem_index_by_chapter, reverse=True):
             if chapter_num == 0:
                 continue
@@ -274,8 +270,6 @@ class DenormalizeQuotationMarksPostprocessor:
                 tokens.insert(next_index, UsfmToken(UsfmTokenType.TEXT, text=sentence))
 
     def postprocess_usfm(self, usfm: str, stylesheet: str | UsfmStylesheet = "usfm.sty") -> str:
-        # The draft \rem is written by the draft-building step (translator's update_usfm, or the existing draft
-        # file); this step only denormalizes the quotation marks and appends its note to that existing \rem.
         if isinstance(stylesheet, str):
             stylesheet = UsfmStylesheet(stylesheet)
 

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -129,7 +129,6 @@ class DenormalizeQuotationMarksPostprocessor:
     _DENORMALIZED_CHAPTER_REMARK_SENTENCE = (
         "Quotation marks have been adjusted automatically to match the rest of the project."
     )
-    _SKIPPED_CHAPTER_REMARK_SENTENCE = "Quotation marks could not be successfully denormalized."
     _project_convention_cache: Dict[str, QuoteConvention] = {}
 
     def __init__(
@@ -239,12 +238,9 @@ class DenormalizeQuotationMarksPostprocessor:
 
     def _create_chapter_remarks(self, chapter_strategies: List[QuotationMarkUpdateStrategy]) -> Dict[int, str]:
         return {
-            chapter_num: (
-                self._SKIPPED_CHAPTER_REMARK_SENTENCE
-                if strategy == QuotationMarkUpdateStrategy.SKIP
-                else self._DENORMALIZED_CHAPTER_REMARK_SENTENCE
-            )
+            chapter_num: self._DENORMALIZED_CHAPTER_REMARK_SENTENCE
             for chapter_num, strategy in enumerate(chapter_strategies, 1)
+            if strategy != QuotationMarkUpdateStrategy.SKIP
         }
 
     @staticmethod

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -56,18 +56,22 @@ POSTPROCESS_SUFFIX_CHARS = {
 
 
 class PlaceMarkersPostprocessor:
-    _BEHAVIOR_DESCRIPTION_MAP = {
-        UpdateUsfmMarkerBehavior.PRESERVE: " were preserved.",
-        UpdateUsfmMarkerBehavior.STRIP: " were removed.",
+    _PARAGRAPH_MARKER_REMARKS = {
+        "end": "Paragraph break positions were moved to the end of the verse.",
+        "place": "Paragraph break positions were preserved.",
+        "strip": "Paragraph breaks were removed.",
     }
 
     def __init__(
         self,
-        paragraph_behavior: UpdateUsfmMarkerBehavior,
+        paragraph_behavior: str,
         embed_behavior: UpdateUsfmMarkerBehavior,
         style_behavior: UpdateUsfmMarkerBehavior,
     ):
         self._paragraph_behavior = paragraph_behavior
+        self._paragraph_marker_behavior = (
+            UpdateUsfmMarkerBehavior.STRIP if paragraph_behavior == "strip" else UpdateUsfmMarkerBehavior.PRESERVE
+        )
         self._embed_behavior = embed_behavior
         self._style_behavior = style_behavior
         self._update_block_handlers = [PlaceMarkersUsfmUpdateBlockHandler()]
@@ -75,18 +79,15 @@ class PlaceMarkersPostprocessor:
     def get_update_block_handlers(self) -> Sequence[UsfmUpdateBlockHandler]:
         return self._update_block_handlers
 
-    def create_paragraph_remark(self) -> str:
-        return self._create_remark_sentence_for_behavior(self._paragraph_behavior, ["paragraph break positions"])
+    def get_paragraph_marker_remark(self) -> Optional[str]:
+        return self._PARAGRAPH_MARKER_REMARKS.get(self._paragraph_behavior)
 
-    def _create_remark_sentence_for_behavior(self, behavior: UpdateUsfmMarkerBehavior, items: List[str]) -> str:
-        return self._format_group_of_items_for_remark(items) + self._BEHAVIOR_DESCRIPTION_MAP[behavior]
-
-    def _format_group_of_items_for_remark(self, items: List[str]) -> str:
-        if len(items) == 1:
-            return items[0].capitalize()
-        elif len(items) == 2:
-            return f"{items[0].capitalize()} and {items[1]}"
-        return f"{items[0].capitalize()}, {', '.join(items[1:-1])}, and {items[-1]}"
+    def replace_paragraph_marker_remark(self, remark: str) -> str:
+        for sentence in self._PARAGRAPH_MARKER_REMARKS.values():
+            remark = remark.replace(f" {sentence}", "").replace(sentence, "")
+        remark = remark.strip()
+        paragraph_remark = self.get_paragraph_marker_remark()
+        return f"{remark} {paragraph_remark}".strip() if paragraph_remark else remark
 
     def postprocess_usfm(
         self,
@@ -98,7 +99,7 @@ class PlaceMarkersPostprocessor:
         handler = UpdateUsfmParserHandler(
             rows=rows,
             text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
-            paragraph_behavior=self._paragraph_behavior,
+            paragraph_behavior=self._paragraph_marker_behavior,
             embed_behavior=self._embed_behavior,
             style_behavior=self._style_behavior,
             update_block_handlers=self._update_block_handlers,
@@ -330,9 +331,7 @@ class PostprocessConfig:
         return suffix if len(suffix) > 1 else ""
 
     def get_paragraph_marker_remark(self) -> Optional[str]:
-        if self._config["paragraph_behavior"] not in ("place", "strip"):
-            return None
-        return self.create_place_markers_postprocessor().create_paragraph_remark()
+        return self.create_place_markers_postprocessor().get_paragraph_marker_remark()
 
     def is_base_config(self) -> bool:
         return self._config == POSTPROCESS_DEFAULTS
@@ -357,7 +356,7 @@ class PostprocessConfig:
 
     def create_place_markers_postprocessor(self) -> PlaceMarkersPostprocessor:
         return PlaceMarkersPostprocessor(
-            paragraph_behavior=self.get_paragraph_behavior(),
+            paragraph_behavior=self._config["paragraph_behavior"],
             embed_behavior=self.get_embed_behavior(),
             style_behavior=self.get_style_behavior(),
         )

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -83,6 +83,8 @@ class PlaceMarkersPostprocessor:
         return self._PARAGRAPH_MARKER_REMARKS.get(self._paragraph_behavior)
 
     def replace_paragraph_marker_remark(self, remark: str) -> str:
+        if not any(sentence in remark for sentence in self._PARAGRAPH_MARKER_REMARKS.values()):
+            return remark
         for sentence in self._PARAGRAPH_MARKER_REMARKS.values():
             remark = remark.replace(f" {sentence}", "").replace(sentence, "")
         remark = remark.strip()
@@ -245,7 +247,7 @@ class DenormalizeQuotationMarksPostprocessor:
         }
 
     @staticmethod
-    def _append_sentences_to_last_rem(tokens: List[UsfmToken], chapter_sentences: Dict[int, str]) -> None:
+    def _append_sentences_to_last_rem(tokens: List[UsfmToken], chapter_quotation_remarks: Dict[int, str]) -> None:
         last_rem_index_by_chapter: Dict[int, int] = {}
         current_chapter = 0
         for index, token in enumerate(tokens):
@@ -259,23 +261,23 @@ class DenormalizeQuotationMarksPostprocessor:
         for chapter_num in sorted(last_rem_index_by_chapter, reverse=True):
             if chapter_num == 0:
                 continue
-            sentence = chapter_sentences.get(chapter_num)
-            if not sentence:
+            quotation_remark = chapter_quotation_remarks.get(chapter_num)
+            if not quotation_remark:
                 continue
             next_index = last_rem_index_by_chapter[chapter_num] + 1
             if next_index < len(tokens) and tokens[next_index].type == UsfmTokenType.TEXT:
                 existing_text = tokens[next_index].text or ""
                 separator = "" if existing_text == "" or existing_text.endswith(" ") else " "
-                tokens[next_index].text = existing_text + separator + sentence
+                tokens[next_index].text = existing_text + separator + quotation_remark
             else:
-                tokens.insert(next_index, UsfmToken(UsfmTokenType.TEXT, text=sentence))
+                tokens.insert(next_index, UsfmToken(UsfmTokenType.TEXT, text=quotation_remark))
 
     def postprocess_usfm(self, usfm: str, stylesheet: str | UsfmStylesheet = "usfm.sty") -> str:
         if isinstance(stylesheet, str):
             stylesheet = UsfmStylesheet(stylesheet)
 
         best_chapter_strategies = self._get_best_chapter_strategies(usfm, stylesheet)
-        chapter_sentences = self._create_chapter_remarks(best_chapter_strategies)
+        chapter_quotation_remarks = self._create_chapter_remarks(best_chapter_strategies)
 
         handler = UpdateUsfmParserHandler(
             update_block_handlers=self._create_update_block_handlers(best_chapter_strategies),
@@ -284,7 +286,7 @@ class DenormalizeQuotationMarksPostprocessor:
 
         tokenizer = UsfmTokenizer(stylesheet)
         out_tokens = tokenizer.tokenize(handler.get_usfm(stylesheet))
-        self._append_sentences_to_last_rem(out_tokens, chapter_sentences)
+        self._append_sentences_to_last_rem(out_tokens, chapter_quotation_remarks)
         return tokenizer.detokenize(out_tokens)
 
 

--- a/silnlp/common/translator.py
+++ b/silnlp/common/translator.py
@@ -481,9 +481,7 @@ class Translator(AbstractContextManager["Translator"], ABC):
                             if config.is_marker_placement_required()
                             else None
                         ),
-                        # Defer remarks to the quotation denormalization step so they can be merged into a single
-                        # \rem per chapter; otherwise write them here.
-                        remarks=None if config.is_quotation_mark_denormalization_required() else remarks,
+                        remarks=remarks,
                         compare_segments=True,
                     )
 
@@ -517,7 +515,7 @@ class Translator(AbstractContextManager["Translator"], ABC):
                             config.create_denormalize_quotation_marks_postprocessor(training_corpus_pairs)
                         )
                         usfm_out = quotation_denormalization_postprocessor.postprocess_usfm(
-                            usfm_out, remarks if (trg_project is not None or src_from_project) else None
+                            usfm_out, stylesheet=stylesheet
                         )
                     except (UnknownQuoteConventionException, NoDetectedQuoteConventionException) as e:
                         LOGGER.warning(str(e) + " Skipping quotation mark denormalization.")

--- a/silnlp/nmt/postprocess.py
+++ b/silnlp/nmt/postprocess.py
@@ -2,11 +2,20 @@ import argparse
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import yaml
 from attr import dataclass
-from machine.corpora import FileParatextProjectSettingsParser, ScriptureRef, UsfmFileText, UsfmStylesheet, UsfmTextType
+from machine.corpora import (
+    FileParatextProjectSettingsParser,
+    ScriptureRef,
+    UsfmFileText,
+    UsfmStylesheet,
+    UsfmTextType,
+    UsfmToken,
+    UsfmTokenizer,
+    UsfmTokenType,
+)
 from machine.scripture import book_number_to_id, get_chapters
 from transformers.trainer_utils import get_last_checkpoint
 
@@ -29,6 +38,26 @@ from .hugging_face_config import get_best_checkpoint
 LOGGER = logging.getLogger(__package__ + ".postprocess")
 
 
+# Replicating machine.py's filter_tokens_by_chapter function here since it's not currently public
+def filter_tokens_by_chapter(tokens: List[UsfmToken], chapters: List[int]) -> List[UsfmToken]:
+    filtered: List[UsfmToken] = []
+    in_chapter = False
+    in_id_marker = False
+    for index, token in enumerate(tokens):
+        if index == 0 and token.marker == "id":
+            in_id_marker = True
+            if 1 in chapters:
+                in_chapter = True
+        elif in_id_marker and token.marker is not None and token.marker != "id":
+            in_id_marker = False
+        elif token.type == UsfmTokenType.CHAPTER:
+            data = str(token.data).strip() if token.data is not None else ""
+            in_chapter = data.isdigit() and int(data) in chapters
+        if in_id_marker or in_chapter:
+            filtered.append(token)
+    return filtered
+
+
 @dataclass
 class Sentence:
     text: str
@@ -38,12 +67,12 @@ class Sentence:
 @dataclass
 class DraftSentences:
     sentences: List[Sentence]
-    remarks: List[str]
+    remarks: List[Tuple[int, str]]
 
 
 # Takes the path to a USFM file and the relevant info to parse it
 # and returns the text of all non-embed sentences and their respective references,
-# along with any remarks (\rem) that were inserted at the beginning of the file
+# along with any remarks (\rem), paired with the chapter they appear in (0 for book-level remarks)
 def get_sentences(
     book_path: Path, stylesheet: UsfmStylesheet, encoding: str, book: str, chapters: List[int] = []
 ) -> DraftSentences:
@@ -51,8 +80,8 @@ def get_sentences(
 
     for sent in UsfmFileText(stylesheet, encoding, book, book_path, include_all_text=True):
         marker = sent.ref.path[-1].name if len(sent.ref.path) > 0 else ""
-        if marker == "rem" and len(draft_sentences.sentences) == 0:
-            draft_sentences.remarks.append(sent.text)
+        if marker == "rem":
+            draft_sentences.remarks.append((sent.ref.chapter_num, sent.text))
             continue
         if (
             marker in PARAGRAPH_TYPE_EMBEDS
@@ -137,37 +166,52 @@ def postprocess_draft(
         stylesheet = UsfmStylesheet("usfm.sty")
         encoding = "utf-8-sig"
 
-    src_sentences = get_sentences(draft_metadata.source_path, stylesheet, encoding, book)
     draft_sentences = get_sentences(draft_metadata.draft_path, stylesheet, encoding, book)
+    draft_chapters = sorted({sentence.ref.chapter_num for sentence in draft_sentences.sentences})
+    src_sentences = get_sentences(draft_metadata.source_path, stylesheet, encoding, book, draft_chapters)
 
     # Verify reference parity
     if len(src_sentences.sentences) != len(draft_sentences.sentences):
         LOGGER.warning(
-            f"Can't process {draft_metadata.source_path} and {draft_metadata.draft_path}: Unequal number of verses/references"
+            f"Can't process {draft_metadata.source_path} and {draft_metadata.draft_path}: "
+            f"Unequal number of verses/references"
         )
         return
     for src_sentence, draft_sentence in zip(src_sentences.sentences, draft_sentences.sentences):
         if src_sentence.ref.to_relaxed() != draft_sentence.ref.to_relaxed():
             LOGGER.warning(
-                f"Can't process {draft_metadata.source_path} and {draft_metadata.draft_path}: Mismatched ref, {src_sentence.ref} != {draft_sentence.ref}. Files must have the exact same USFM structure"
+                f"Can't process {draft_metadata.source_path} and {draft_metadata.draft_path}: "
+                f"Mismatched ref, {src_sentence.ref} != {draft_sentence.ref}. "
+                f"Files must have the exact same USFM structure"
             )
             return
 
-    if any(config.is_marker_placement_required() for config in postprocess_handler.configs):
+    source_usfm = None
+    if any(config.is_marker_processing_required() for config in postprocess_handler.configs):
         postprocess_handler.construct_rows(
             [s.ref for s in src_sentences.sentences],
             [s.text for s in src_sentences.sentences],
             [s.text for s in draft_sentences.sentences],
         )
 
-    with draft_metadata.source_path.open(encoding=encoding) as f:
-        source_usfm = f.read()
+        with draft_metadata.source_path.open(encoding=encoding) as f:
+            source_usfm = f.read()
+        if draft_chapters:
+            tokenizer = UsfmTokenizer(stylesheet)
+            source_usfm = tokenizer.detokenize(
+                filter_tokens_by_chapter(tokenizer.tokenize(source_usfm), draft_chapters)
+            )
 
     for config in postprocess_handler.configs:
-        if config.is_marker_placement_required():
+        paragraph_remark = config.get_paragraph_marker_remark()
+        remarks = [
+            (chapter_num, f"{text} {paragraph_remark}" if paragraph_remark else text)
+            for chapter_num, text in draft_sentences.remarks
+        ]
+        if config.is_marker_processing_required():
             place_markers_postprocessor = config.create_place_markers_postprocessor()
             target_usfm = place_markers_postprocessor.postprocess_usfm(
-                source_usfm, config.rows, draft_sentences.remarks
+                source_usfm, config.rows, remarks, stylesheet=stylesheet
             )
         else:
             with draft_metadata.draft_path.open(encoding=encoding) as f:
@@ -178,7 +222,9 @@ def postprocess_draft(
                 quotation_denormalization_postprocessor = config.create_denormalize_quotation_marks_postprocessor(
                     training_corpus_pairs,
                 )
-                target_usfm = quotation_denormalization_postprocessor.postprocess_usfm(target_usfm)
+                target_usfm = quotation_denormalization_postprocessor.postprocess_usfm(
+                    target_usfm, stylesheet=stylesheet
+                )
             except (UnknownQuoteConventionException, NoDetectedQuoteConventionException) as e:
                 LOGGER.warning(str(e) + " Skipping quotation mark denormalization.")
                 continue

--- a/silnlp/nmt/postprocess.py
+++ b/silnlp/nmt/postprocess.py
@@ -205,9 +205,11 @@ def postprocess_draft(
     for config in postprocess_handler.configs:
         if config.is_marker_processing_required():
             place_markers_postprocessor = config.create_place_markers_postprocessor()
+            source_remark_texts = {text.strip() for _, text in src_sentences.remarks}
             remarks = [
                 (chapter_num, place_markers_postprocessor.replace_paragraph_marker_remark(text))
                 for chapter_num, text in draft_sentences.remarks
+                if text.strip() not in source_remark_texts
             ]
             target_usfm = place_markers_postprocessor.postprocess_usfm(
                 source_usfm, config.rows, remarks, stylesheet=stylesheet

--- a/silnlp/nmt/postprocess.py
+++ b/silnlp/nmt/postprocess.py
@@ -166,9 +166,11 @@ def postprocess_draft(
         stylesheet = UsfmStylesheet("usfm.sty")
         encoding = "utf-8-sig"
 
-    draft_sentences = get_sentences(draft_metadata.draft_path, stylesheet, encoding, book)
-    draft_chapters = sorted({sentence.ref.chapter_num for sentence in draft_sentences.sentences})
-    src_sentences = get_sentences(draft_metadata.source_path, stylesheet, encoding, book, draft_chapters)
+    draft_sentences: DraftSentences = get_sentences(draft_metadata.draft_path, stylesheet, encoding, book)
+    draft_chapters: List[int] = sorted({sentence.ref.chapter_num for sentence in draft_sentences.sentences})
+    src_sentences: DraftSentences = get_sentences(
+        draft_metadata.source_path, stylesheet, encoding, book, draft_chapters
+    )
 
     # Verify reference parity
     if len(src_sentences.sentences) != len(draft_sentences.sentences):

--- a/silnlp/nmt/postprocess.py
+++ b/silnlp/nmt/postprocess.py
@@ -203,13 +203,12 @@ def postprocess_draft(
             )
 
     for config in postprocess_handler.configs:
-        paragraph_remark = config.get_paragraph_marker_remark()
-        remarks = [
-            (chapter_num, f"{text} {paragraph_remark}" if paragraph_remark else text)
-            for chapter_num, text in draft_sentences.remarks
-        ]
         if config.is_marker_processing_required():
             place_markers_postprocessor = config.create_place_markers_postprocessor()
+            remarks = [
+                (chapter_num, place_markers_postprocessor.replace_paragraph_marker_remark(text))
+                for chapter_num, text in draft_sentences.remarks
+            ]
             target_usfm = place_markers_postprocessor.postprocess_usfm(
                 source_usfm, config.rows, remarks, stylesheet=stylesheet
             )


### PR DESCRIPTION
This PR adds full support for incremental draft generation to the postprocess.py and postprocess_draft.py scripts. Since remarks are now at a chapter level, some adjustments were needed to make sure multiple remarks don't get inserted if postprocess.py is called after translate.py.

It also adjusts remarks so that they fully match the Scripture Forge remarks. For example:

>no postprocessing
>
>\rem This draft of JUD 1 was generated by AI from project [src project] on 2026-06-10 02:36:02Z. It should be reviewed carefully for errors before use. Paragraph break positions were moved to the end of the verse.

>paragraph_behavior: place
  include_style_markers: True
  include_embeds: True
  denormalize_quotation_marks: True
>
>\rem This draft of ACT 11 was generated by AI from project [src project] on 2026-06-10 18:17:04Z. It should be reviewed carefully for errors before use. Paragraph break positions were preserved.
>
>(no quotation remark if quotation denormalization was unsuccessful for the chapter)

>paragraph_behavior: strip
>
>\rem This draft of ACT 11 was generated by AI from project [src project] on 2026-06-10 18:17:04Z. It should be reviewed carefully for errors before use. Paragraph breaks were removed.

>denormalize_quotation_marks: True
  source_quote_convention: standard_english
  target_quote_convention: western_european
>
>\rem This draft of ACT 12 was generated by AI from project NIV11 on 2026-06-10 18:17:04Z. It should be reviewed carefully for errors before use. Paragraph break positions were moved to the end of the verse. Quotation marks have been adjusted automatically to match the rest of the project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1095)
<!-- Reviewable:end -->
