### PR TITLE
remove workaround for get_chapters

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5179,13 +5179,13 @@ type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12
 
 [[package]]
 name = "sil-machine"
-version = "1.8.10"
+version = "1.8.11"
 description = "A natural language processing library that is focused on providing tools for resource-poor languages."
 optional = false
 python-versions = "<3.14,>=3.10"
 files = [
-    {file = "sil_machine-1.8.10-py3-none-any.whl", hash = "sha256:5fea84f138d41c9b591a67165280ee94b485f431b7092c968ae530a2cc592afc"},
-    {file = "sil_machine-1.8.10.tar.gz", hash = "sha256:b986945a5aa4ea7135764b7a8b0fdc0761b52884c8af4f828ae5536d7350afab"},
+    {file = "sil_machine-1.8.11-py3-none-any.whl", hash = "sha256:b8754ceb2da9e92a652ad26f2313ab07b77556edca309b3472434d5fbe7ba312"},
+    {file = "sil_machine-1.8.11.tar.gz", hash = "sha256:a55e53a7ee0cc20c6cd93255c1588680a2d8b56853818889aac7c3cdcceefb73"},
 ]
 
 [package.dependencies]
@@ -6143,4 +6143,4 @@ eflomal = ["eflomal"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "846e933d2f7f204db068f69bee3f804984c99f73a146974abc99393185773288"
+content-hash = "9d421a45d8d3cfe90f854203e7fd05b2f5efaf4f13540c370fded69cd897749d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ tqdm = "^4.62.2"
 sacrebleu = "^2.3.1"
 ctranslate2 = "^3.5.1"
 libclang = "14.0.6"
-sil-machine = {extras = ["thot"], version = "1.8.10"}
+sil-machine = {extras = ["thot"], version = "1.8.11"}
 datasets = "^2.7.1"
 torch = {version = "^2.4", source = "torch"}
 sacremoses = "^0.0.53"

--- a/silnlp/common/postprocesser.py
+++ b/silnlp/common/postprocesser.py
@@ -20,7 +20,6 @@ from machine.corpora import (
 )
 from machine.punctuation_analysis import (
     STANDARD_QUOTE_CONVENTIONS,
-    Chapter,
     FileParatextProjectQuoteConventionDetector,
     QuotationMarkDenormalizationFirstPass,
     QuotationMarkDenormalizationUsfmUpdateBlockHandler,
@@ -209,35 +208,14 @@ class DenormalizeQuotationMarksPostprocessor:
 
     def _get_best_chapter_strategies(self, usfm: str, stylesheet: UsfmStylesheet) -> List[QuotationMarkUpdateStrategy]:
         quotation_mark_update_first_pass = QuotationMarkDenormalizationFirstPass(self._target_quote_convention)
-
         parse_usfm(usfm, quotation_mark_update_first_pass, stylesheet)
 
-        # sil-machine's get_chapters() currently mislabels chapter numbers, temp workaround until machine.py is fixed
-        strategy_by_chapter: Dict[int, QuotationMarkUpdateStrategy] = {}
-        for chapter, (_, strategy) in zip(
-            quotation_mark_update_first_pass.get_chapters(),
-            quotation_mark_update_first_pass.find_best_chapter_strategies(),
-        ):
-            chapter_num = self._get_chapter_number(chapter)
-            if chapter_num is None:
-                LOGGER.warning(
-                    "Could not determine a chapter's number while denormalizing quotation marks; skipping it."
-                )
-                continue
-            strategy_by_chapter[chapter_num] = strategy
-
-        chapter_strategies = [QuotationMarkUpdateStrategy.APPLY_FULL] * max(strategy_by_chapter, default=0)
-        for chapter_num, strategy in strategy_by_chapter.items():
-            chapter_strategies[chapter_num - 1] = strategy
-        return chapter_strategies
-
-    @staticmethod
-    def _get_chapter_number(chapter: Chapter) -> Optional[int]:
-        for verse in chapter.verses:
-            for text_segment in verse.text_segments:
-                if text_segment.chapter is not None:
-                    return text_segment.chapter
-        return None
+        chapter_strategies = quotation_mark_update_first_pass.find_best_chapter_strategies()
+        max_chapter = max((n for n, _ in chapter_strategies), default=0)
+        padded_chapter_strategies = [QuotationMarkUpdateStrategy.APPLY_FULL] * max_chapter
+        for chapter_num, strategy in chapter_strategies:
+            padded_chapter_strategies[chapter_num - 1] = strategy
+        return padded_chapter_strategies
 
     def _create_chapter_remarks(self, chapter_strategies: List[QuotationMarkUpdateStrategy]) -> Dict[int, str]:
         return {


### PR DESCRIPTION
This PR addresses issue #1098. It upgrades silnlp to the latest version of sil-machine and removes the workaround for the get_chapters bug that was in the previous version of sil-machine, simplifying the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1104)
<!-- Reviewable:end -->
