### PR TITLE
Fix issue with ref_projects being empty

### DIFF
--- a/scripts/automate_onboard_project.py
+++ b/scripts/automate_onboard_project.py
@@ -109,13 +109,13 @@ try:
                 ]
             )
 
-        if len(args.ref_projects) > 0:
+        if args.ref_projects and len(args.ref_projects) > 0:
             onboarding_args.extend(["--ref-projects", *args.ref_projects])
 
-        if len(args.completed_books) > 0:
+        if args.completed_books and len(args.completed_books) > 0:
             onboarding_args.extend(["--completed-books", *args.completed_books])
 
-        if len(args.planned_books) > 0:
+        if args.planned_books and len(args.planned_books) > 0:
             onboarding_args.extend(["--planned-books", *args.planned_books])
 
         sys.argv = onboarding_args

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -963,7 +963,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--ref-projects",
-        help="The Reference Paratext project name(s) for onboarding the Main Pproject(s). The project(s) will be stored on the bucket at Paratext/projects/<project>.",
+        help="The Reference Paratext project name(s) for onboarding the Main Project(s). The project(s) will be stored on the bucket at Paratext/projects/<project>.",
         nargs="+",
         default=None,
     )


### PR DESCRIPTION
This fixes a bug introduced in this [PR](https://github.com/sillsdev/silnlp/pull/1105), which causes a `TypeError` when `args.ref_projects` is `None`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1112)
<!-- Reviewable:end -->
