### PR TITLE
Increase number of samples used for linear regression

### DIFF
--- a/silnlp/common/linear_regression.py
+++ b/silnlp/common/linear_regression.py
@@ -109,7 +109,7 @@ def perform_enhanced_linear_regression(x: List[float], y: List[float]) -> Linear
     weighting_scheme = InverseDensityPointWeightingScheme()
 
     bootstrap_results = []
-    for _ in range(100):
+    for _ in range(1000):
         sampled_x, sampled_y = sampler.sample(num_samples=len(x))
         result = perform_weighted_linear_regression(sampled_x, sampled_y, point_weighting_scheme=weighting_scheme)
         bootstrap_results.append(result)


### PR DESCRIPTION
The PR increases the number of samples used for bootstrap sampling in the new linear regression method.  This should improve the stability of the regression results across different runs for a negligible runtime cost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1115)
<!-- Reviewable:end -->
