### PR TITLE
set token to False

### DIFF
--- a/silnlp/nmt/hugging_face_config.py
+++ b/silnlp/nmt/hugging_face_config.py
@@ -319,7 +319,7 @@ class FilePreTrainedModelProvider(PreTrainedModelProvider):
     ) -> PreTrainedModel:
         model = cast(
             PreTrainedModel,
-            AutoModelForSeq2SeqLM.from_pretrained(model_name, config=model_config, device_map=device_map),
+            AutoModelForSeq2SeqLM.from_pretrained(model_name, config=model_config, device_map=device_map, token=False),
         )
         return model
 
@@ -328,6 +328,7 @@ class FilePreTrainedModelProvider(PreTrainedModelProvider):
             model_name,
             torch_dtype=self._dtype,
             attn_implementation=self._attention_implementation,
+            token=False,
         )
 
 
@@ -532,7 +533,7 @@ class HuggingFaceConfig(Config):
             file.seek(0)
             json.dump(data, file, ensure_ascii=False, indent=4)
             file.truncate()
-        self._tokenizer = AutoTokenizer.from_pretrained(str(self.exp_dir), use_fast=True)
+        self._tokenizer = AutoTokenizer.from_pretrained(str(self.exp_dir), use_fast=True, token=False)
         return
 
     def _train_sp_tokenizer(self, files, vocab_size) -> Union[SentencePieceBPETokenizer, SentencePieceUnigramTokenizer]:
@@ -701,12 +702,12 @@ class HuggingFaceConfig(Config):
                 and not (self.exp_dir / "tokenizer_config.json").is_file()
             ):
                 if self.model_prefix == "facebook/nllb-200":
-                    self._tokenizer = NllbTokenizer.from_pretrained(str(self.exp_dir))
+                    self._tokenizer = NllbTokenizer.from_pretrained(str(self.exp_dir), token=False)
                     self._tokenizer = convert_slow_tokenizer(self._tokenizer)
                     self._tokenizer = NllbTokenizerFast(tokenizer_object=self._tokenizer)
                     self._tokenizer.save_pretrained(str(self.exp_dir))
                 elif self.model_prefix == "google/madlad400":
-                    self._tokenizer = T5Tokenizer.from_pretrained(str(self.exp_dir))
+                    self._tokenizer = T5Tokenizer.from_pretrained(str(self.exp_dir), token=False)
                     self._tokenizer = convert_slow_tokenizer(self._tokenizer)
                     self._tokenizer = T5TokenizerFast(tokenizer_object=self._tokenizer)
                     self._tokenizer.add_special_tokens(
@@ -728,7 +729,7 @@ class HuggingFaceConfig(Config):
                     model_name_or_path = str(parent_dir)
                 else:
                     model_name_or_path = self.model
-                self._tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)
+                self._tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True, token=False)
             self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
         return self._tokenizer
 
@@ -743,7 +744,7 @@ class HuggingFaceConfig(Config):
             else:
                 model_name_or_path = self.model
 
-            self._tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)
+            self._tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True, token=False)
             self._tokenizer.deprecation_warnings["Asking-to-pad-a-fast-tokenizer"] = True
         return self._tokenizer
 
@@ -978,6 +979,7 @@ class HuggingFaceNMTModel(NMTModel):
             id2label={},
             num_labels=0,
             attn_implementation=self._config.params["attn_implementation"],
+            token=False,
         )
         if self._num_devices == 2 and self._config.model_prefix == "facebook/nllb-200":
             device_map = {

--- a/tests/smoke_tests/mock_pretrained_model.py
+++ b/tests/smoke_tests/mock_pretrained_model.py
@@ -32,7 +32,7 @@ def create_mock_pretrained_model(
     if model_stats is None:
         model_stats = ModelTrainingStats()
 
-    underlying_model = cast(PreTrainedModel, AutoModelForSeq2SeqLM.from_pretrained(_TINY_MODEL_NAME))
+    underlying_model = cast(PreTrainedModel, AutoModelForSeq2SeqLM.from_pretrained(_TINY_MODEL_NAME, token=False))
     underlying_model_forward = underlying_model.forward
     last_transition_scores: torch.Tensor | None = None
 


### PR DESCRIPTION
This addresses issue #791, to set `token=False` in all `from_pretrained` methods, since we ran into an issue with an expired/invalid huggingface token in the past, despite public hf repos like the one for NLLB not needing a token to access it all. So setting `token=False` just avoids the issue of expired/revoked tokens entirely.

I did consider adding a boolean option `use_private_hf_repo` to config.yml that could be used to determine whether token should be set to False or None (if None, it uses tokens stored in the cache or the environment). However, since we never use private hf repos for translation work, that seemed like it might be more complicated than we need. But I can add something like this if we'd prefer to keep the functionality to access private hf repos.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1101)
<!-- Reviewable:end -->
