### PR TITLE
Add create_onboarding_experiments utility

### DIFF
--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -12,6 +12,8 @@ import itertools
 import json
 import logging
 import re
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -45,6 +47,22 @@ SEED = 111
 MODEL = "facebook/nllb-200-distilled-1.3B"
 BOOK_COMPLETENESS_THRESHOLD = 0.98
 MAX_UNPROMPTED_MIXED = 3
+
+EXPERIMENT_ARGS = [
+    "-m",
+    "silnlp.nmt.experiment",
+    "--save-checkpoints",
+    "--save-confidences",
+    "--clearml-queue",
+    "jobs_urgent",
+    "--clearml-tag",
+    "eitl",
+    "--preprocess",
+    "--stats",
+    "--train",
+    "--test",
+    "--translate",
+]
 
 
 @dataclass
@@ -310,6 +328,37 @@ def write_yaml(path: Path, content: dict) -> None:
         yaml.dump(content, file, sort_keys=False, default_flow_style=False, allow_unicode=True)
 
 
+def submit_experiments(experiments: List[Experiment], experiments_dir: Path, submit: Optional[bool]) -> None:
+    """Print the run command for each experiment and optionally execute them.
+
+    submit: True runs without asking, None asks first, False only prints the commands.
+    """
+    names = [experiment.folder.relative_to(experiments_dir).as_posix() for experiment in experiments]
+    print("\nTo run the experiments:")
+    for name in names:
+        print(f"  poetry run python {' '.join(EXPERIMENT_ARGS)} {name}")
+    if submit is None:
+        try:
+            reply = input(f"\nRun {len(names)} experiment(s) now? [y/N]: ").strip().lower()
+        except EOFError:
+            reply = ""
+        submit = reply in ("y", "yes")
+    if not submit:
+        return
+
+    failures = []
+    for name in names:
+        print(f"\nRunning experiment {name}")
+        result = subprocess.run([sys.executable] + EXPERIMENT_ARGS + [name])
+        if result.returncode != 0:
+            failures.append(name)
+            print(f"Experiment {name} exited with code {result.returncode}.")
+    if failures:
+        print(f"\n{len(failures)} of {len(names)} experiment(s) failed: {', '.join(failures)}")
+    else:
+        print(f"\nAll {len(names)} experiment(s) completed.")
+
+
 def resolve_request_dir(request: str, experiments_dir: Path) -> Path:
     requests_dir = experiments_dir / "_OnboardingRequests"
     for name in [request, f"{request}_Request"]:
@@ -328,6 +377,7 @@ def run(
     min_parallel: int,
     min_alignment: float,
     dry_run: bool = False,
+    submit: Optional[bool] = False,
 ) -> List[Experiment]:
     log_path = request_dir / "onboarding.log"
     if not log_path.is_file():
@@ -356,6 +406,7 @@ def run(
     mixed = select_mixed_pairs([list(pair) for pair in itertools.combinations(passing, 2)], dry_run)
 
     experiments: List[Experiment] = []
+    existing_experiments: List[Experiment] = []
     print()
     for sources in [[c] for c in passing] + mixed:
         label = " + ".join(source.name for source in sources)
@@ -372,6 +423,14 @@ def run(
         existing, index = find_existing(lang_dir, prefix, config)
         if existing is not None:
             print(f"Skipped {label}: {existing} already contains an identical config.yml.")
+            existing_experiments.append(
+                Experiment(
+                    sources=sources,
+                    folder=existing,
+                    config=config,
+                    translate_config=build_translate_config(sources, translate_books),
+                )
+            )
             continue
         folder = lang_dir / f"{prefix}_{index}"
         experiment = Experiment(
@@ -388,6 +447,11 @@ def run(
             write_yaml(folder / "config.yml", experiment.config)
             write_yaml(folder / "translate_config.yml", experiment.translate_config)
             print(f"Created {folder} (corpus_books: {corpus_books})")
+    if experiments or existing_experiments:
+        # Existing folders with an identical config are offered too: their creation was
+        # skipped, but the experiments themselves may not have been run yet.
+        # In a dry run nothing new exists to execute, so only print the commands.
+        submit_experiments(experiments + existing_experiments, experiments_dir, submit=False if dry_run else submit)
     return experiments
 
 
@@ -408,6 +472,11 @@ def main() -> None:
         help="Book or semicolon-separated list of books for translate_config.yml",
     )
     parser.add_argument("--dry-run", action="store_true", help="Report without creating folders or files")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run each created experiment (silnlp.nmt.experiment) without asking first",
+    )
     args = parser.parse_args()
 
     environment = SilNlpEnv.create_standard_environment()
@@ -421,6 +490,7 @@ def main() -> None:
         min_parallel=args.min_parallel,
         min_alignment=args.min_alignment,
         dry_run=args.dry_run,
+        submit=True if args.run else None,
     )
 
 

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -12,15 +12,16 @@ import itertools
 import json
 import logging
 import re
+import string
 import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import AbstractSet, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import yaml
-from machine.scripture import ALL_BOOK_IDS, book_id_to_number, is_nt, is_ot
+from machine.scripture import ALL_BOOK_IDS, book_id_to_number, book_number_to_id, get_chapters, is_nt, is_ot
 
 from .environment import SilNlpEnv
 from .iso_info import ALT_ISO, NLLB_TAG_FROM_ISO
@@ -171,6 +172,34 @@ def stem_to_project(stem: str) -> str:
     return stem.split("-", 1)[1] if "-" in stem else stem
 
 
+def parse_book_list(value: str) -> str:
+    """Normalise and validate a book list from the command line.
+
+    Any selection get_chapters accepts is kept verbatim (books, OT/NT, ranges like GEN-DEU,
+    chapter selections like "MAT 1-4", subtractions like "NT;-REV"). A plain book list may
+    also be separated by commas or spaces instead of semicolons. Raises ValueError with
+    get_chapters' message when the value is not a valid book list.
+    """
+    verbatim = value.strip().upper()
+    candidates = [verbatim, ";".join(token for token in re.split(r"[;,\s]+", verbatim) if token)]
+    error: Optional[ValueError] = None
+    for candidate in candidates:
+        try:
+            if get_chapters(candidate):
+                return candidate
+        except ValueError as e:
+            error = error or e
+    raise ValueError(f"'{value}' is not a valid book list{f': {error}' if error else '.'}")
+
+
+def compact_canons(books: List[str]) -> str:
+    """Replace a full testament's books with its OT/NT token."""
+    for canon, token in [(OT_CANON, "OT"), (NT_CANON, "NT")]:
+        if all(book in books for book in canon):
+            books = [book for book in books if book not in canon] + [token]
+    return ";".join(books)
+
+
 def to_iso3(iso: str) -> Optional[str]:
     if len(iso) == 3:
         return iso
@@ -184,17 +213,56 @@ def nllb_tag(iso: str, script: str) -> str:
     return NLLB_TAG_FROM_ISO.get(iso3, f"{iso3}_{script}")
 
 
-def lookup_language(iso: str, assets_dir: Path) -> Tuple[str, str]:
-    """Return (language name, country) for an iso code from languageFamilies.json."""
+def load_language_entries(assets_dir: Path) -> List[dict]:
+    with open(assets_dir / "languageFamilies.json", "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def lookup_language(iso: str, entries: List[dict]) -> Tuple[str, str]:
+    """Return (language name, country) for an iso code from the languageFamilies.json entries."""
     iso3 = to_iso3(iso)
     if iso3 is None:
         raise ValueError(f"Cannot resolve iso code '{iso}' to a 3-letter code.")
-    with open(assets_dir / "languageFamilies.json", "r", encoding="utf-8") as file:
-        entries = json.load(file)
     for entry in entries:
         if entry.get("isoCode") == iso3:
             return entry["language"], entry["langCountry"]
     raise ValueError(f"Iso code '{iso3}' not found in languageFamilies.json; cannot determine language and country.")
+
+
+def synthesize_trg_iso(iso3: str, real_isos: AbstractSet[str]) -> str:
+    """Derive a code that is neither a real iso code nor in NLLB by mutating the last two letters."""
+    for last_two in itertools.product(string.ascii_lowercase, repeat=2):
+        candidate = iso3[0] + "".join(last_two)
+        if candidate != iso3 and candidate not in real_isos and candidate not in NLLB_TAG_FROM_ISO:
+            return candidate
+    raise ValueError(f"Could not synthesize a target iso code from '{iso3}'.")
+
+
+def find_prior_rename(scripture_dir: Optional[Path], main: MainProject, real_isos: AbstractSet[str]) -> Optional[str]:
+    """Return the synthetic iso of an extract file renamed by a previous run, if one exists.
+
+    The renamed file on disk is the durable record of the code chosen earlier, so re-runs
+    reuse it instead of deriving a possibly different code from the current iso tables.
+    """
+    if scripture_dir is None or not scripture_dir.is_dir():
+        return None
+    for path in sorted(scripture_dir.glob(f"*-{stem_to_project(main.stem)}.txt")):
+        iso = stem_to_iso(path.stem)
+        if iso != main.iso and iso not in real_isos and iso not in NLLB_TAG_FROM_ISO:
+            return iso
+    return None
+
+
+def execute_rename(scripture_dir: Path, terms_dir: Optional[Path], old_stem: str, new_stem: str) -> None:
+    """Rename the target extract file (and its terms renderings files) to the synthetic stem."""
+    old_path = scripture_dir / f"{old_stem}.txt"
+    old_path.rename(scripture_dir / f"{new_stem}.txt")
+    print(f"Renamed {old_path.name} to {new_stem}.txt in {scripture_dir}")
+    if terms_dir is not None and terms_dir.is_dir():
+        for path in sorted(terms_dir.glob(f"{old_stem}-*-renderings.txt")):
+            target = f"{new_stem}{path.name[len(old_stem):]}"
+            path.rename(terms_dir / target)
+            print(f"Renamed {path.name} to {target} in {terms_dir}")
 
 
 def folder_name(name: str) -> str:
@@ -211,17 +279,42 @@ def load_verse_counts(request_dir: Path, experiments_dir: Path) -> pd.DataFrame:
     if not frames:
         raise FileNotFoundError(
             f"No verse_counts.csv found in {request_dir} or {experiments_dir / 'verse_counts'};"
-            " required for --books complete."
+            " required for --training-books complete."
         )
     df = pd.concat(frames)
     return df[~df.index.duplicated(keep="first")]
 
 
-def resolve_corpus_books(books_arg: str, stems: Sequence[str], verse_counts: Optional[pd.DataFrame]) -> str:
+def resolve_corpus_books(
+    books_arg: str,
+    stems: Sequence[str],
+    verse_counts: Optional[pd.DataFrame],
+    exclude: AbstractSet[int] = frozenset(),
+) -> Tuple[str, List[str]]:
+    """Resolve the corpus_books list, excluding the books in `exclude` (canon book numbers).
+
+    An explicit books_arg is kept verbatim (it may use any get_chapters syntax) with
+    subtraction selections appended for the excluded books it covers.
+    Returns (corpus_books string, ids of the books that were excluded from it).
+    """
     if books_arg.lower() != "complete":
-        return books_arg
+        selection = get_chapters(books_arg)  # book number -> chapter list ([] = whole book)
+        overlap = sorted(number for number in selection if number in exclude)
+        removed = [book_number_to_id(number) for number in overlap]
+        if not removed:
+            return books_arg, []
+        if len(overlap) == len(selection):
+            return "", removed
+        subtractions = [
+            f"-{book_number_to_id(number)}{','.join(str(chapter) for chapter in selection[number])}"
+            for number in overlap
+        ]
+        corpus_books = ";".join([books_arg] + subtractions)
+        get_chapters(corpus_books)  # never emit a selection the downstream parser rejects
+        return corpus_books, removed
+
     if verse_counts is None:
-        raise ValueError("verse counts are required for --books complete")
+        raise ValueError("verse counts are required for --training-books complete")
     if "complete" not in verse_counts.index:
         raise ValueError("No 'complete' row found in verse_counts.csv; cannot apply the completeness rule.")
     for stem in stems:
@@ -240,29 +333,30 @@ def resolve_corpus_books(books_arg: str, stems: Sequence[str], verse_counts: Opt
         if all(not pd.isna(count) and count >= threshold for count in counts):
             books.append(book)
 
-    for canon, token in [(OT_CANON, "OT"), (NT_CANON, "NT")]:
-        if all(book in books for book in canon):
-            books = [book for book in books if book not in canon] + [token]
-    return ";".join(books)
+    removed = [book for book in books if book_id_to_number(book) in exclude]
+    return compact_canons([book for book in books if book_id_to_number(book) not in exclude]), removed
 
 
-def build_config(sources: List[Candidate], main: MainProject, corpus_books: str) -> dict:
+def build_config(
+    sources: List[Candidate], main: MainProject, corpus_books: str, test_variant: Optional[str] = None
+) -> dict:
     lang_codes: Dict[str, str] = {}
     for source in sources:
         lang_codes.setdefault(source.iso, nllb_tag(source.iso, source.script))
     lang_codes.setdefault(main.iso, nllb_tag(main.iso, main.script or ""))
     src_stems = [source.stem for source in sources]
+    corpus_pair: Dict[str, object] = {
+        "corpus_books": corpus_books,
+        "mapping": "mixed_src",
+        "src": src_stems[0] if len(src_stems) == 1 else src_stems,
+        "trg": main.stem,
+        "type": "train" if test_variant == "notest" else "train,test",
+    }
+    if test_variant == "test100":
+        corpus_pair["test_size"] = 100
     return {
         "data": {
-            "corpus_pairs": [
-                {
-                    "corpus_books": corpus_books,
-                    "mapping": "mixed_src",
-                    "src": src_stems[0] if len(src_stems) == 1 else src_stems,
-                    "trg": main.stem,
-                    "type": "train,test",
-                }
-            ],
+            "corpus_pairs": [corpus_pair],
             "lang_codes": lang_codes,
             "seed": SEED,
         },
@@ -328,15 +422,19 @@ def write_yaml(path: Path, content: dict) -> None:
         yaml.dump(content, file, sort_keys=False, default_flow_style=False, allow_unicode=True)
 
 
-def submit_experiments(experiments: List[Experiment], experiments_dir: Path, submit: Optional[bool]) -> None:
+def submit_experiments(
+    experiments: List[Experiment], experiments_dir: Path, submit: Optional[bool], no_test: bool = False
+) -> None:
     """Print the run command for each experiment and optionally execute them.
 
     submit: True runs without asking, None asks first, False only prints the commands.
+    no_test: drop the --test stage (the experiments have no test set).
     """
+    experiment_args = [arg for arg in EXPERIMENT_ARGS if not (no_test and arg == "--test")]
     names = [experiment.folder.relative_to(experiments_dir).as_posix() for experiment in experiments]
     print("\nTo run the experiments:")
     for name in names:
-        print(f"  poetry run python {' '.join(EXPERIMENT_ARGS)} {name}")
+        print(f"  poetry run python {' '.join(experiment_args)} {name}")
     if submit is None:
         try:
             reply = input(f"\nRun {len(names)} experiment(s) now? [y/N]: ").strip().lower()
@@ -349,7 +447,7 @@ def submit_experiments(experiments: List[Experiment], experiments_dir: Path, sub
     failures = []
     for name in names:
         print(f"\nRunning experiment {name}")
-        result = subprocess.run([sys.executable] + EXPERIMENT_ARGS + [name])
+        result = subprocess.run([sys.executable] + experiment_args + [name])
         if result.returncode != 0:
             failures.append(name)
             print(f"Experiment {name} exited with code {result.returncode}.")
@@ -372,19 +470,25 @@ def run(
     request_dir: Path,
     experiments_dir: Path,
     assets_dir: Path,
-    books: str,
+    training_books: str,
     translate_books: str,
     min_parallel: int,
     min_alignment: float,
+    scripture_dir: Optional[Path] = None,
+    terms_dir: Optional[Path] = None,
+    test_variant: Optional[str] = None,
     dry_run: bool = False,
     submit: Optional[bool] = False,
 ) -> List[Experiment]:
+    if test_variant not in (None, "notest", "test100"):
+        raise ValueError(f"Unknown test_variant '{test_variant}'; expected None, 'notest' or 'test100'.")
     log_path = request_dir / "onboarding.log"
     if not log_path.is_file():
         raise FileNotFoundError(f"No onboarding.log found in {request_dir}.")
     main, candidates = parse_log(log_path)
 
-    language, country = lookup_language(main.iso, assets_dir)
+    language_entries = load_language_entries(assets_dir)
+    language, country = lookup_language(main.iso, language_entries)
     lang_dir = experiments_dir / folder_name(country) / folder_name(language)
     print(f"Main project: {main.name} ({main.stem}), language: {language} [{main.iso}], country: {country}")
     print(f"Experiment location: {lang_dir}")
@@ -399,27 +503,82 @@ def run(
         print(f"\nNo references passed the thresholds (parallel >= {min_parallel}, alignment >= {min_alignment}).")
         return []
 
+    # The src and trg isos of a corpus pair must differ. When a passing reference shares the
+    # main project's iso, switch the main project to a synthetic code (not a real iso, not in
+    # NLLB) and rename its extract file to match. The rename is deferred until an experiment
+    # is actually created; a run that creates nothing leaves MT/scripture untouched. A rename
+    # done by a previous run (recorded by the file on disk) is reused even when the current
+    # thresholds no longer surface the clash, so the configs always match the file that exists.
+    counts_stem = main.stem  # verse_counts.csv is keyed by the original stem
+    real_isos = {entry["isoCode"] for entry in language_entries}
+    prior_iso = find_prior_rename(scripture_dir, main, real_isos)
+    clashing = [c for c in passing if to_iso3(c.iso) == to_iso3(main.iso)]
+    pending_rename: Optional[Tuple[str, str]] = None  # (old stem, new stem), executed on first creation
+    if clashing or prior_iso is not None:
+        synthetic = prior_iso or synthesize_trg_iso(to_iso3(main.iso) or main.iso, real_isos)
+        if clashing:
+            names = ", ".join(c.name for c in clashing)
+            print(
+                f"\n{names} share{'s' if len(clashing) == 1 else ''} iso code '{main.iso}' with the target"
+                f" project; using synthetic target code '{synthetic}' instead."
+            )
+        else:
+            print(f"\nUsing synthetic target code '{synthetic}' from the previously renamed extract file.")
+        new_stem = f"{synthetic}-{stem_to_project(main.stem)}"
+        if scripture_dir is None:
+            if not dry_run:
+                raise ValueError("No scripture directory available to rename the target extract file in.")
+            print(f"Would rename {main.stem}.txt to {new_stem}.txt in the MT scripture folder.")
+        else:
+            old_exists = (scripture_dir / f"{main.stem}.txt").is_file()
+            new_exists = (scripture_dir / f"{new_stem}.txt").is_file()
+            if old_exists and new_exists:
+                raise RuntimeError(
+                    f"Both {main.stem}.txt and {new_stem}.txt exist in {scripture_dir} (the original was"
+                    " probably re-extracted after an earlier rename); remove the stale one before re-running."
+                )
+            if old_exists:
+                pending_rename = (main.stem, new_stem)
+                if dry_run:
+                    print(
+                        f"Would rename {main.stem}.txt to {new_stem}.txt in {scripture_dir}"
+                        " (and matching terms renderings files)."
+                    )
+            elif not new_exists and not dry_run:
+                raise FileNotFoundError(f"Neither {main.stem}.txt nor {new_stem}.txt found in {scripture_dir}.")
+        main.iso, main.stem = synthetic, new_stem
+
     verse_counts = None
-    if books.lower() == "complete":
+    if training_books.lower() == "complete":
         verse_counts = load_verse_counts(request_dir, experiments_dir)
+    translate_set = frozenset(get_chapters(translate_books))
 
     mixed = select_mixed_pairs([list(pair) for pair in itertools.combinations(passing, 2)], dry_run)
 
     experiments: List[Experiment] = []
     existing_experiments: List[Experiment] = []
+    warned_removals: set = set()
     print()
     for sources in [[c] for c in passing] + mixed:
         label = " + ".join(source.name for source in sources)
         try:
-            corpus_books = resolve_corpus_books(books, [s.stem for s in sources] + [main.stem], verse_counts)
+            corpus_books, removed = resolve_corpus_books(
+                training_books, [s.stem for s in sources] + [counts_stem], verse_counts, exclude=translate_set
+            )
         except ValueError as e:
             print(f"Skipped {label}: {e}")
             continue
+        if removed and tuple(removed) not in warned_removals:
+            warned_removals.add(tuple(removed))
+            print(f"Warning: excluded the books being translated from corpus_books: {';'.join(removed)}")
         if not corpus_books:
-            print(f"Skipped {label}: no book meets the {BOOK_COMPLETENESS_THRESHOLD:.0%} completeness rule.")
+            print(
+                f"Skipped {label}: no training books remain after the {BOOK_COMPLETENESS_THRESHOLD:.0%}"
+                " completeness rule and the translate-book exclusion."
+            )
             continue
-        config = build_config(sources, main, corpus_books)
-        prefix = "_".join([source.name for source in sources] + [main.iso])
+        config = build_config(sources, main, corpus_books, test_variant)
+        prefix = "_".join([source.name for source in sources] + [main.iso] + ([test_variant] if test_variant else []))
         existing, index = find_existing(lang_dir, prefix, config)
         if existing is not None:
             print(f"Skipped {label}: {existing} already contains an identical config.yml.")
@@ -443,6 +602,10 @@ def run(
         if dry_run:
             print(f"Would create {folder} (corpus_books: {corpus_books})")
         else:
+            if pending_rename is not None:
+                assert scripture_dir is not None
+                execute_rename(scripture_dir, terms_dir, *pending_rename)
+                pending_rename = None
             folder.mkdir(parents=True, exist_ok=True)
             write_yaml(folder / "config.yml", experiment.config)
             write_yaml(folder / "translate_config.yml", experiment.translate_config)
@@ -451,7 +614,12 @@ def run(
         # Existing folders with an identical config are offered too: their creation was
         # skipped, but the experiments themselves may not have been run yet.
         # In a dry run nothing new exists to execute, so only print the commands.
-        submit_experiments(experiments + existing_experiments, experiments_dir, submit=False if dry_run else submit)
+        submit_experiments(
+            experiments + existing_experiments,
+            experiments_dir,
+            submit=False if dry_run else submit,
+            no_test=test_variant == "notest",
+        )
     return experiments
 
 
@@ -461,15 +629,30 @@ def main() -> None:
     parser.add_argument("request", help="Request folder name in MT/experiments/_OnboardingRequests")
     parser.add_argument("--min-parallel", type=int, default=2000, help="Minimum parallel verse count (default 2000)")
     parser.add_argument("--min-alignment", type=float, default=0.2, help="Minimum alignment score (default 0.2)")
+    book_list_syntax = (
+        "separated by commas, semicolons or spaces, including silnlp selections like ranges and"
+        ' subtractions (quote semicolons and spaces: "GEN;RUT", "GEN RUT", "NT;-REV", "GEN-DEU")'
+    )
     parser.add_argument(
-        "--books",
+        "--training-books",
         default="complete",
-        help="Semicolon-separated corpus_books list, or 'complete' (default) to derive it from verse_counts.csv",
+        help=f"Corpus_books list {book_list_syntax}, or 'complete' (default) to derive it from verse_counts.csv",
     )
     parser.add_argument(
         "--translate-books",
         required=True,
-        help="Book or semicolon-separated list of books for translate_config.yml",
+        help=f"Book or list of books for translate_config.yml, {book_list_syntax}",
+    )
+    test_group = parser.add_mutually_exclusive_group()
+    test_group.add_argument(
+        "--no-test",
+        action="store_true",
+        help="Train-only experiments (type: train, no test set); folder names gain _notest",
+    )
+    test_group.add_argument(
+        "--test100",
+        action="store_true",
+        help="Use a 100-verse test set (test_size: 100); folder names gain _test100",
     )
     parser.add_argument("--dry-run", action="store_true", help="Report without creating folders or files")
     parser.add_argument(
@@ -478,6 +661,12 @@ def main() -> None:
         help="Run each created experiment (silnlp.nmt.experiment) without asking first",
     )
     args = parser.parse_args()
+    try:
+        if args.training_books.strip().lower() != "complete":
+            args.training_books = parse_book_list(args.training_books)
+        args.translate_books = parse_book_list(args.translate_books)
+    except ValueError as e:
+        parser.error(str(e))
 
     environment = SilNlpEnv.create_standard_environment()
     experiments_dir = Path(environment.mt_experiments_dir)
@@ -485,10 +674,13 @@ def main() -> None:
         request_dir=resolve_request_dir(args.request, experiments_dir),
         experiments_dir=experiments_dir,
         assets_dir=Path(environment.assets_dir),
-        books=args.books,
+        training_books=args.training_books,
         translate_books=args.translate_books,
         min_parallel=args.min_parallel,
         min_alignment=args.min_alignment,
+        scripture_dir=Path(environment.mt_scripture_dir),
+        terms_dir=Path(environment.mt_terms_dir),
+        test_variant="notest" if args.no_test else "test100" if args.test100 else None,
         dry_run=args.dry_run,
         submit=True if args.run else None,
     )

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -1,11 +1,12 @@
 """Create NMT experiment folders from a production onboarding request or analyze run.
 
-Parses the onboarding.log written by silnlp.common.onboard_project in a
-MT/experiments/_OnboardingRequests/<request> folder — or the corpus-stats.csv
-written by silnlp.common.analyze in any experiment folder (e.g. PNG/Taupota/Align) —
-selects the reference projects whose alignment stats pass the thresholds, and creates
-<Country>/<Language>/<experiment> folders containing config.yml and
-translate_config.yml. See create_onboarding_experiments_plan.md for details.
+Parses the corpus-stats.csv written by silnlp.common.analyze — found either in a
+MT/experiments/_OnboardingRequests/<request> folder (top level or alignments/) or in
+any experiment folder (e.g. PNG/Taupota/Align) — falling back to scraping the
+onboarding.log for older request folders without one. It then selects the reference
+projects whose alignment stats pass the thresholds, offers the top experiments for
+selection, and creates <Country>/<Language>/<experiment> folders containing config.yml
+and translate_config.yml. See create_onboarding_experiments_plan.md for details.
 """
 
 import argparse
@@ -48,7 +49,7 @@ CHECKPOINT = 5000
 SEED = 111
 MODEL = "facebook/nllb-200-distilled-1.3B"
 BOOK_COMPLETENESS_THRESHOLD = 0.98
-MAX_UNPROMPTED_MIXED = 3
+TOP_EXPERIMENTS = 20
 
 EXPERIMENT_ARGS = [
     "-m",
@@ -165,30 +166,54 @@ def parse_log(log_path: Path) -> Tuple[MainProject, List[Candidate]]:
     return main, list(candidates.values())
 
 
-def parse_corpus_stats(stats_path: Path) -> Tuple[MainProject, List[Candidate]]:
+def stem_matches(stem: str, target: str) -> bool:
+    """Case-insensitive match of a target against a stem, its iso prefix, or its project name."""
+    return target.lower() in (stem.lower(), stem_to_iso(stem).lower(), stem_to_project(stem).lower())
+
+
+def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[MainProject, List[Candidate]]:
     """Parse a corpus-stats.csv written by silnlp.common.analyze.
 
     The main project is the stem appearing in every row on one side: trg for alignment
-    runs (e.g. <Country>/<Language>/Align), src for onboarding analyze runs. With a
-    single row both sides are constant; the trg side is assumed to be the main project
-    (the alignment convention; onboarding folders are parsed from onboarding.log instead).
+    runs (e.g. <Country>/<Language>/Align), src for onboarding analyze runs. `target`
+    (an iso code, project name or stem) overrides the detection; it may match either
+    side per row, and rows not involving it are ignored.
     """
     df = pd.read_csv(stats_path)
     if df.empty:
         raise ValueError(f"{stats_path} contains no rows.")
-    if df["trg_project"].nunique() == 1:
-        main_col, ref_col = "trg_project", "src_project"
-    elif df["src_project"].nunique() == 1:
-        main_col, ref_col = "src_project", "trg_project"
+
+    oriented = []  # (main stem, main script, ref stem, ref script, row)
+    if target is not None:
+        skipped = 0
+        for _, row in df.iterrows():
+            if stem_matches(row["src_project"], target):
+                oriented.append((row["src_project"], row["src_script"], row["trg_project"], row["trg_script"], row))
+            elif stem_matches(row["trg_project"], target):
+                oriented.append((row["trg_project"], row["trg_script"], row["src_project"], row["src_script"], row))
+            else:
+                skipped += 1
+        if not oriented:
+            raise ValueError(f"'{target}' does not match any project in {stats_path}.")
+        main_stems = sorted({entry[0] for entry in oriented})
+        if len(main_stems) > 1:
+            raise ValueError(
+                f"'{target}' matches more than one project in {stats_path} ({', '.join(main_stems)});"
+                " use the project name to disambiguate."
+            )
+        if skipped:
+            LOGGER.warning(f"Ignoring {skipped} row(s) in {stats_path.name} that do not involve '{target}'.")
+    elif df["trg_project"].nunique() == 1 and df["src_project"].nunique() > 1:
+        for _, row in df.iterrows():
+            oriented.append((row["trg_project"], row["trg_script"], row["src_project"], row["src_script"], row))
+    elif df["src_project"].nunique() == 1 and df["trg_project"].nunique() > 1:
+        for _, row in df.iterrows():
+            oriented.append((row["src_project"], row["src_script"], row["trg_project"], row["trg_script"], row))
     else:
-        raise ValueError(
-            f"Cannot determine the main project in {stats_path}: neither src_project nor trg_project is constant."
-        )
-    main_script_col, ref_script_col = (f"{col.split('_')[0]}_script" for col in (main_col, ref_col))
+        raise ValueError(f"Cannot determine the main project in {stats_path}; specify it with --target.")
 
     candidates: Dict[str, Candidate] = {}
-    for _, row in df.iterrows():
-        ref_stem = row[ref_col]
+    for _, _, ref_stem, ref_script, row in oriented:
         candidates[stem_to_project(ref_stem)] = Candidate(
             name=stem_to_project(ref_stem),
             stem=ref_stem,
@@ -196,18 +221,27 @@ def parse_corpus_stats(stats_path: Path) -> Tuple[MainProject, List[Candidate]]:
             count=int(row["count"]),
             parallel=int(row["parallel"]),
             alignment=float(row["align_score"]),
-            script=str(row[ref_script_col]).strip(),
+            script=str(ref_script).strip(),
         )
 
-    main_stem = df[main_col].iloc[0]
+    main_stem, main_script = oriented[0][0], oriented[0][1]
     main = MainProject(
         name=stem_to_project(main_stem),
         stem=main_stem,
         iso=stem_to_iso(main_stem),
         verses=None,
-        script=str(df[main_script_col].iloc[0]).strip(),
+        script=str(main_script).strip(),
     )
     return main, list(candidates.values())
+
+
+def parse_log_main_name(log_path: Path) -> Optional[str]:
+    """Return the main project name from onboarding.log, if the log names one."""
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        m = MAIN_PROJECT_RE.search(line)
+        if m is not None:
+            return m.group(1)
+    return None
 
 
 def stem_to_iso(stem: str) -> str:
@@ -439,25 +473,35 @@ def find_existing(lang_dir: Path, prefix: str, config: dict) -> Tuple[Optional[P
     return None, max_index + 1
 
 
-def select_mixed_pairs(pairs: List[List[Candidate]], dry_run: bool) -> List[List[Candidate]]:
-    if len(pairs) <= MAX_UNPROMPTED_MIXED:
-        return pairs
-    print(f"\n{len(pairs)} mixed-source experiments pass the thresholds:")
-    for i, pair in enumerate(pairs, start=1):
-        names = " + ".join(f"{source.name} ({source.alignment:.4f})" for source in pair)
-        print(f"  {i}. {names}")
+def select_experiments(
+    singles: List[List[Candidate]], mixed: List[List[Candidate]], dry_run: bool
+) -> List[List[Candidate]]:
+    """Show the top possible experiments (singles first) and ask which to create.
+
+    Under dry_run the list is only displayed and every displayed experiment is returned.
+    """
+    total = len(singles) + len(mixed)
+    displayed = (singles + mixed)[:TOP_EXPERIMENTS]
+    shown = f"top {len(displayed)} of {total}" if total > len(displayed) else f"{total}"
+    print(f"\nPossible experiments ({shown}, single sources first):")
+    for i, sources in enumerate(displayed, start=1):
+        names = " + ".join(f"{source.name} ({source.alignment:.4f})" for source in sources)
+        print(f"  {i:>2}. {names}")
     if dry_run:
-        print("Dry run: all listed pairs are included in the report below.")
-        return pairs
-    reply = input("Enter the numbers to create (e.g. 1,3), 'all' or 'none': ").strip().lower()
+        print("Dry run: all listed experiments are included in the report below.")
+        return displayed
+    try:
+        reply = input("Enter the numbers to create (e.g. 1,3), 'all' or 'none': ").strip().lower()
+    except EOFError:
+        reply = ""
     if reply in ("", "none"):
         return []
     if reply == "all":
-        return pairs
+        return displayed
     chosen = []
     for token in re.split(r"[,\s]+", reply):
-        if token.isdigit() and 1 <= int(token) <= len(pairs):
-            chosen.append(pairs[int(token) - 1])
+        if token.isdigit() and 1 <= int(token) <= len(displayed):
+            chosen.append(displayed[int(token) - 1])
         else:
             LOGGER.warning(f"Ignoring invalid selection '{token}'.")
     return chosen
@@ -525,24 +569,36 @@ def run(
     scripture_dir: Optional[Path] = None,
     terms_dir: Optional[Path] = None,
     test_variant: Optional[str] = None,
+    target: Optional[str] = None,
     dry_run: bool = False,
     submit: Optional[bool] = False,
 ) -> List[Experiment]:
     if test_variant not in (None, "notest", "test100"):
         raise ValueError(f"Unknown test_variant '{test_variant}'; expected None, 'notest' or 'test100'.")
     log_path = request_dir / "onboarding.log"
-    stats_path = request_dir / "corpus-stats.csv"
+    stats_paths = [request_dir / "corpus-stats.csv", request_dir / "alignments" / "corpus-stats.csv"]
+    stats_path = next((path for path in stats_paths if path.is_file()), None)
     lang_dir_override: Optional[Path] = None
-    if log_path.is_file():
-        main, candidates = parse_log(log_path)
-    elif stats_path.is_file():
-        main, candidates = parse_corpus_stats(stats_path)
+    if stats_path is not None:
+        # The CSV is the stable machine-readable artifact, so it is preferred over scraping
+        # the log; an explicit --target wins over the log's main-project line as the hint
+        # for which side of the CSV is the target.
+        main_hint = target or (parse_log_main_name(log_path) if log_path.is_file() else None)
+        main, candidates = parse_corpus_stats(stats_path, target=main_hint)
         # A stats folder inside the experiments tree (e.g. PNG/Taupota/Align) creates its
-        # experiments next to itself, keeping whatever country/language naming already exists.
-        if experiments_dir.resolve() in request_dir.resolve().parents:
+        # experiments next to itself, keeping whatever country/language naming already
+        # exists — but never inside _OnboardingRequests, where the derived location applies.
+        request_parents = request_dir.resolve().parents
+        if experiments_dir.resolve() in request_parents and (
+            (experiments_dir / "_OnboardingRequests").resolve() not in request_parents
+        ):
             lang_dir_override = request_dir.parent
+    elif log_path.is_file():
+        main, candidates = parse_log(log_path)
+        if target is not None and not stem_matches(main.stem, target):
+            raise ValueError(f"--target '{target}' does not match the main project '{main.stem}' in {log_path}.")
     else:
-        raise FileNotFoundError(f"No onboarding.log or corpus-stats.csv found in {request_dir}.")
+        raise FileNotFoundError(f"No corpus-stats.csv or onboarding.log found in {request_dir}.")
 
     language_entries = load_language_entries(assets_dir)
     language, country = lookup_language(main.iso, language_entries)
@@ -610,13 +666,15 @@ def run(
         verse_counts = load_verse_counts(request_dir, experiments_dir)
     translate_set = frozenset(get_chapters(translate_books))
 
-    mixed = select_mixed_pairs([list(pair) for pair in itertools.combinations(passing, 2)], dry_run)
+    chosen = select_experiments(
+        [[c] for c in passing], [list(pair) for pair in itertools.combinations(passing, 2)], dry_run
+    )
 
     experiments: List[Experiment] = []
     existing_experiments: List[Experiment] = []
     warned_removals: set = set()
     print()
-    for sources in [[c] for c in passing] + mixed:
+    for sources in chosen:
         label = " + ".join(source.name for source in sources)
         try:
             corpus_books, removed = resolve_corpus_books(
@@ -690,6 +748,11 @@ def main() -> None:
     )
     parser.add_argument("--min-parallel", type=int, default=2000, help="Minimum parallel verse count (default 2000)")
     parser.add_argument("--min-alignment", type=float, default=0.2, help="Minimum alignment score (default 0.2)")
+    parser.add_argument(
+        "--target",
+        help="Iso code or project name of the target language, overriding its detection from"
+        " corpus-stats.csv (it may appear in either column) or onboarding.log",
+    )
     book_list_syntax = (
         "separated by commas, semicolons or spaces, including silnlp selections like ranges and"
         ' subtractions (quote semicolons and spaces: "GEN;RUT", "GEN RUT", "NT;-REV", "GEN-DEU")'
@@ -742,6 +805,7 @@ def main() -> None:
         scripture_dir=Path(environment.mt_scripture_dir),
         terms_dir=Path(environment.mt_terms_dir),
         test_variant="notest" if args.no_test else "test100" if args.test100 else None,
+        target=args.target,
         dry_run=args.dry_run,
         submit=True if args.run else None,
     )

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -24,6 +24,7 @@ from typing import AbstractSet, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import yaml
+from machine.corpora import FileParatextProjectSettingsParser
 from machine.scripture import ALL_BOOK_IDS, book_id_to_number, book_number_to_id, get_chapters, is_nt, is_ot
 
 from .environment import SilNlpEnv
@@ -472,13 +473,75 @@ def build_config(
     }
 
 
-def build_translate_config(sources: List[Candidate], translate_books: str) -> dict:
+def build_translate_config(
+    sources: List[Candidate], translate_books: str, source_projects: Optional[Dict[str, str]] = None
+) -> dict:
+    source_projects = source_projects or {}
     return {
         "translate": [
-            {"books": translate_books, "src_project": source.name, "checkpoint": CHECKPOINT} for source in sources
+            {
+                "books": translate_books,
+                "src_project": source_projects.get(source.name, source.name),
+                "checkpoint": CHECKPOINT,
+            }
+            for source in sources
         ],
         "postprocess": [{"paragraph_behavior": "place"}],
     }
+
+
+def check_translate_source(projects_dir: Path, project: str, books: Sequence[str]) -> Optional[str]:
+    """Return why `project` cannot supply `books` for translation, or None if it can.
+
+    The books' file names come from the project's Settings.xml naming convention.
+    """
+    project_dir = projects_dir / project
+    if not project_dir.is_dir():
+        return f"there is no project folder '{project}' in {projects_dir}"
+    try:
+        settings = FileParatextProjectSettingsParser(project_dir).parse()
+    except Exception as e:
+        return f"the settings of project '{project}' could not be read ({e})"
+    missing = [book for book in books if not (project_dir / settings.get_book_file_name(book)).is_file()]
+    if missing:
+        return f"project '{project}' does not contain {';'.join(missing)}"
+    return None
+
+
+def resolve_translate_sources(
+    source_names: Sequence[str], books: Sequence[str], projects_dir: Optional[Path], dry_run: bool
+) -> Dict[str, str]:
+    """Check that each translation source project contains the books to be translated.
+
+    Warns about a missing project or missing books and asks for a different project to
+    translate from (checked too), so the user can decide how to proceed. Returns a mapping
+    of source name -> project to use as src_project in translate_config.yml.
+    """
+    replacements: Dict[str, str] = {}
+    if projects_dir is None:
+        return replacements
+    for name in source_names:
+        current = name
+        while True:
+            problem = check_translate_source(projects_dir, current, books)
+            if problem is None:
+                break
+            print(f"Warning: cannot translate {';'.join(books)} from '{current}': {problem}.")
+            if dry_run:
+                break
+            try:
+                reply = input(
+                    f"Enter a different project to translate from (or press Enter to keep '{current}'): "
+                ).strip()
+            except EOFError:
+                reply = ""
+            if not reply or reply == current:
+                break
+            current = reply
+        if current != name:
+            print(f"Translating from '{current}' instead of '{name}'.")
+            replacements[name] = current
+    return replacements
 
 
 def find_existing(lang_dir: Path, prefix: str, config: dict) -> Tuple[Optional[Path], int]:
@@ -603,6 +666,7 @@ def run(
     min_alignment: float,
     scripture_dir: Optional[Path] = None,
     terms_dir: Optional[Path] = None,
+    projects_dir: Optional[Path] = None,
     test_variant: Optional[str] = None,
     target: Optional[str] = None,
     top: int = TOP_EXPERIMENTS,
@@ -766,6 +830,12 @@ def run(
         [[c] for c in passing], [list(pair) for pair in itertools.combinations(passing, 2)], dry_run, top=top
     )
 
+    # The chosen sources double as the projects to translate from; make sure each project
+    # folder and every book to be translated actually exists before writing the configs.
+    translate_book_ids = [book_number_to_id(number) for number in sorted(translate_set)]
+    source_names = list(dict.fromkeys(source.name for sources in chosen for source in sources))
+    source_projects = resolve_translate_sources(source_names, translate_book_ids, projects_dir, dry_run)
+
     experiments: List[Experiment] = []
     existing_experiments: List[Experiment] = []
     warned_removals: set = set()
@@ -798,7 +868,7 @@ def run(
                     sources=sources,
                     folder=existing,
                     config=config,
-                    translate_config=build_translate_config(sources, translate_books),
+                    translate_config=build_translate_config(sources, translate_books, source_projects),
                 )
             )
             continue
@@ -807,7 +877,7 @@ def run(
             sources=sources,
             folder=folder,
             config=config,
-            translate_config=build_translate_config(sources, translate_books),
+            translate_config=build_translate_config(sources, translate_books, source_projects),
         )
         experiments.append(experiment)
         if dry_run:
@@ -907,6 +977,7 @@ def main() -> None:
         min_alignment=args.min_alignment,
         scripture_dir=Path(environment.mt_scripture_dir),
         terms_dir=Path(environment.mt_terms_dir),
+        projects_dir=Path(environment.pt_projects_dir),
         test_variant="notest" if args.no_test else "test100" if args.test100 else None,
         target=args.target,
         top=args.top,

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -167,8 +167,18 @@ def parse_log(log_path: Path) -> Tuple[MainProject, List[Candidate]]:
 
 
 def stem_matches(stem: str, target: str) -> bool:
-    """Case-insensitive match of a target against a stem, its iso prefix, or its project name."""
-    return target.lower() in (stem.lower(), stem_to_iso(stem).lower(), stem_to_project(stem).lower())
+    """Case-insensitive match of a target against a stem, its iso prefix, or its project name.
+
+    Iso codes match across their 2- and 3-letter forms (e.g. 'fra' matches an 'fr-' stem).
+    """
+    target = target.lower()
+    if target in (stem.lower(), stem_to_project(stem).lower()):
+        return True
+    stem_iso = stem_to_iso(stem).lower()
+    if target == stem_iso:
+        return True
+    target_iso3 = to_iso3(target) if len(target) in (2, 3) else None
+    return target_iso3 is not None and target_iso3 == to_iso3(stem_iso)
 
 
 def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[MainProject, List[Candidate]]:
@@ -187,9 +197,16 @@ def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[
     if target is not None:
         skipped = 0
         for _, row in df.iterrows():
-            if stem_matches(row["src_project"], target):
+            src_match = stem_matches(row["src_project"], target)
+            trg_match = stem_matches(row["trg_project"], target)
+            if src_match and trg_match and row["src_project"] != row["trg_project"]:
+                raise ValueError(
+                    f"'{target}' matches both sides of a row in {stats_path}"
+                    f" ({row['src_project']} and {row['trg_project']}); use the project name to disambiguate."
+                )
+            if src_match:
                 oriented.append((row["src_project"], row["src_script"], row["trg_project"], row["trg_script"], row))
-            elif stem_matches(row["trg_project"], target):
+            elif trg_match:
                 oriented.append((row["trg_project"], row["trg_script"], row["src_project"], row["src_script"], row))
             else:
                 skipped += 1
@@ -213,7 +230,11 @@ def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[
         raise ValueError(f"Cannot determine the main project in {stats_path}; specify it with --target.")
 
     candidates: Dict[str, Candidate] = {}
+    incomplete = 0
     for _, _, ref_stem, ref_script, row in oriented:
+        if any(pd.isna(row[column]) for column in ("count", "parallel", "align_score")):
+            incomplete += 1
+            continue
         candidates[stem_to_project(ref_stem)] = Candidate(
             name=stem_to_project(ref_stem),
             stem=ref_stem,
@@ -223,6 +244,8 @@ def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[
             alignment=float(row["align_score"]),
             script=str(ref_script).strip(),
         )
+    if incomplete:
+        LOGGER.warning(f"Skipping {incomplete} row(s) in {stats_path.name} with missing statistics.")
 
     main_stem, main_script = oriented[0][0], oriented[0][1]
     main = MainProject(
@@ -237,10 +260,11 @@ def parse_corpus_stats(stats_path: Path, target: Optional[str] = None) -> Tuple[
 
 def parse_log_main_name(log_path: Path) -> Optional[str]:
     """Return the main project name from onboarding.log, if the log names one."""
-    for line in log_path.read_text(encoding="utf-8").splitlines():
-        m = MAIN_PROJECT_RE.search(line)
-        if m is not None:
-            return m.group(1)
+    with open(log_path, "r", encoding="utf-8", errors="replace") as file:
+        for line in file:
+            m = MAIN_PROJECT_RE.search(line)
+            if m is not None:
+                return m.group(1)
     return None
 
 
@@ -474,19 +498,21 @@ def find_existing(lang_dir: Path, prefix: str, config: dict) -> Tuple[Optional[P
 
 
 def select_experiments(
-    singles: List[List[Candidate]], mixed: List[List[Candidate]], dry_run: bool
+    singles: List[List[Candidate]], mixed: List[List[Candidate]], dry_run: bool, top: int = TOP_EXPERIMENTS
 ) -> List[List[Candidate]]:
     """Show the top possible experiments (singles first) and ask which to create.
 
     Under dry_run the list is only displayed and every displayed experiment is returned.
     """
     total = len(singles) + len(mixed)
-    displayed = (singles + mixed)[:TOP_EXPERIMENTS]
+    displayed = (singles + mixed)[:top]
     shown = f"top {len(displayed)} of {total}" if total > len(displayed) else f"{total}"
     print(f"\nPossible experiments ({shown}, single sources first):")
     for i, sources in enumerate(displayed, start=1):
         names = " + ".join(f"{source.name} ({source.alignment:.4f})" for source in sources)
         print(f"  {i:>2}. {names}")
+    if total > len(displayed):
+        print(f"Use --top to list more than {top} experiments.")
     if dry_run:
         print("Dry run: all listed experiments are included in the report below.")
         return displayed
@@ -495,15 +521,20 @@ def select_experiments(
     except EOFError:
         reply = ""
     if reply in ("", "none"):
+        print("No experiments selected.")
         return []
     if reply == "all":
         return displayed
     chosen = []
     for token in re.split(r"[,\s]+", reply):
         if token.isdigit() and 1 <= int(token) <= len(displayed):
-            chosen.append(displayed[int(token) - 1])
+            selection = displayed[int(token) - 1]
+            if selection not in chosen:
+                chosen.append(selection)
         else:
             LOGGER.warning(f"Ignoring invalid selection '{token}'.")
+    if not chosen:
+        print("No experiments selected.")
     return chosen
 
 
@@ -570,6 +601,7 @@ def run(
     terms_dir: Optional[Path] = None,
     test_variant: Optional[str] = None,
     target: Optional[str] = None,
+    top: int = TOP_EXPERIMENTS,
     dry_run: bool = False,
     submit: Optional[bool] = False,
 ) -> List[Experiment]:
@@ -579,18 +611,53 @@ def run(
     stats_paths = [request_dir / "corpus-stats.csv", request_dir / "alignments" / "corpus-stats.csv"]
     stats_path = next((path for path in stats_paths if path.is_file()), None)
     lang_dir_override: Optional[Path] = None
+    flipped = False
     if stats_path is not None:
         # The CSV is the stable machine-readable artifact, so it is preferred over scraping
-        # the log; an explicit --target wins over the log's main-project line as the hint
-        # for which side of the CSV is the target.
-        main_hint = target or (parse_log_main_name(log_path) if log_path.is_file() else None)
-        main, candidates = parse_corpus_stats(stats_path, target=main_hint)
+        # the log. An explicit --target is authoritative; the log's main-project line is only
+        # a soft hint — if it does not fit the CSV, fall back to auto-detection and finally to
+        # parsing the log itself, so a stale or partial CSV never breaks a working folder.
+        log_hint = parse_log_main_name(log_path) if log_path.is_file() and target is None else None
+        try:
+            main, candidates = parse_corpus_stats(stats_path, target=target or log_hint)
+        except ValueError as stats_error:
+            if target is not None:
+                raise
+            try:
+                if log_hint is None:
+                    raise stats_error
+                LOGGER.warning(f"{stats_error} Falling back to auto-detection.")
+                main, candidates = parse_corpus_stats(stats_path)
+            except ValueError as auto_error:
+                if not log_path.is_file():
+                    raise
+                LOGGER.warning(f"{auto_error} Falling back to {log_path.name}.")
+                main, candidates = parse_log(log_path)
+
+        # Report when the chosen target differs from what the analyze run itself would give
+        # (--target flipped the direction); the folder-derived location must not apply then.
+        detected_stem: Optional[str] = main.stem
+        if target is not None:
+            natural_hint = parse_log_main_name(log_path) if log_path.is_file() else None
+            try:
+                detected_stem = parse_corpus_stats(stats_path, target=natural_hint)[0].stem
+            except ValueError:
+                detected_stem = None
+        flipped = detected_stem is not None and detected_stem != main.stem
+        if flipped:
+            print(f"Note: --target overrides the analyze run's own target project ({detected_stem}).")
+
         # A stats folder inside the experiments tree (e.g. PNG/Taupota/Align) creates its
         # experiments next to itself, keeping whatever country/language naming already
-        # exists — but never inside _OnboardingRequests, where the derived location applies.
+        # exists — but not for request folders (which use the derived location), not directly
+        # under MT/experiments itself, and not when --target flipped the target language.
         request_parents = request_dir.resolve().parents
-        if experiments_dir.resolve() in request_parents and (
-            (experiments_dir / "_OnboardingRequests").resolve() not in request_parents
+        if (
+            experiments_dir.resolve() in request_parents
+            and request_dir.resolve().parent != experiments_dir.resolve()
+            and (experiments_dir / "_OnboardingRequests").resolve() not in request_parents
+            and not log_path.is_file()
+            and not flipped
         ):
             lang_dir_override = request_dir.parent
     elif log_path.is_file():
@@ -657,6 +724,30 @@ def run(
                         f"Would rename {main.stem}.txt to {new_stem}.txt in {scripture_dir}"
                         " (and matching terms renderings files)."
                     )
+                else:
+                    # Renaming touches the shared MT/scripture store — always confirm first.
+                    print(
+                        f"The target extract file {main.stem}.txt (and matching terms renderings files)"
+                        f" must be renamed to {new_stem}.txt in {scripture_dir}."
+                    )
+                    if flipped:
+                        print(
+                            "Warning: the target was overridden with --target. Renaming a shared"
+                            " reference Bible's extract file would break every other experiment"
+                            " that uses it — only continue if this is the minority-language project."
+                        )
+                    elif to_iso3(main.iso) in NLLB_TAG_FROM_ISO:
+                        print(
+                            f"Caution: '{main.iso}' is an NLLB language code; make sure {main.stem} is the"
+                            " minority-language project sharing that code, not a shared reference Bible."
+                        )
+                    try:
+                        reply = input("Rename it when the first experiment is created? [y/N]: ").strip().lower()
+                    except EOFError:
+                        reply = ""
+                    if reply not in ("y", "yes"):
+                        print("Aborted: the rename is required to create these experiments.")
+                        return []
             elif not new_exists and not dry_run:
                 raise FileNotFoundError(f"Neither {main.stem}.txt nor {new_stem}.txt found in {scripture_dir}.")
         main.iso, main.stem = synthetic, new_stem
@@ -667,7 +758,7 @@ def run(
     translate_set = frozenset(get_chapters(translate_books))
 
     chosen = select_experiments(
-        [[c] for c in passing], [list(pair) for pair in itertools.combinations(passing, 2)], dry_run
+        [[c] for c in passing], [list(pair) for pair in itertools.combinations(passing, 2)], dry_run, top=top
     )
 
     experiments: List[Experiment] = []
@@ -751,7 +842,14 @@ def main() -> None:
     parser.add_argument(
         "--target",
         help="Iso code or project name of the target language, overriding its detection from"
-        " corpus-stats.csv (it may appear in either column) or onboarding.log",
+        " corpus-stats.csv (it may appear in either column); with only an onboarding.log the"
+        " value must match the log's main project",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=TOP_EXPERIMENTS,
+        help=f"Maximum number of experiments listed for selection (default {TOP_EXPERIMENTS})",
     )
     book_list_syntax = (
         "separated by commas, semicolons or spaces, including silnlp selections like ranges and"
@@ -806,6 +904,7 @@ def main() -> None:
         terms_dir=Path(environment.mt_terms_dir),
         test_variant="notest" if args.no_test else "test100" if args.test100 else None,
         target=args.target,
+        top=args.top,
         dry_run=args.dry_run,
         submit=True if args.run else None,
     )

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -1,8 +1,9 @@
-"""Create NMT experiment folders from a production onboarding request.
+"""Create NMT experiment folders from a production onboarding request or analyze run.
 
 Parses the onboarding.log written by silnlp.common.onboard_project in a
-MT/experiments/_OnboardingRequests/<request> folder, selects the reference
-projects whose alignment stats pass the thresholds, and creates
+MT/experiments/_OnboardingRequests/<request> folder — or the corpus-stats.csv
+written by silnlp.common.analyze in any experiment folder (e.g. PNG/Taupota/Align) —
+selects the reference projects whose alignment stats pass the thresholds, and creates
 <Country>/<Language>/<experiment> folders containing config.yml and
 translate_config.yml. See create_onboarding_experiments_plan.md for details.
 """
@@ -160,6 +161,51 @@ def parse_log(log_path: Path) -> Tuple[MainProject, List[Candidate]]:
         iso=stem_to_iso(main_stem),
         verses=verses.get(main_stem),
         script=main_script,
+    )
+    return main, list(candidates.values())
+
+
+def parse_corpus_stats(stats_path: Path) -> Tuple[MainProject, List[Candidate]]:
+    """Parse a corpus-stats.csv written by silnlp.common.analyze.
+
+    The main project is the stem appearing in every row on one side: trg for alignment
+    runs (e.g. <Country>/<Language>/Align), src for onboarding analyze runs. With a
+    single row both sides are constant; the trg side is assumed to be the main project
+    (the alignment convention; onboarding folders are parsed from onboarding.log instead).
+    """
+    df = pd.read_csv(stats_path)
+    if df.empty:
+        raise ValueError(f"{stats_path} contains no rows.")
+    if df["trg_project"].nunique() == 1:
+        main_col, ref_col = "trg_project", "src_project"
+    elif df["src_project"].nunique() == 1:
+        main_col, ref_col = "src_project", "trg_project"
+    else:
+        raise ValueError(
+            f"Cannot determine the main project in {stats_path}: neither src_project nor trg_project is constant."
+        )
+    main_script_col, ref_script_col = (f"{col.split('_')[0]}_script" for col in (main_col, ref_col))
+
+    candidates: Dict[str, Candidate] = {}
+    for _, row in df.iterrows():
+        ref_stem = row[ref_col]
+        candidates[stem_to_project(ref_stem)] = Candidate(
+            name=stem_to_project(ref_stem),
+            stem=ref_stem,
+            iso=stem_to_iso(ref_stem),
+            count=int(row["count"]),
+            parallel=int(row["parallel"]),
+            alignment=float(row["align_score"]),
+            script=str(row[ref_script_col]).strip(),
+        )
+
+    main_stem = df[main_col].iloc[0]
+    main = MainProject(
+        name=stem_to_project(main_stem),
+        stem=main_stem,
+        iso=stem_to_iso(main_stem),
+        verses=None,
+        script=str(df[main_script_col].iloc[0]).strip(),
     )
     return main, list(candidates.values())
 
@@ -459,11 +505,13 @@ def submit_experiments(
 
 def resolve_request_dir(request: str, experiments_dir: Path) -> Path:
     requests_dir = experiments_dir / "_OnboardingRequests"
-    for name in [request, f"{request}_Request"]:
-        candidate = requests_dir / name
+    for candidate in [requests_dir / request, requests_dir / f"{request}_Request", experiments_dir / request]:
         if candidate.is_dir():
             return candidate
-    raise FileNotFoundError(f"No request folder '{request}' or '{request}_Request' found in {requests_dir}.")
+    raise FileNotFoundError(
+        f"No request folder '{request}' or '{request}_Request' found in {requests_dir},"
+        f" and '{request}' is not a folder in {experiments_dir}."
+    )
 
 
 def run(
@@ -483,13 +531,22 @@ def run(
     if test_variant not in (None, "notest", "test100"):
         raise ValueError(f"Unknown test_variant '{test_variant}'; expected None, 'notest' or 'test100'.")
     log_path = request_dir / "onboarding.log"
-    if not log_path.is_file():
-        raise FileNotFoundError(f"No onboarding.log found in {request_dir}.")
-    main, candidates = parse_log(log_path)
+    stats_path = request_dir / "corpus-stats.csv"
+    lang_dir_override: Optional[Path] = None
+    if log_path.is_file():
+        main, candidates = parse_log(log_path)
+    elif stats_path.is_file():
+        main, candidates = parse_corpus_stats(stats_path)
+        # A stats folder inside the experiments tree (e.g. PNG/Taupota/Align) creates its
+        # experiments next to itself, keeping whatever country/language naming already exists.
+        if experiments_dir.resolve() in request_dir.resolve().parents:
+            lang_dir_override = request_dir.parent
+    else:
+        raise FileNotFoundError(f"No onboarding.log or corpus-stats.csv found in {request_dir}.")
 
     language_entries = load_language_entries(assets_dir)
     language, country = lookup_language(main.iso, language_entries)
-    lang_dir = experiments_dir / folder_name(country) / folder_name(language)
+    lang_dir = lang_dir_override or experiments_dir / folder_name(country) / folder_name(language)
     print(f"Main project: {main.name} ({main.stem}), language: {language} [{main.iso}], country: {country}")
     print(f"Experiment location: {lang_dir}")
 
@@ -626,7 +683,11 @@ def run(
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
     parser = argparse.ArgumentParser(description="Create experiment folders from an onboarding request.")
-    parser.add_argument("request", help="Request folder name in MT/experiments/_OnboardingRequests")
+    parser.add_argument(
+        "request",
+        help="Request folder name in MT/experiments/_OnboardingRequests, or a folder relative to"
+        " MT/experiments containing a corpus-stats.csv from an analyze run (e.g. PNG/Taupota/Align)",
+    )
     parser.add_argument("--min-parallel", type=int, default=2000, help="Minimum parallel verse count (default 2000)")
     parser.add_argument("--min-alignment", type=float, default=0.2, help="Minimum alignment score (default 0.2)")
     book_list_syntax = (

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -14,6 +14,7 @@ import itertools
 import json
 import logging
 import re
+import shutil
 import string
 import subprocess
 import sys
@@ -342,10 +343,10 @@ def synthesize_trg_iso(iso3: str, real_isos: AbstractSet[str]) -> str:
     raise ValueError(f"Could not synthesize a target iso code from '{iso3}'.")
 
 
-def find_prior_rename(scripture_dir: Optional[Path], main: MainProject, real_isos: AbstractSet[str]) -> Optional[str]:
-    """Return the synthetic iso of an extract file renamed by a previous run, if one exists.
+def find_prior_copy(scripture_dir: Optional[Path], main: MainProject, real_isos: AbstractSet[str]) -> Optional[str]:
+    """Return the synthetic iso of an extract copy made by a previous run, if one exists.
 
-    The renamed file on disk is the durable record of the code chosen earlier, so re-runs
+    The copied file on disk is the durable record of the code chosen earlier, so re-runs
     reuse it instead of deriving a possibly different code from the current iso tables.
     """
     if scripture_dir is None or not scripture_dir.is_dir():
@@ -357,16 +358,19 @@ def find_prior_rename(scripture_dir: Optional[Path], main: MainProject, real_iso
     return None
 
 
-def execute_rename(scripture_dir: Path, terms_dir: Optional[Path], old_stem: str, new_stem: str) -> None:
-    """Rename the target extract file (and its terms renderings files) to the synthetic stem."""
+def execute_copy(scripture_dir: Path, terms_dir: Optional[Path], old_stem: str, new_stem: str) -> None:
+    """Copy the target extract file (and its terms renderings files) to the synthetic stem.
+
+    The original files are kept: they may be referenced by other experiments and tools.
+    """
     old_path = scripture_dir / f"{old_stem}.txt"
-    old_path.rename(scripture_dir / f"{new_stem}.txt")
-    print(f"Renamed {old_path.name} to {new_stem}.txt in {scripture_dir}")
+    shutil.copyfile(old_path, scripture_dir / f"{new_stem}.txt")
+    print(f"Copied {old_path.name} to {new_stem}.txt in {scripture_dir}")
     if terms_dir is not None and terms_dir.is_dir():
         for path in sorted(terms_dir.glob(f"{old_stem}-*-renderings.txt")):
             target = f"{new_stem}{path.name[len(old_stem):]}"
-            path.rename(terms_dir / target)
-            print(f"Renamed {path.name} to {target} in {terms_dir}")
+            shutil.copyfile(path, terms_dir / target)
+            print(f"Copied {path.name} to {target} in {terms_dir}")
 
 
 def folder_name(name: str) -> str:
@@ -685,15 +689,16 @@ def run(
 
     # The src and trg isos of a corpus pair must differ. When a passing reference shares the
     # main project's iso, switch the main project to a synthetic code (not a real iso, not in
-    # NLLB) and rename its extract file to match. The rename is deferred until an experiment
-    # is actually created; a run that creates nothing leaves MT/scripture untouched. A rename
-    # done by a previous run (recorded by the file on disk) is reused even when the current
-    # thresholds no longer surface the clash, so the configs always match the file that exists.
+    # NLLB) and copy its extract file to the new stem, keeping the original. The copy is
+    # deferred until an experiment is actually created; a run that creates nothing leaves
+    # MT/scripture untouched. A copy made by a previous run (recorded by the file on disk) is
+    # reused even when the current thresholds no longer surface the clash, so the configs
+    # always match a file that exists.
     counts_stem = main.stem  # verse_counts.csv is keyed by the original stem
     real_isos = {entry["isoCode"] for entry in language_entries}
-    prior_iso = find_prior_rename(scripture_dir, main, real_isos)
+    prior_iso = find_prior_copy(scripture_dir, main, real_isos)
     clashing = [c for c in passing if to_iso3(c.iso) == to_iso3(main.iso)]
-    pending_rename: Optional[Tuple[str, str]] = None  # (old stem, new stem), executed on first creation
+    pending_copy: Optional[Tuple[str, str]] = None  # (old stem, new stem), executed on first creation
     if clashing or prior_iso is not None:
         synthetic = prior_iso or synthesize_trg_iso(to_iso3(main.iso) or main.iso, real_isos)
         if clashing:
@@ -703,38 +708,38 @@ def run(
                 f" project; using synthetic target code '{synthetic}' instead."
             )
         else:
-            print(f"\nUsing synthetic target code '{synthetic}' from the previously renamed extract file.")
+            print(f"\nUsing synthetic target code '{synthetic}' from the previously copied extract file.")
         new_stem = f"{synthetic}-{stem_to_project(main.stem)}"
         if scripture_dir is None:
             if not dry_run:
-                raise ValueError("No scripture directory available to rename the target extract file in.")
-            print(f"Would rename {main.stem}.txt to {new_stem}.txt in the MT scripture folder.")
+                raise ValueError("No scripture directory available to copy the target extract file in.")
+            print(f"Would copy {main.stem}.txt to {new_stem}.txt in the MT scripture folder.")
         else:
-            old_exists = (scripture_dir / f"{main.stem}.txt").is_file()
-            new_exists = (scripture_dir / f"{new_stem}.txt").is_file()
-            if old_exists and new_exists:
-                raise RuntimeError(
-                    f"Both {main.stem}.txt and {new_stem}.txt exist in {scripture_dir} (the original was"
-                    " probably re-extracted after an earlier rename); remove the stale one before re-running."
-                )
-            if old_exists:
-                pending_rename = (main.stem, new_stem)
+            old_path = scripture_dir / f"{main.stem}.txt"
+            new_path = scripture_dir / f"{new_stem}.txt"
+            if new_path.is_file():
+                if old_path.is_file() and old_path.stat().st_mtime > new_path.stat().st_mtime:
+                    LOGGER.warning(
+                        f"{new_path.name} may be outdated: {old_path.name} is newer (probably re-extracted)."
+                        f" Delete {new_path.name} and re-run to refresh the copy."
+                    )
+            elif old_path.is_file():
+                pending_copy = (main.stem, new_stem)
                 if dry_run:
                     print(
-                        f"Would rename {main.stem}.txt to {new_stem}.txt in {scripture_dir}"
+                        f"Would copy {main.stem}.txt to {new_stem}.txt in {scripture_dir}"
                         " (and matching terms renderings files)."
                     )
                 else:
-                    # Renaming touches the shared MT/scripture store — always confirm first.
+                    # The copy adds files to the shared MT/scripture store — always confirm first.
                     print(
-                        f"The target extract file {main.stem}.txt (and matching terms renderings files)"
-                        f" must be renamed to {new_stem}.txt in {scripture_dir}."
+                        f"{main.stem}.txt (and matching terms renderings files) will be copied to"
+                        f" {new_stem}.txt in {scripture_dir}; the originals are kept."
                     )
                     if flipped:
                         print(
-                            "Warning: the target was overridden with --target. Renaming a shared"
-                            " reference Bible's extract file would break every other experiment"
-                            " that uses it — only continue if this is the minority-language project."
+                            "Warning: the target was overridden with --target; make sure"
+                            f" {main.stem} really is the intended target project."
                         )
                     elif to_iso3(main.iso) in NLLB_TAG_FROM_ISO:
                         print(
@@ -742,13 +747,13 @@ def run(
                             " minority-language project sharing that code, not a shared reference Bible."
                         )
                     try:
-                        reply = input("Rename it when the first experiment is created? [y/N]: ").strip().lower()
+                        reply = input("Copy the file when the first experiment is created? [y/N]: ").strip().lower()
                     except EOFError:
                         reply = ""
                     if reply not in ("y", "yes"):
-                        print("Aborted: the rename is required to create these experiments.")
+                        print("Aborted: the copy is required to create these experiments.")
                         return []
-            elif not new_exists and not dry_run:
+            elif not dry_run:
                 raise FileNotFoundError(f"Neither {main.stem}.txt nor {new_stem}.txt found in {scripture_dir}.")
         main.iso, main.stem = synthetic, new_stem
 
@@ -808,22 +813,22 @@ def run(
         if dry_run:
             print(f"Would create {folder} (corpus_books: {corpus_books})")
         else:
-            if pending_rename is not None:
+            if pending_copy is not None:
                 assert scripture_dir is not None
-                execute_rename(scripture_dir, terms_dir, *pending_rename)
-                pending_rename = None
+                execute_copy(scripture_dir, terms_dir, *pending_copy)
+                pending_copy = None
             folder.mkdir(parents=True, exist_ok=True)
             write_yaml(folder / "config.yml", experiment.config)
             write_yaml(folder / "translate_config.yml", experiment.translate_config)
             print(f"Created {folder} (corpus_books: {corpus_books})")
-    if experiments or existing_experiments:
+    if (experiments or existing_experiments) and not dry_run:
         # Existing folders with an identical config are offered too: their creation was
-        # skipped, but the experiments themselves may not have been run yet.
-        # In a dry run nothing new exists to execute, so only print the commands.
+        # skipped, but the experiments themselves may not have been run yet. A dry run
+        # only lists what would be created, without the run commands.
         submit_experiments(
             experiments + existing_experiments,
             experiments_dir,
-            submit=False if dry_run else submit,
+            submit=submit,
             no_test=test_variant == "notest",
         )
     return experiments

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -1,0 +1,428 @@
+"""Create NMT experiment folders from a production onboarding request.
+
+Parses the onboarding.log written by silnlp.common.onboard_project in a
+MT/experiments/_OnboardingRequests/<request> folder, selects the reference
+projects whose alignment stats pass the thresholds, and creates
+<Country>/<Language>/<experiment> folders containing config.yml and
+translate_config.yml. See create_onboarding_experiments_plan.md for details.
+"""
+
+import argparse
+import itertools
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import pandas as pd
+import yaml
+from machine.scripture import ALL_BOOK_IDS, book_id_to_number, is_nt, is_ot
+
+from .environment import SilNlpEnv
+from .iso_info import ALT_ISO, NLLB_TAG_FROM_ISO
+
+LOGGER = logging.getLogger(__package__ + ".create_onboarding_experiments")
+
+OT_CANON = [book for book in ALL_BOOK_IDS if is_ot(book_id_to_number(book))]
+NT_CANON = [book for book in ALL_BOOK_IDS if is_nt(book_id_to_number(book))]
+
+MAIN_PROJECT_RE = re.compile(r"Processing onboarding request for main project '([^']+)'")
+EXTRACT_RE = re.compile(r"Extracted corpus file: .*[/\\]([^/\\]+)\.txt\s*$")
+VERSES_RE = re.compile(r"# of Verses: (\d+)")
+# "beteween" is how onboard_project's analyze step spells it in the log.
+ALIGN_RE = re.compile(r"Computing alignment beteween (\S+) and (\S+) using")
+STATS_RE = re.compile(
+    r"(?P<main>\S+) -> (?P<ref>\S+) stats - count: (?P<count>\d+),"
+    r".*?parallel count: (?P<parallel>\d+) alignment: (?P<alignment>[\d.]+),"
+    r".*?source script: (?P<src_script>[^,]+),"
+    r".*?target script: (?P<trg_script>[^,]+),"
+)
+
+CHECKPOINT = 5000
+SEED = 111
+MODEL = "facebook/nllb-200-distilled-1.3B"
+BOOK_COMPLETENESS_THRESHOLD = 0.98
+MAX_UNPROMPTED_MIXED = 3
+
+
+@dataclass
+class Candidate:
+    """A reference project aligned against the main project in the log."""
+
+    name: str
+    stem: str  # extract file stem, e.g. en-NIV11R
+    iso: str  # iso prefix exactly as it appears in the filename
+    count: int
+    parallel: int
+    alignment: float
+    script: str
+
+
+@dataclass
+class MainProject:
+    name: str
+    stem: str
+    iso: str
+    verses: Optional[int]
+    script: Optional[str]
+
+
+@dataclass
+class Experiment:
+    sources: List[Candidate]
+    folder: Path
+    config: dict
+    translate_config: dict
+
+
+def parse_log(log_path: Path) -> Tuple[MainProject, List[Candidate]]:
+    main_name: Optional[str] = None
+    stems: Dict[str, str] = {}  # project name -> extract stem
+    verses: Dict[str, int] = {}  # extract stem -> # of Verses
+    stats: List[dict] = []
+    last_stem: Optional[str] = None
+
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        m = MAIN_PROJECT_RE.search(line)
+        if m is not None and main_name is None:
+            main_name = m.group(1)
+            continue
+        m = EXTRACT_RE.search(line)
+        if m is not None:
+            last_stem = m.group(1)
+            stems[stem_to_project(last_stem)] = last_stem
+            continue
+        m = VERSES_RE.search(line)
+        if m is not None and last_stem is not None:
+            verses[last_stem] = int(m.group(1))
+            last_stem = None
+            continue
+        m = ALIGN_RE.search(line)
+        if m is not None:
+            for stem in m.groups():
+                stems[stem_to_project(stem)] = stem
+            continue
+        m = STATS_RE.search(line)
+        if m is not None:
+            stats.append(m.groupdict())
+
+    if main_name is None:
+        raise ValueError(f"No 'Processing onboarding request for main project' line found in {log_path}.")
+    main_stem = stems.get(main_name)
+    if main_stem is None:
+        raise ValueError(f"No extract file or alignment line found for main project '{main_name}' in {log_path}.")
+
+    candidates: Dict[str, Candidate] = {}
+    main_script: Optional[str] = None
+    for entry in stats:
+        if entry["main"] != main_name:
+            continue
+        main_script = entry["src_script"].strip()
+        ref_name = entry["ref"]
+        ref_stem = stems.get(ref_name)
+        if ref_stem is None:
+            LOGGER.warning(f"No extract stem found for aligned project '{ref_name}'. Skipping it.")
+            continue
+        candidates[ref_name] = Candidate(
+            name=ref_name,
+            stem=ref_stem,
+            iso=stem_to_iso(ref_stem),
+            count=int(entry["count"]),
+            parallel=int(entry["parallel"]),
+            alignment=float(entry["alignment"]),
+            script=entry["trg_script"].strip(),
+        )
+
+    main = MainProject(
+        name=main_name,
+        stem=main_stem,
+        iso=stem_to_iso(main_stem),
+        verses=verses.get(main_stem),
+        script=main_script,
+    )
+    return main, list(candidates.values())
+
+
+def stem_to_iso(stem: str) -> str:
+    return stem.split("-", 1)[0]
+
+
+def stem_to_project(stem: str) -> str:
+    return stem.split("-", 1)[1] if "-" in stem else stem
+
+
+def to_iso3(iso: str) -> Optional[str]:
+    if len(iso) == 3:
+        return iso
+    return ALT_ISO.get_alternative(iso)
+
+
+def nllb_tag(iso: str, script: str) -> str:
+    iso3 = to_iso3(iso)
+    if iso3 is None:
+        raise ValueError(f"Cannot resolve iso code '{iso}' to a 3-letter code.")
+    return NLLB_TAG_FROM_ISO.get(iso3, f"{iso3}_{script}")
+
+
+def lookup_language(iso: str, assets_dir: Path) -> Tuple[str, str]:
+    """Return (language name, country) for an iso code from languageFamilies.json."""
+    iso3 = to_iso3(iso)
+    if iso3 is None:
+        raise ValueError(f"Cannot resolve iso code '{iso}' to a 3-letter code.")
+    with open(assets_dir / "languageFamilies.json", "r", encoding="utf-8") as file:
+        entries = json.load(file)
+    for entry in entries:
+        if entry.get("isoCode") == iso3:
+            return entry["language"], entry["langCountry"]
+    raise ValueError(f"Iso code '{iso3}' not found in languageFamilies.json; cannot determine language and country.")
+
+
+def folder_name(name: str) -> str:
+    name = name.replace(",", "").replace("-", " ")
+    return "_".join(word.capitalize() for word in name.split())
+
+
+def load_verse_counts(request_dir: Path, experiments_dir: Path) -> pd.DataFrame:
+    """Load verse_counts.csv from the request folder, extended with any rows only in the global file."""
+    frames = []
+    for path in [request_dir / "verse_counts.csv", experiments_dir / "verse_counts" / "verse_counts.csv"]:
+        if path.is_file():
+            frames.append(pd.read_csv(path, index_col="file"))
+    if not frames:
+        raise FileNotFoundError(
+            f"No verse_counts.csv found in {request_dir} or {experiments_dir / 'verse_counts'};"
+            " required for --books complete."
+        )
+    df = pd.concat(frames)
+    return df[~df.index.duplicated(keep="first")]
+
+
+def resolve_corpus_books(books_arg: str, stems: Sequence[str], verse_counts: Optional[pd.DataFrame]) -> str:
+    if books_arg.lower() != "complete":
+        return books_arg
+    if verse_counts is None:
+        raise ValueError("verse counts are required for --books complete")
+    if "complete" not in verse_counts.index:
+        raise ValueError("No 'complete' row found in verse_counts.csv; cannot apply the completeness rule.")
+    for stem in stems:
+        if stem not in verse_counts.index:
+            raise ValueError(f"No verse counts found for '{stem}'; cannot apply the completeness rule.")
+
+    books = []
+    for book in OT_CANON + NT_CANON:
+        if book not in verse_counts.columns:
+            continue
+        complete_count = verse_counts.at["complete", book]
+        if pd.isna(complete_count) or complete_count <= 0:
+            continue
+        threshold = BOOK_COMPLETENESS_THRESHOLD * complete_count
+        counts = [verse_counts.at[stem, book] for stem in stems]
+        if all(not pd.isna(count) and count >= threshold for count in counts):
+            books.append(book)
+
+    for canon, token in [(OT_CANON, "OT"), (NT_CANON, "NT")]:
+        if all(book in books for book in canon):
+            books = [book for book in books if book not in canon] + [token]
+    return ";".join(books)
+
+
+def build_config(sources: List[Candidate], main: MainProject, corpus_books: str) -> dict:
+    lang_codes: Dict[str, str] = {}
+    for source in sources:
+        lang_codes.setdefault(source.iso, nllb_tag(source.iso, source.script))
+    lang_codes.setdefault(main.iso, nllb_tag(main.iso, main.script or ""))
+    src_stems = [source.stem for source in sources]
+    return {
+        "data": {
+            "corpus_pairs": [
+                {
+                    "corpus_books": corpus_books,
+                    "mapping": "mixed_src",
+                    "src": src_stems[0] if len(src_stems) == 1 else src_stems,
+                    "trg": main.stem,
+                    "type": "train,test",
+                }
+            ],
+            "lang_codes": lang_codes,
+            "seed": SEED,
+        },
+        "model": MODEL,
+    }
+
+
+def build_translate_config(sources: List[Candidate], translate_books: str) -> dict:
+    return {
+        "translate": [
+            {"books": translate_books, "src_project": source.name, "checkpoint": CHECKPOINT} for source in sources
+        ],
+        "postprocess": [{"paragraph_behavior": "place"}],
+    }
+
+
+def find_existing(lang_dir: Path, prefix: str, config: dict) -> Tuple[Optional[Path], int]:
+    """Return (folder with an identical config or None, next free index) for prefix_<n> folders."""
+    pattern = re.compile(rf"^{re.escape(prefix)}_(\d+)$")
+    max_index = 0
+    for folder in lang_dir.iterdir() if lang_dir.is_dir() else []:
+        m = pattern.match(folder.name)
+        if m is None or not folder.is_dir():
+            continue
+        max_index = max(max_index, int(m.group(1)))
+        config_path = folder / "config.yml"
+        if config_path.is_file():
+            try:
+                with open(config_path, "r", encoding="utf-8") as file:
+                    if yaml.safe_load(file) == config:
+                        return folder, max_index
+            except yaml.YAMLError:
+                LOGGER.warning(f"Could not parse {config_path}; ignoring it for the identical-config check.")
+    return None, max_index + 1
+
+
+def select_mixed_pairs(pairs: List[List[Candidate]], dry_run: bool) -> List[List[Candidate]]:
+    if len(pairs) <= MAX_UNPROMPTED_MIXED:
+        return pairs
+    print(f"\n{len(pairs)} mixed-source experiments pass the thresholds:")
+    for i, pair in enumerate(pairs, start=1):
+        names = " + ".join(f"{source.name} ({source.alignment:.4f})" for source in pair)
+        print(f"  {i}. {names}")
+    if dry_run:
+        print("Dry run: all listed pairs are included in the report below.")
+        return pairs
+    reply = input("Enter the numbers to create (e.g. 1,3), 'all' or 'none': ").strip().lower()
+    if reply in ("", "none"):
+        return []
+    if reply == "all":
+        return pairs
+    chosen = []
+    for token in re.split(r"[,\s]+", reply):
+        if token.isdigit() and 1 <= int(token) <= len(pairs):
+            chosen.append(pairs[int(token) - 1])
+        else:
+            LOGGER.warning(f"Ignoring invalid selection '{token}'.")
+    return chosen
+
+
+def write_yaml(path: Path, content: dict) -> None:
+    with open(path, "w", encoding="utf-8") as file:
+        yaml.dump(content, file, sort_keys=False, default_flow_style=False, allow_unicode=True)
+
+
+def resolve_request_dir(request: str, experiments_dir: Path) -> Path:
+    requests_dir = experiments_dir / "_OnboardingRequests"
+    for name in [request, f"{request}_Request"]:
+        candidate = requests_dir / name
+        if candidate.is_dir():
+            return candidate
+    raise FileNotFoundError(f"No request folder '{request}' or '{request}_Request' found in {requests_dir}.")
+
+
+def run(
+    request_dir: Path,
+    experiments_dir: Path,
+    assets_dir: Path,
+    books: str,
+    translate_books: str,
+    min_parallel: int,
+    min_alignment: float,
+    dry_run: bool = False,
+) -> List[Experiment]:
+    log_path = request_dir / "onboarding.log"
+    if not log_path.is_file():
+        raise FileNotFoundError(f"No onboarding.log found in {request_dir}.")
+    main, candidates = parse_log(log_path)
+
+    language, country = lookup_language(main.iso, assets_dir)
+    lang_dir = experiments_dir / folder_name(country) / folder_name(language)
+    print(f"Main project: {main.name} ({main.stem}), language: {language} [{main.iso}], country: {country}")
+    print(f"Experiment location: {lang_dir}")
+
+    candidates.sort(key=lambda c: c.alignment, reverse=True)
+    passing = [c for c in candidates if c.parallel >= min_parallel and c.alignment >= min_alignment]
+    print(f"\n{'Reference':<24} {'iso':<5} {'count':>7} {'parallel':>9} {'alignment':>10}  result")
+    for c in candidates:
+        result = "pass" if c in passing else "fail"
+        print(f"{c.name:<24} {c.iso:<5} {c.count:>7} {c.parallel:>9} {c.alignment:>10.4f}  {result}")
+    if not passing:
+        print(f"\nNo references passed the thresholds (parallel >= {min_parallel}, alignment >= {min_alignment}).")
+        return []
+
+    verse_counts = None
+    if books.lower() == "complete":
+        verse_counts = load_verse_counts(request_dir, experiments_dir)
+
+    mixed = select_mixed_pairs([list(pair) for pair in itertools.combinations(passing, 2)], dry_run)
+
+    experiments: List[Experiment] = []
+    print()
+    for sources in [[c] for c in passing] + mixed:
+        label = " + ".join(source.name for source in sources)
+        try:
+            corpus_books = resolve_corpus_books(books, [s.stem for s in sources] + [main.stem], verse_counts)
+        except ValueError as e:
+            print(f"Skipped {label}: {e}")
+            continue
+        if not corpus_books:
+            print(f"Skipped {label}: no book meets the {BOOK_COMPLETENESS_THRESHOLD:.0%} completeness rule.")
+            continue
+        config = build_config(sources, main, corpus_books)
+        prefix = "_".join([source.name for source in sources] + [main.iso])
+        existing, index = find_existing(lang_dir, prefix, config)
+        if existing is not None:
+            print(f"Skipped {label}: {existing} already contains an identical config.yml.")
+            continue
+        folder = lang_dir / f"{prefix}_{index}"
+        experiment = Experiment(
+            sources=sources,
+            folder=folder,
+            config=config,
+            translate_config=build_translate_config(sources, translate_books),
+        )
+        experiments.append(experiment)
+        if dry_run:
+            print(f"Would create {folder} (corpus_books: {corpus_books})")
+        else:
+            folder.mkdir(parents=True, exist_ok=True)
+            write_yaml(folder / "config.yml", experiment.config)
+            write_yaml(folder / "translate_config.yml", experiment.translate_config)
+            print(f"Created {folder} (corpus_books: {corpus_books})")
+    return experiments
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+    parser = argparse.ArgumentParser(description="Create experiment folders from an onboarding request.")
+    parser.add_argument("request", help="Request folder name in MT/experiments/_OnboardingRequests")
+    parser.add_argument("--min-parallel", type=int, default=2000, help="Minimum parallel verse count (default 2000)")
+    parser.add_argument("--min-alignment", type=float, default=0.2, help="Minimum alignment score (default 0.2)")
+    parser.add_argument(
+        "--books",
+        default="complete",
+        help="Semicolon-separated corpus_books list, or 'complete' (default) to derive it from verse_counts.csv",
+    )
+    parser.add_argument(
+        "--translate-books",
+        required=True,
+        help="Book or semicolon-separated list of books for translate_config.yml",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report without creating folders or files")
+    args = parser.parse_args()
+
+    environment = SilNlpEnv.create_standard_environment()
+    experiments_dir = Path(environment.mt_experiments_dir)
+    run(
+        request_dir=resolve_request_dir(args.request, experiments_dir),
+        experiments_dir=experiments_dir,
+        assets_dir=Path(environment.assets_dir),
+        books=args.books,
+        translate_books=args.translate_books,
+        min_parallel=args.min_parallel,
+        min_alignment=args.min_alignment,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/create_onboarding_experiments/onboarding.log
+++ b/tests/data/create_onboarding_experiments/onboarding.log
@@ -1,0 +1,16 @@
+2026-07-02 13:06:38,608 - silnlp.common.onboard_project - INFO - Processing onboarding request for main project 'A33_2026_07_02'
+2026-07-02 13:06:38,608 - silnlp.common.onboard_project - INFO - Onboarding main project 'A33_2026_07_02'
+2026-07-02 13:06:45,890 - silnlp.common.extract_corpora - INFO - Extracted corpus file: /root/M/MT/scripture/sdl-A33_2026_07_02.txt
+2026-07-02 13:06:45,891 - silnlp.common.extract_corpora - INFO - # of Verses: 5084
+2026-07-02 13:06:58,558 - silnlp.common.onboard_project - INFO - Onboarding reference project 'HINCLBSI'
+2026-07-02 13:07:14,630 - silnlp.common.extract_corpora - INFO - Extracted corpus file: /root/M/MT/scripture/hi-HINCLBSI.txt
+2026-07-02 13:07:14,631 - silnlp.common.extract_corpora - INFO - # of Verses: 30997
+2026-07-02 13:08:13,559 - silnlp.common.onboard_project - INFO - Onboarding reference project 'a55_2026_07_02'
+2026-07-02 13:08:18,376 - silnlp.common.extract_corpora - INFO - Extracted corpus file: /root/M/MT/scripture/arb-a55_2026_07_02.txt
+2026-07-02 13:08:18,377 - silnlp.common.extract_corpora - INFO - # of Verses: 179
+2026-07-02 13:08:55,839 - silnlp.common.analyze - INFO - Computing alignment beteween sdl-A33_2026_07_02 and en-NIV11R using Eflomal
+2026-07-02 13:09:03,178 - silnlp.common.analyze - INFO - A33_2026_07_02 -> NIV11R stats - count: 31096, source only count: 14 target only count: 26012 parallel count: 5070 alignment: 0.3388, filtered count: 0, alignment (filtered): 0.3388, source script: Arab, source script in model: True, target script: Latn, target script in model: True
+2026-07-02 13:09:03,624 - silnlp.common.analyze - INFO - Computing alignment beteween sdl-A33_2026_07_02 and hi-HINCLBSI using Eflomal
+2026-07-02 13:09:11,418 - silnlp.common.analyze - INFO - A33_2026_07_02 -> HINCLBSI stats - count: 30998, source only count: 1 target only count: 25929 parallel count: 5068 alignment: 0.2605, filtered count: 0, alignment (filtered): 0.2605, source script: Arab, source script in model: True, target script: Deva, target script in model: True
+2026-07-02 13:09:19,570 - silnlp.common.analyze - INFO - Computing alignment beteween sdl-A33_2026_07_02 and arb-a55_2026_07_02 using Eflomal
+2026-07-02 13:09:28,254 - silnlp.common.analyze - INFO - A33_2026_07_02 -> a55_2026_07_02 stats - count: 5258, source only count: 5079 target only count: 178 parallel count: 1 alignment: 0.4000, filtered count: 0, alignment (filtered): 0.4000, source script: Arab, source script in model: True, target script: Arab, target script in model: True

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -1,0 +1,191 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from silnlp.common.create_onboarding_experiments import (
+    NT_CANON,
+    find_existing,
+    folder_name,
+    nllb_tag,
+    parse_log,
+    resolve_corpus_books,
+    run,
+)
+
+ASSETS_DIR = Path(__file__).parent.parent / "silnlp" / "assets"
+SAMPLE_LOG_PATH = Path(__file__).parent / "data" / "create_onboarding_experiments" / "onboarding.log"
+
+BOOKS = ["GEN", "EXO", "MAT", "MRK"]
+
+
+def make_verse_counts(path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "file": ["complete", "sdl-A33_2026_07_02", "en-NIV11R", "hi-HINCLBSI", "arb-a55_2026_07_02"],
+            "GEN": [1533, 0, 1533, 1533, 0],
+            "EXO": [1213, 0, 1213, 1213, 0],
+            "MAT": [1071, 1071, 1071, 1071, 0],
+            "MRK": [678, 678, 678, 678, 179],
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+@pytest.fixture
+def request_dir(tmp_path: Path) -> Path:
+    request = tmp_path / "_OnboardingRequests" / "A33_2026_07_02_Request"
+    request.mkdir(parents=True)
+    (request / "onboarding.log").write_text(SAMPLE_LOG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    make_verse_counts(request / "verse_counts.csv")
+    return request
+
+
+def test_parse_log(request_dir: Path):
+    main, candidates = parse_log(request_dir / "onboarding.log")
+    assert main.name == "A33_2026_07_02"
+    assert main.stem == "sdl-A33_2026_07_02"
+    assert main.iso == "sdl"
+    assert main.verses == 5084
+    assert main.script == "Arab"
+
+    by_name = {c.name: c for c in candidates}
+    assert set(by_name) == {"NIV11R", "HINCLBSI", "a55_2026_07_02"}
+    # NIV11R has no "Extracted corpus file" line; its stem comes from the alignment line.
+    niv = by_name["NIV11R"]
+    assert (niv.stem, niv.iso, niv.count, niv.parallel, niv.alignment, niv.script) == (
+        "en-NIV11R",
+        "en",
+        31096,
+        5070,
+        0.3388,
+        "Latn",
+    )
+    assert by_name["HINCLBSI"].script == "Deva"
+    assert by_name["a55_2026_07_02"].parallel == 1
+
+
+def test_folder_name():
+    assert folder_name("Russian Federation") == "Russian_Federation"
+    assert folder_name("Arabic, Standard") == "Arabic_Standard"
+    assert folder_name("Mari-Hill") == "Mari_Hill"
+    assert folder_name("Saudi Arabian Sign Language") == "Saudi_Arabian_Sign_Language"
+
+
+def test_nllb_tag():
+    assert nllb_tag("en", "Latn") == "eng_Latn"  # 2-letter code resolved to the NLLB tag
+    assert nllb_tag("hi", "Deva") == "hin_Deva"
+    assert nllb_tag("sdl", "Arab") == "sdl_Arab"  # not in NLLB: iso3 + script from the log
+
+
+def test_resolve_corpus_books_verbatim():
+    assert resolve_corpus_books("GEN;EXO;NT", [], None) == "GEN;EXO;NT"
+
+
+def test_resolve_corpus_books_complete(request_dir: Path):
+    df = pd.read_csv(request_dir / "verse_counts.csv", index_col="file")
+    books = resolve_corpus_books("complete", ["en-NIV11R", "sdl-A33_2026_07_02"], df)
+    assert books == "MAT;MRK"
+    # arb-a55 has partial MRK (179 < 98% of 678), so nothing qualifies with it as a source.
+    assert resolve_corpus_books("complete", ["arb-a55_2026_07_02", "sdl-A33_2026_07_02"], df) == ""
+
+
+def test_resolve_corpus_books_nt_compaction():
+    stems = ["en-NIV11R", "sdl-TRG"]
+    df = pd.DataFrame(100, index=["complete"] + stems, columns=NT_CANON)
+    df.index.name = "file"
+    assert resolve_corpus_books("complete", stems, df) == "NT"
+
+
+def test_find_existing(tmp_path: Path):
+    config = {"model": "m", "data": {"seed": 111}}
+    lang_dir = tmp_path / "Lang"
+    existing, index = find_existing(lang_dir, "NIV11R_sdl", config)
+    assert existing is None and index == 1
+
+    folder = lang_dir / "NIV11R_sdl_2"
+    folder.mkdir(parents=True)
+    (folder / "config.yml").write_text(yaml.dump({"model": "other"}), encoding="utf-8")
+    existing, index = find_existing(lang_dir, "NIV11R_sdl", config)
+    assert existing is None and index == 3
+
+    (folder / "config.yml").write_text(yaml.dump(config), encoding="utf-8")
+    existing, _ = find_existing(lang_dir, "NIV11R_sdl", config)
+    assert existing == folder
+
+
+def test_run_creates_experiments(request_dir: Path, tmp_path: Path):
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        books="complete",
+        translate_books="MAT;MRK",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    lang_dir = tmp_path / "Saudi_Arabia" / "Saudi_Arabian_Sign_Language"
+    folders = sorted(e.folder.name for e in experiments)
+    assert folders == ["HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1", "NIV11R_sdl_1"]
+
+    with open(lang_dir / "NIV11R_sdl_1" / "config.yml", "r", encoding="utf-8") as file:
+        config = yaml.safe_load(file)
+    assert config == {
+        "data": {
+            "corpus_pairs": [
+                {
+                    "corpus_books": "MAT;MRK",
+                    "mapping": "mixed_src",
+                    "src": "en-NIV11R",
+                    "trg": "sdl-A33_2026_07_02",
+                    "type": "train,test",
+                }
+            ],
+            "lang_codes": {"en": "eng_Latn", "sdl": "sdl_Arab"},
+            "seed": 111,
+        },
+        "model": "facebook/nllb-200-distilled-1.3B",
+    }
+
+    # Mixed experiment: sources ordered by alignment (NIV11R 0.3388 first), one translate entry per source.
+    with open(lang_dir / "NIV11R_HINCLBSI_sdl_1" / "config.yml", "r", encoding="utf-8") as file:
+        mixed = yaml.safe_load(file)
+    assert mixed["data"]["corpus_pairs"][0]["src"] == ["en-NIV11R", "hi-HINCLBSI"]
+    assert mixed["data"]["lang_codes"] == {"en": "eng_Latn", "hi": "hin_Deva", "sdl": "sdl_Arab"}
+    with open(lang_dir / "NIV11R_HINCLBSI_sdl_1" / "translate_config.yml", "r", encoding="utf-8") as file:
+        translate = yaml.safe_load(file)
+    assert translate == {
+        "translate": [
+            {"books": "MAT;MRK", "src_project": "NIV11R", "checkpoint": 5000},
+            {"books": "MAT;MRK", "src_project": "HINCLBSI", "checkpoint": 5000},
+        ],
+        "postprocess": [{"paragraph_behavior": "place"}],
+    }
+
+    # Running again skips everything: identical configs already exist.
+    again = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        books="complete",
+        translate_books="MAT;MRK",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    assert again == []
+
+
+def test_run_dry_run(request_dir: Path, tmp_path: Path):
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        books="MAT",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        dry_run=True,
+    )
+    assert len(experiments) == 3
+    assert not (tmp_path / "Saudi_Arabia").exists()

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -59,8 +59,8 @@ def request_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def select_all(monkeypatch):
-    """Answer the experiment-selection prompt with 'all'."""
-    monkeypatch.setattr("builtins.input", lambda prompt: "all")
+    """Answer the experiment-selection prompt with 'all' and the rename confirmation with 'y'."""
+    monkeypatch.setattr("builtins.input", lambda prompt: "y" if "Rename" in prompt else "all")
 
 
 def test_parse_log(request_dir: Path):
@@ -324,6 +324,147 @@ def test_parse_corpus_stats_target(tmp_path: Path):
     assert main.stem == "sdl-A33_2026_07_02" and [c.name for c in candidates] == ["NIV11R"]
 
 
+def test_parse_corpus_stats_skips_incomplete_rows(tmp_path: Path):
+    # analyze.py writes empty count cells when original extracts are missing; such rows
+    # must not crash the parse, only drop the affected candidate.
+    stats_path = tmp_path / "corpus-stats.csv"
+    stats_path.write_text(
+        "src_project,trg_project,count,src_only,trg_only,parallel,align_score,filtered_count,"
+        "filtered_align_score,src_script,src_script_in_model,trg_script,trg_script_in_model\n"
+        "sdl-MAIN,en-REF1,10,0,0,5,0.5,0,0.5,Arab,True,Latn,True\n"
+        "sdl-MAIN,en-REF2,,,,,,,,Arab,True,Latn,True\n",
+        encoding="utf-8",
+    )
+    main, candidates = parse_corpus_stats(stats_path)
+    assert main.stem == "sdl-MAIN"
+    assert [c.name for c in candidates] == ["REF1"]
+
+
+def test_parse_corpus_stats_target_matching_both_sides_of_a_row(tmp_path: Path):
+    stats_path = tmp_path / "corpus-stats.csv"
+    stats_path.write_text(
+        "src_project,trg_project,count,src_only,trg_only,parallel,align_score,filtered_count,"
+        "filtered_align_score,src_script,src_script_in_model,trg_script,trg_script_in_model\n"
+        "sdl-A33,sdl-BackTrans,10,0,0,5,0.5,0,0.5,Arab,True,Arab,True\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="matches both sides"):
+        parse_corpus_stats(stats_path, target="sdl")
+    # The project name still disambiguates.
+    main, _ = parse_corpus_stats(stats_path, target="BackTrans")
+    assert main.stem == "sdl-BackTrans"
+
+
+def test_stem_matches_iso_equivalence():
+    from silnlp.common.create_onboarding_experiments import stem_matches
+
+    assert stem_matches("fr-BDS", "fra")  # 3-letter target matches the 2-letter stem prefix
+    assert stem_matches("fra-BDS", "fr")
+    assert stem_matches("en-NIV11R", "ENG")
+    assert not stem_matches("fr-BDS", "deu")
+    assert stem_matches("fr-BDS", "bds")  # project-name leg is unaffected
+
+
+def test_run_falls_back_to_log_when_csv_is_unusable(request_dir: Path, tmp_path: Path, capsys, select_all):
+    # A stale/partial CSV that neither fits the log's main project nor auto-detects must
+    # not brick a folder that previously worked from onboarding.log.
+    alignments = request_dir / "alignments"
+    alignments.mkdir()
+    pd.DataFrame(
+        {
+            "src_project": ["en-X", "fr-Y"],
+            "trg_project": ["de-P", "es-Q"],  # neither column constant, no A33 stem
+            "count": [1, 1],
+            "parallel": [1, 1],
+            "align_score": [0.5, 0.5],
+            "src_script": ["Latn", "Latn"],
+            "trg_script": ["Latn", "Latn"],
+        }
+    ).to_csv(alignments / "corpus-stats.csv", index=False)
+
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    # Falls back to the log and behaves exactly like a log-only folder.
+    assert sorted(e.folder.name for e in experiments) == ["HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1", "NIV11R_sdl_1"]
+
+
+def test_run_target_flip_uses_derived_location(tmp_path: Path, capsys):
+    # When --target flips the direction, the create-next-to-stats rule must not file the
+    # experiments under the stats folder's (different) language.
+    align_dir = tmp_path / "KSA" / "SignLang" / "Align"
+    align_dir.mkdir(parents=True)
+    make_corpus_stats(align_dir / "corpus-stats.csv")
+    make_verse_counts(align_dir / "verse_counts.csv")
+    run(
+        request_dir=align_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        target="NIV11R",
+        dry_run=True,
+    )
+    output = capsys.readouterr().out
+    assert "Note: --target overrides the analyze run's own target project (sdl-A33_2026_07_02)." in output
+    assert "Experiment location: " + str(tmp_path / "KSA" / "SignLang") not in output
+
+
+def test_run_stats_folder_directly_under_experiments_uses_derived_location(tmp_path: Path, capsys):
+    stats_dir = tmp_path / "MyAlignRun"
+    stats_dir.mkdir()
+    make_corpus_stats(stats_dir / "corpus-stats.csv")
+    make_verse_counts(stats_dir / "verse_counts.csv")
+    run(
+        request_dir=stats_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        dry_run=True,
+    )
+    output = capsys.readouterr().out
+    # Not dumped at the experiments root: the derived Country/Language location is used.
+    assert f"Experiment location: {tmp_path / 'Saudi_Arabia' / 'Saudi_Arabian_Sign_Language'}" in output
+
+
+def test_run_rename_declined_aborts(request_dir: Path, tmp_path: Path, capsys, monkeypatch):
+    log_path = request_dir / "onboarding.log"
+    log_path.write_text(log_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
+    counts_path = request_dir / "verse_counts.csv"
+    counts_path.write_text(counts_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
+    scripture_dir = tmp_path / "scripture"
+    scripture_dir.mkdir()
+    (scripture_dir / "sdl-A33_2026_07_02.txt").write_text("verses\n", encoding="utf-8")
+
+    monkeypatch.setattr("builtins.input", lambda prompt: "n" if "Rename" in prompt else "all")
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=scripture_dir,
+    )
+    assert experiments == []
+    assert "Aborted: the rename is required" in capsys.readouterr().out
+    # Nothing was renamed and nothing was created.
+    assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
+    assert not (tmp_path / "Saudi_Arabia").exists()
+
+
 def make_candidate(name: str, alignment: float) -> Candidate:
     return Candidate(name=name, stem=f"en-{name}", iso="en", count=1, parallel=1, alignment=alignment, script="Latn")
 
@@ -346,6 +487,15 @@ def test_select_experiments(monkeypatch, capsys):
     assert select_experiments(singles, mixed, dry_run=False) == [singles[0], mixed[0]]
     monkeypatch.setattr("builtins.input", lambda prompt: "none")
     assert select_experiments(singles, mixed, dry_run=False) == []
+
+    # Duplicate tokens are deduplicated (a repeat would otherwise be submitted twice).
+    monkeypatch.setattr("builtins.input", lambda prompt: "1,1 2")
+    assert select_experiments(singles, mixed, dry_run=False) == [singles[0], singles[1]]
+
+    # --top widens (or narrows) the display cap.
+    monkeypatch.setattr("builtins.input", lambda prompt: "all")
+    assert len(select_experiments(singles, mixed, dry_run=False, top=25)) == 25
+    assert select_experiments(singles, mixed, dry_run=False, top=2) == singles[:2]
 
     # Dry run returns everything displayed without prompting.
     monkeypatch.setattr("builtins.input", lambda prompt: pytest.fail("dry run must not prompt"))

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 import yaml
+from machine.scripture import book_id_to_number
 
 from silnlp.common.create_onboarding_experiments import (
     EXPERIMENT_ARGS,
@@ -12,12 +13,16 @@ from silnlp.common.create_onboarding_experiments import (
     Experiment,
     find_existing,
     folder_name,
+    load_language_entries,
     nllb_tag,
+    parse_book_list,
     parse_log,
     resolve_corpus_books,
     run,
     submit_experiments,
+    synthesize_trg_iso,
 )
+from silnlp.common.iso_info import NLLB_TAG_FROM_ISO
 
 ASSETS_DIR = Path(__file__).parent.parent / "silnlp" / "assets"
 SAMPLE_LOG_PATH = Path(__file__).parent / "data" / "create_onboarding_experiments" / "onboarding.log"
@@ -84,23 +89,86 @@ def test_nllb_tag():
     assert nllb_tag("sdl", "Arab") == "sdl_Arab"  # not in NLLB: iso3 + script from the log
 
 
+def test_parse_book_list():
+    assert parse_book_list("GEN;RUT") == "GEN;RUT"
+    assert parse_book_list("GEN,RUT") == "GEN,RUT"  # already valid downstream syntax, kept verbatim
+    assert parse_book_list("GEN RUT") == "GEN;RUT"
+    assert parse_book_list("gen rut") == "GEN;RUT"
+    assert parse_book_list(" GEN, RUT ;JON ") == "GEN;RUT;JON"  # internal spaces force normalisation
+    assert parse_book_list("GEN") == "GEN"
+    # Full get_chapters syntax is preserved verbatim (ranges, chapters, subtraction).
+    assert parse_book_list("MAT 1-4") == "MAT 1-4"
+    assert parse_book_list("mat 1-4") == "MAT 1-4"
+    assert parse_book_list("NT;-REV") == "NT;-REV"
+    assert parse_book_list("GEN-DEU") == "GEN-DEU"
+    # Invalid book lists are rejected at the CLI instead of failing at preprocess time.
+    with pytest.raises(ValueError, match="not a valid book list"):
+        parse_book_list("GEN;MTT")
+    with pytest.raises(ValueError, match="not a valid book list"):
+        parse_book_list("")
+
+
 def test_resolve_corpus_books_verbatim():
-    assert resolve_corpus_books("GEN;EXO;NT", [], None) == "GEN;EXO;NT"
+    assert resolve_corpus_books("GEN;EXO;NT", [], None) == ("GEN;EXO;NT", [])
 
 
 def test_resolve_corpus_books_complete(request_dir: Path):
     df = pd.read_csv(request_dir / "verse_counts.csv", index_col="file")
-    books = resolve_corpus_books("complete", ["en-NIV11R", "sdl-A33_2026_07_02"], df)
-    assert books == "MAT;MRK"
+    books, removed = resolve_corpus_books("complete", ["en-NIV11R", "sdl-A33_2026_07_02"], df)
+    assert (books, removed) == ("MAT;MRK", [])
     # arb-a55 has partial MRK (179 < 98% of 678), so nothing qualifies with it as a source.
-    assert resolve_corpus_books("complete", ["arb-a55_2026_07_02", "sdl-A33_2026_07_02"], df) == ""
+    assert resolve_corpus_books("complete", ["arb-a55_2026_07_02", "sdl-A33_2026_07_02"], df) == ("", [])
 
 
 def test_resolve_corpus_books_nt_compaction():
     stems = ["en-NIV11R", "sdl-TRG"]
     df = pd.DataFrame(100, index=["complete"] + stems, columns=NT_CANON)
     df.index.name = "file"
-    assert resolve_corpus_books("complete", stems, df) == "NT"
+    assert resolve_corpus_books("complete", stems, df) == ("NT", [])
+
+
+def test_resolve_corpus_books_excludes_translate_books():
+    mat = {book_id_to_number("MAT")}
+    # Explicit lists are kept verbatim, with subtraction selections appended for excluded books.
+    assert resolve_corpus_books("GEN;EXO;MAT", [], None, exclude=mat) == ("GEN;EXO;MAT;-MAT", ["MAT"])
+    assert resolve_corpus_books("NT", [], None, exclude=mat) == ("NT;-MAT", ["MAT"])
+    assert resolve_corpus_books("OT;NT", [], None, exclude=mat) == ("OT;NT;-MAT", ["MAT"])
+    # Books hidden inside ranges are excluded too.
+    exo = {book_id_to_number("EXO")}
+    assert resolve_corpus_books("GEN-DEU", [], None, exclude=exo) == ("GEN-DEU;-EXO", ["EXO"])
+    # Chapter-level selections subtract exactly the selected chapters.
+    assert resolve_corpus_books("GEN;MAT 1-4", [], None, exclude=mat) == ("GEN;MAT 1-4;-MAT1,2,3,4", ["MAT"])
+    # Excluding everything empties the list.
+    assert resolve_corpus_books("MAT", [], None, exclude=mat) == ("", ["MAT"])
+    # Books not in the list are not reported as removed.
+    assert resolve_corpus_books("GEN;EXO", [], None, exclude=mat) == ("GEN;EXO", [])
+    # Case-insensitive: exclusion works regardless of how the CLI value was cased (numbers, not strings).
+    books, removed = resolve_corpus_books("complete", ["en-NIV11R", "sdl-TRG"], _nt_counts(), exclude=mat)
+    assert removed == ["MAT"]
+
+
+def _nt_counts() -> pd.DataFrame:
+    df = pd.DataFrame(100, index=["complete", "en-NIV11R", "sdl-TRG"], columns=NT_CANON)
+    df.index.name = "file"
+    return df
+
+
+def test_resolve_corpus_books_complete_excludes_translate_books(request_dir: Path):
+    df = pd.read_csv(request_dir / "verse_counts.csv", index_col="file")
+    books, removed = resolve_corpus_books(
+        "complete", ["en-NIV11R", "sdl-A33_2026_07_02"], df, exclude={book_id_to_number("MAT")}
+    )
+    assert (books, removed) == ("MRK", ["MAT"])
+
+
+def test_synthesize_trg_iso():
+    real_isos = {entry["isoCode"] for entry in load_language_entries(ASSETS_DIR)}
+    code = synthesize_trg_iso("sdl", real_isos)
+    assert len(code) == 3 and code[0] == "s" and code != "sdl"
+    assert code not in real_isos
+    assert code not in NLLB_TAG_FROM_ISO
+    # Deterministic: same input gives the same code on re-runs.
+    assert synthesize_trg_iso("sdl", real_isos) == code
 
 
 def test_find_existing(tmp_path: Path):
@@ -125,8 +193,8 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
         request_dir=request_dir,
         experiments_dir=tmp_path,
         assets_dir=ASSETS_DIR,
-        books="complete",
-        translate_books="MAT;MRK",
+        training_books="complete",
+        translate_books="MAT",
         min_parallel=2000,
         min_alignment=0.2,
     )
@@ -134,13 +202,17 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
     folders = sorted(e.folder.name for e in experiments)
     assert folders == ["HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1", "NIV11R_sdl_1"]
 
+    # The translated book MAT is excluded from corpus_books (complete would give MAT;MRK).
+    output = capsys.readouterr().out
+    assert "excluded the books being translated from corpus_books: MAT" in output
+
     with open(lang_dir / "NIV11R_sdl_1" / "config.yml", "r", encoding="utf-8") as file:
         config = yaml.safe_load(file)
     assert config == {
         "data": {
             "corpus_pairs": [
                 {
-                    "corpus_books": "MAT;MRK",
+                    "corpus_books": "MRK",
                     "mapping": "mixed_src",
                     "src": "en-NIV11R",
                     "trg": "sdl-A33_2026_07_02",
@@ -162,21 +234,20 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
         translate = yaml.safe_load(file)
     assert translate == {
         "translate": [
-            {"books": "MAT;MRK", "src_project": "NIV11R", "checkpoint": 5000},
-            {"books": "MAT;MRK", "src_project": "HINCLBSI", "checkpoint": 5000},
+            {"books": "MAT", "src_project": "NIV11R", "checkpoint": 5000},
+            {"books": "MAT", "src_project": "HINCLBSI", "checkpoint": 5000},
         ],
         "postprocess": [{"paragraph_behavior": "place"}],
     }
 
     # Running again creates nothing (identical configs already exist), but the
     # existing experiments are still offered for running.
-    capsys.readouterr()
     again = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
         assets_dir=ASSETS_DIR,
-        books="complete",
-        translate_books="MAT;MRK",
+        training_books="complete",
+        translate_books="MAT",
         min_parallel=2000,
         min_alignment=0.2,
     )
@@ -185,6 +256,182 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
     assert "To run the experiments:" in output
     for name in ["NIV11R_sdl_1", "HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1"]:
         assert f"Saudi_Arabia/Saudi_Arabian_Sign_Language/{name}" in output
+
+
+def test_run_translating_all_training_books_skips(request_dir: Path, tmp_path: Path, capsys):
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT;MRK",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    assert experiments == []
+    output = capsys.readouterr().out
+    assert "no training books remain" in output
+
+
+def test_run_test_variants(request_dir: Path, tmp_path: Path):
+    for variant, expected_type in [("notest", "train"), ("test100", "train,test")]:
+        experiments = run(
+            request_dir=request_dir,
+            experiments_dir=tmp_path,
+            assets_dir=ASSETS_DIR,
+            training_books="complete",
+            translate_books="MAT",
+            min_parallel=2000,
+            min_alignment=0.2,
+            test_variant=variant,
+        )
+        folders = sorted(e.folder.name for e in experiments)
+        assert folders == [f"HINCLBSI_sdl_{variant}_1", f"NIV11R_HINCLBSI_sdl_{variant}_1", f"NIV11R_sdl_{variant}_1"]
+        pair = experiments[0].config["data"]["corpus_pairs"][0]
+        assert pair["type"] == expected_type
+        if variant == "test100":
+            assert pair["test_size"] == 100
+        else:
+            assert "test_size" not in pair
+
+
+def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_path: Path, capsys):
+    # Make NIV11R clash with the main project by giving it the same iso prefix.
+    log_path = request_dir / "onboarding.log"
+    log_path.write_text(log_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
+    counts_path = request_dir / "verse_counts.csv"
+    counts_path.write_text(counts_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
+
+    scripture_dir = tmp_path / "scripture"
+    scripture_dir.mkdir()
+    (scripture_dir / "sdl-A33_2026_07_02.txt").write_text("verses\n", encoding="utf-8")
+    terms_dir = tmp_path / "terms"
+    terms_dir.mkdir()
+    (terms_dir / "sdl-A33_2026_07_02-Major-renderings.txt").write_text("terms\n", encoding="utf-8")
+
+    # A dry run reports the clash and the would-be rename without touching anything,
+    # even when no scripture directory is available.
+    dry = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=scripture_dir,
+        terms_dir=terms_dir,
+        dry_run=True,
+    )
+    assert len(dry) == 3
+    assert "Would rename sdl-A33_2026_07_02.txt" in capsys.readouterr().out
+    assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
+    run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=None,
+        dry_run=True,
+    )
+    assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
+    capsys.readouterr()
+
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=scripture_dir,
+        terms_dir=terms_dir,
+    )
+    output = capsys.readouterr().out
+    assert "shares iso code 'sdl' with the target project" in output
+
+    real_isos = {entry["isoCode"] for entry in load_language_entries(ASSETS_DIR)}
+    synthetic = synthesize_trg_iso("sdl", real_isos)
+    # The extract and terms files were renamed and the configs use the synthetic stem and lang code.
+    assert not (scripture_dir / "sdl-A33_2026_07_02.txt").exists()
+    assert (scripture_dir / f"{synthetic}-A33_2026_07_02.txt").is_file()
+    assert not (terms_dir / "sdl-A33_2026_07_02-Major-renderings.txt").exists()
+    assert (terms_dir / f"{synthetic}-A33_2026_07_02-Major-renderings.txt").is_file()
+    by_folder = {e.folder.name: e for e in experiments}
+    assert f"NIV11R_{synthetic}_1" in by_folder
+    pair = by_folder[f"NIV11R_{synthetic}_1"].config["data"]["corpus_pairs"][0]
+    assert pair["src"] == "sdl-NIV11R"
+    assert pair["trg"] == f"{synthetic}-A33_2026_07_02"
+    lang_codes = by_folder[f"NIV11R_{synthetic}_1"].config["data"]["lang_codes"]
+    assert lang_codes["sdl"] == "sdl_Latn"  # the source keeps its own (Latn) script tag
+    assert lang_codes[synthetic] == f"{synthetic}_Arab"
+
+    # Re-running with the file already renamed reuses the code recorded by the file on disk.
+    again = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=scripture_dir,
+    )
+    assert again == []
+
+    # Even when no clash is detectable any more (here: the log no longer contains the
+    # clashing stem), the prior rename recorded by the file on disk is adopted so the
+    # configs keep matching the file that actually exists.
+    log_path.write_text(log_path.read_text(encoding="utf-8").replace("sdl-NIV11R", "en-NIV11R"), encoding="utf-8")
+    counts_path.write_text(counts_path.read_text(encoding="utf-8").replace("sdl-NIV11R", "en-NIV11R"), encoding="utf-8")
+    capsys.readouterr()
+    adopted = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        scripture_dir=scripture_dir,
+        dry_run=True,
+    )
+    assert "previously renamed extract file" in capsys.readouterr().out
+    assert adopted  # dry run still proposes experiments
+    for experiment in adopted:
+        assert experiment.config["data"]["corpus_pairs"][0]["trg"] == f"{synthetic}-A33_2026_07_02"
+
+    # If the original extract reappears next to the renamed one, the ambiguity is an error.
+    (scripture_dir / "sdl-A33_2026_07_02.txt").write_text("verses\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="remove the stale one"):
+        run(
+            request_dir=request_dir,
+            experiments_dir=tmp_path,
+            assets_dir=ASSETS_DIR,
+            training_books="complete",
+            translate_books="MAT",
+            min_parallel=2000,
+            min_alignment=0.2,
+            scripture_dir=scripture_dir,
+        )
+
+
+def test_run_rejects_unknown_test_variant(request_dir: Path, tmp_path: Path):
+    with pytest.raises(ValueError, match="Unknown test_variant"):
+        run(
+            request_dir=request_dir,
+            experiments_dir=tmp_path,
+            assets_dir=ASSETS_DIR,
+            training_books="complete",
+            translate_books="MAT",
+            min_parallel=2000,
+            min_alignment=0.2,
+            test_variant="no-test",
+        )
 
 
 def test_submit_experiments(monkeypatch, capsys, tmp_path: Path):
@@ -209,17 +456,24 @@ def test_submit_experiments(monkeypatch, capsys, tmp_path: Path):
     submit_experiments([experiment], tmp_path, submit=None)
     assert len(calls) == 1  # declined at the prompt, nothing new ran
 
+    # no_test drops the --test stage from both the printed and executed command.
+    capsys.readouterr()
+    submit_experiments([experiment], tmp_path, submit=True, no_test=True)
+    assert calls[-1] == [sys.executable] + [a for a in EXPERIMENT_ARGS if a != "--test"] + ["Country/Lang/NIV11R_sdl_1"]
+    assert "--test" not in capsys.readouterr().out
+
 
 def test_run_dry_run(request_dir: Path, tmp_path: Path):
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
         assets_dir=ASSETS_DIR,
-        books="MAT",
+        training_books="MAT;MRK",
         translate_books="MAT",
         min_parallel=2000,
         min_alignment=0.2,
         dry_run=True,
     )
     assert len(experiments) == 3
+    assert all(e.config["data"]["corpus_pairs"][0]["corpus_books"] == "MAT;MRK;-MAT" for e in experiments)
     assert not (tmp_path / "Saudi_Arabia").exists()

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -10,6 +10,8 @@ from machine.scripture import book_id_to_number
 from silnlp.common.create_onboarding_experiments import (
     EXPERIMENT_ARGS,
     NT_CANON,
+    TOP_EXPERIMENTS,
+    Candidate,
     Experiment,
     find_existing,
     folder_name,
@@ -21,6 +23,7 @@ from silnlp.common.create_onboarding_experiments import (
     resolve_corpus_books,
     resolve_request_dir,
     run,
+    select_experiments,
     submit_experiments,
     synthesize_trg_iso,
 )
@@ -52,6 +55,12 @@ def request_dir(tmp_path: Path) -> Path:
     (request / "onboarding.log").write_text(SAMPLE_LOG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
     make_verse_counts(request / "verse_counts.csv")
     return request
+
+
+@pytest.fixture
+def select_all(monkeypatch):
+    """Answer the experiment-selection prompt with 'all'."""
+    monkeypatch.setattr("builtins.input", lambda prompt: "all")
 
 
 def test_parse_log(request_dir: Path):
@@ -265,7 +274,134 @@ def test_parse_corpus_stats(tmp_path: Path):
         parse_corpus_stats(tmp_path / "ambiguous.csv")
 
 
-def test_run_from_corpus_stats_folder(tmp_path: Path, capsys):
+def test_parse_corpus_stats_target(tmp_path: Path):
+    stats_path = tmp_path / "corpus-stats.csv"
+    make_corpus_stats(stats_path)
+
+    # The target may be given as an iso code, a project name, or a full stem.
+    for target in ("sdl", "A33_2026_07_02", "sdl-A33_2026_07_02", "SDL"):
+        main, candidates = parse_corpus_stats(stats_path, target=target)
+        assert main.stem == "sdl-A33_2026_07_02"
+        assert {c.name for c in candidates} == {"NIV11R", "HINCLBSI", "a55_2026_07_02"}
+
+    # The target may sit on either side per row, and rows not involving it are ignored.
+    mixed_direction = pd.DataFrame(
+        {
+            "src_project": ["en-NIV11R", "sdl-A33_2026_07_02", "en-NIV11R"],
+            "trg_project": ["sdl-A33_2026_07_02", "hi-HINCLBSI", "fr-BDS"],
+            "count": [10, 20, 30],
+            "parallel": [5, 6, 7],
+            "align_score": [0.5, 0.4, 0.3],
+            "src_script": ["Latn", "Arab", "Latn"],
+            "trg_script": ["Arab", "Deva", "Latn"],
+        }
+    )
+    mixed_direction.to_csv(tmp_path / "mixed.csv", index=False)
+    main, candidates = parse_corpus_stats(tmp_path / "mixed.csv", target="sdl")
+    assert main.stem == "sdl-A33_2026_07_02"
+    by_name = {c.name: c for c in candidates}
+    assert set(by_name) == {"NIV11R", "HINCLBSI"}  # the NIV11R/BDS row is ignored
+    assert by_name["HINCLBSI"].alignment == 0.4
+
+    # A target matching two different projects (shared iso) is an error.
+    two_projects = mixed_direction.copy()
+    two_projects.loc[2, "trg_project"] = "sdl-OtherProject"
+    two_projects.to_csv(tmp_path / "two.csv", index=False)
+    with pytest.raises(ValueError, match="matches more than one project"):
+        parse_corpus_stats(tmp_path / "two.csv", target="sdl")
+
+    # A target matching nothing is an error.
+    with pytest.raises(ValueError, match="does not match any project"):
+        parse_corpus_stats(stats_path, target="xyz")
+
+    # A single row is ambiguous without a target...
+    single = mixed_direction.iloc[[0]]
+    single.to_csv(tmp_path / "single.csv", index=False)
+    with pytest.raises(ValueError, match="specify it with --target"):
+        parse_corpus_stats(tmp_path / "single.csv")
+    # ...and fine with one.
+    main, candidates = parse_corpus_stats(tmp_path / "single.csv", target="sdl")
+    assert main.stem == "sdl-A33_2026_07_02" and [c.name for c in candidates] == ["NIV11R"]
+
+
+def make_candidate(name: str, alignment: float) -> Candidate:
+    return Candidate(name=name, stem=f"en-{name}", iso="en", count=1, parallel=1, alignment=alignment, script="Latn")
+
+
+def test_select_experiments(monkeypatch, capsys):
+    singles = [[make_candidate(f"S{i:02}", 0.9 - i / 100)] for i in range(15)]
+    mixed = [[s[0], t[0]] for s, t in zip(singles, singles[1:])]  # 14 pairs
+
+    # Capped at TOP_EXPERIMENTS with singles listed first.
+    monkeypatch.setattr("builtins.input", lambda prompt: "all")
+    chosen = select_experiments(singles, mixed, dry_run=False)
+    assert len(chosen) == TOP_EXPERIMENTS
+    assert chosen[:15] == singles and chosen[15:] == mixed[:5]
+    output = capsys.readouterr().out
+    assert f"top {TOP_EXPERIMENTS} of 29" in output
+    assert "S00 (0.9000)" in output
+
+    # Number selection picks from the displayed list; 'none' selects nothing.
+    monkeypatch.setattr("builtins.input", lambda prompt: "1, 16")
+    assert select_experiments(singles, mixed, dry_run=False) == [singles[0], mixed[0]]
+    monkeypatch.setattr("builtins.input", lambda prompt: "none")
+    assert select_experiments(singles, mixed, dry_run=False) == []
+
+    # Dry run returns everything displayed without prompting.
+    monkeypatch.setattr("builtins.input", lambda prompt: pytest.fail("dry run must not prompt"))
+    assert len(select_experiments(singles, mixed, dry_run=True)) == TOP_EXPERIMENTS
+
+
+def test_run_prefers_corpus_stats_over_log(request_dir: Path, tmp_path: Path, capsys, select_all):
+    # A single-row CSV in alignments/ is preferred over the log; the log's main-project
+    # line orients it (a lone row is otherwise ambiguous).
+    alignments = request_dir / "alignments"
+    alignments.mkdir()
+    pd.DataFrame(
+        {
+            "src_project": ["sdl-A33_2026_07_02"],
+            "trg_project": ["en-NIV11R"],
+            "count": [31096],
+            "parallel": [5070],
+            "align_score": [0.5555],  # differs from the log's 0.3388 to prove the CSV is used
+            "src_script": ["Arab"],
+            "trg_script": ["Latn"],
+        }
+    ).to_csv(alignments / "corpus-stats.csv", index=False)
+
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    output = capsys.readouterr().out
+    assert "0.5555" in output  # CSV numbers, not the log's
+    # Experiments still go to the derived location, never into _OnboardingRequests.
+    assert [e.folder for e in experiments] == [
+        tmp_path / "Saudi_Arabia" / "Saudi_Arabian_Sign_Language" / "NIV11R_sdl_1"
+    ]
+    assert not (request_dir / "NIV11R_sdl_1").exists()
+
+
+def test_run_target_mismatch_on_log_only(request_dir: Path, tmp_path: Path):
+    with pytest.raises(ValueError, match="does not match the main project"):
+        run(
+            request_dir=request_dir,
+            experiments_dir=tmp_path,
+            assets_dir=ASSETS_DIR,
+            training_books="complete",
+            translate_books="MAT",
+            min_parallel=2000,
+            min_alignment=0.2,
+            target="nonexistent",
+        )
+
+
+def test_run_from_corpus_stats_folder(tmp_path: Path, capsys, select_all):
     # A stats folder inside the experiments tree creates experiments next to itself,
     # keeping the existing country/language folder naming (e.g. PNG/Taupota).
     experiments_dir = tmp_path
@@ -315,7 +451,7 @@ def test_run_from_corpus_stats_folder(tmp_path: Path, capsys):
     assert (experiments_dir2 / "Saudi_Arabia" / "Saudi_Arabian_Sign_Language" / "NIV11R_sdl_1").is_dir()
 
 
-def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
+def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys, select_all):
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -385,7 +521,7 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
         assert f"Saudi_Arabia/Saudi_Arabian_Sign_Language/{name}" in output
 
 
-def test_run_translating_all_training_books_skips(request_dir: Path, tmp_path: Path, capsys):
+def test_run_translating_all_training_books_skips(request_dir: Path, tmp_path: Path, capsys, select_all):
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -400,7 +536,7 @@ def test_run_translating_all_training_books_skips(request_dir: Path, tmp_path: P
     assert "no training books remain" in output
 
 
-def test_run_test_variants(request_dir: Path, tmp_path: Path):
+def test_run_test_variants(request_dir: Path, tmp_path: Path, select_all):
     for variant, expected_type in [("notest", "train"), ("test100", "train,test")]:
         experiments = run(
             request_dir=request_dir,
@@ -422,7 +558,7 @@ def test_run_test_variants(request_dir: Path, tmp_path: Path):
             assert "test_size" not in pair
 
 
-def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_path: Path, capsys):
+def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_path: Path, capsys, select_all):
     # Make NIV11R clash with the main project by giving it the same iso prefix.
     log_path = request_dir / "onboarding.log"
     log_path.write_text(log_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -1,17 +1,22 @@
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 import yaml
 
 from silnlp.common.create_onboarding_experiments import (
+    EXPERIMENT_ARGS,
     NT_CANON,
+    Experiment,
     find_existing,
     folder_name,
     nllb_tag,
     parse_log,
     resolve_corpus_books,
     run,
+    submit_experiments,
 )
 
 ASSETS_DIR = Path(__file__).parent.parent / "silnlp" / "assets"
@@ -115,7 +120,7 @@ def test_find_existing(tmp_path: Path):
     assert existing == folder
 
 
-def test_run_creates_experiments(request_dir: Path, tmp_path: Path):
+def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -163,7 +168,9 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path):
         "postprocess": [{"paragraph_behavior": "place"}],
     }
 
-    # Running again skips everything: identical configs already exist.
+    # Running again creates nothing (identical configs already exist), but the
+    # existing experiments are still offered for running.
+    capsys.readouterr()
     again = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -174,6 +181,33 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path):
         min_alignment=0.2,
     )
     assert again == []
+    output = capsys.readouterr().out
+    assert "To run the experiments:" in output
+    for name in ["NIV11R_sdl_1", "HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1"]:
+        assert f"Saudi_Arabia/Saudi_Arabian_Sign_Language/{name}" in output
+
+
+def test_submit_experiments(monkeypatch, capsys, tmp_path: Path):
+    experiment = Experiment(
+        sources=[], folder=tmp_path / "Country" / "Lang" / "NIV11R_sdl_1", config={}, translate_config={}
+    )
+    calls = []
+    monkeypatch.setattr(
+        "silnlp.common.create_onboarding_experiments.subprocess.run",
+        lambda cmd: calls.append(cmd) or SimpleNamespace(returncode=0),
+    )
+
+    submit_experiments([experiment], tmp_path, submit=False)
+    output = capsys.readouterr().out
+    assert f"poetry run python {' '.join(EXPERIMENT_ARGS)} Country/Lang/NIV11R_sdl_1" in output
+    assert calls == []
+
+    submit_experiments([experiment], tmp_path, submit=True)
+    assert calls == [[sys.executable] + EXPERIMENT_ARGS + ["Country/Lang/NIV11R_sdl_1"]]
+
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+    submit_experiments([experiment], tmp_path, submit=None)
+    assert len(calls) == 1  # declined at the prompt, nothing new ran
 
 
 def test_run_dry_run(request_dir: Path, tmp_path: Path):

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -16,8 +16,10 @@ from silnlp.common.create_onboarding_experiments import (
     load_language_entries,
     nllb_tag,
     parse_book_list,
+    parse_corpus_stats,
     parse_log,
     resolve_corpus_books,
+    resolve_request_dir,
     run,
     submit_experiments,
     synthesize_trg_iso,
@@ -186,6 +188,131 @@ def test_find_existing(tmp_path: Path):
     (folder / "config.yml").write_text(yaml.dump(config), encoding="utf-8")
     existing, _ = find_existing(lang_dir, "NIV11R_sdl", config)
     assert existing == folder
+
+
+def make_corpus_stats(path: Path, main_is_trg: bool = True) -> None:
+    """Write a corpus-stats.csv in the analyze format, matching the fixture log's stats."""
+    main_stem, main_script = "sdl-A33_2026_07_02", "Arab"
+    refs = [
+        ("en-NIV11R", 31096, 5070, 0.3388, "Latn"),
+        ("hi-HINCLBSI", 30998, 5068, 0.2605, "Deva"),
+        ("arb-a55_2026_07_02", 5258, 1, 0.4000, "Arab"),
+    ]
+    records = []
+    for ref_stem, count, parallel, score, script in refs:
+        main_entry = {"project": main_stem, "script": main_script}
+        ref_entry = {"project": ref_stem, "script": script}
+        src, trg = (ref_entry, main_entry) if main_is_trg else (main_entry, ref_entry)
+        records.append(
+            {
+                "src_project": src["project"],
+                "trg_project": trg["project"],
+                "count": count,
+                "src_only": 0,
+                "trg_only": 0,
+                "parallel": parallel,
+                "align_score": score,
+                "filtered_count": 0,
+                "filtered_align_score": score,
+                "src_script": src["script"],
+                "src_script_in_model": True,
+                "trg_script": trg["script"],
+                "trg_script_in_model": True,
+            }
+        )
+    pd.DataFrame(records).to_csv(path, index=False)
+
+
+def test_parse_corpus_stats(tmp_path: Path):
+    # Both directions parse to the same result: main as trg (alignment run) or src (analyze run).
+    for main_is_trg in (True, False):
+        stats_path = tmp_path / f"corpus-stats-{main_is_trg}.csv"
+        make_corpus_stats(stats_path, main_is_trg=main_is_trg)
+        main, candidates = parse_corpus_stats(stats_path)
+        assert (main.name, main.stem, main.iso, main.script) == (
+            "A33_2026_07_02",
+            "sdl-A33_2026_07_02",
+            "sdl",
+            "Arab",
+        )
+        by_name = {c.name: c for c in candidates}
+        assert set(by_name) == {"NIV11R", "HINCLBSI", "a55_2026_07_02"}
+        niv = by_name["NIV11R"]
+        assert (niv.stem, niv.iso, niv.count, niv.parallel, niv.alignment, niv.script) == (
+            "en-NIV11R",
+            "en",
+            31096,
+            5070,
+            0.3388,
+            "Latn",
+        )
+        assert by_name["HINCLBSI"].script == "Deva"
+
+    # Neither column constant -> the main project cannot be determined.
+    ambiguous = pd.DataFrame(
+        {
+            "src_project": ["en-NIV11R", "hi-HINCLBSI"],
+            "trg_project": ["sdl-A", "sdl-B"],
+            "count": [1, 1],
+            "parallel": [1, 1],
+            "align_score": [0.5, 0.5],
+            "src_script": ["Latn", "Deva"],
+            "trg_script": ["Arab", "Arab"],
+        }
+    )
+    ambiguous.to_csv(tmp_path / "ambiguous.csv", index=False)
+    with pytest.raises(ValueError, match="Cannot determine the main project"):
+        parse_corpus_stats(tmp_path / "ambiguous.csv")
+
+
+def test_run_from_corpus_stats_folder(tmp_path: Path, capsys):
+    # A stats folder inside the experiments tree creates experiments next to itself,
+    # keeping the existing country/language folder naming (e.g. PNG/Taupota).
+    experiments_dir = tmp_path
+    align_dir = experiments_dir / "KSA" / "SignLang" / "Align"
+    align_dir.mkdir(parents=True)
+    make_corpus_stats(align_dir / "corpus-stats.csv")
+    make_verse_counts(align_dir / "verse_counts.csv")
+
+    assert resolve_request_dir("KSA/SignLang/Align", experiments_dir) == align_dir
+
+    experiments = run(
+        request_dir=align_dir,
+        experiments_dir=experiments_dir,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    folders = sorted(e.folder.name for e in experiments)
+    assert folders == ["HINCLBSI_sdl_1", "NIV11R_HINCLBSI_sdl_1", "NIV11R_sdl_1"]
+    # Created next to the Align folder, not under the derived Saudi_Arabia/... location.
+    assert (experiments_dir / "KSA" / "SignLang" / "NIV11R_sdl_1" / "config.yml").is_file()
+    assert not (experiments_dir / "Saudi_Arabia").exists()
+    with open(experiments_dir / "KSA" / "SignLang" / "NIV11R_sdl_1" / "config.yml", "r", encoding="utf-8") as file:
+        config = yaml.safe_load(file)
+    pair = config["data"]["corpus_pairs"][0]
+    assert (pair["src"], pair["trg"], pair["corpus_books"]) == ("en-NIV11R", "sdl-A33_2026_07_02", "MRK")
+
+    # A stats folder outside the experiments tree falls back to the derived location.
+    outside = tmp_path / "outside_tree"
+    outside.mkdir()
+    make_corpus_stats(outside / "corpus-stats.csv")
+    make_verse_counts(outside / "verse_counts.csv")
+    experiments_dir2 = tmp_path / "experiments2"
+    experiments_dir2.mkdir()
+    capsys.readouterr()
+    run(
+        request_dir=outside,
+        experiments_dir=experiments_dir2,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+    )
+    assert (experiments_dir2 / "Saudi_Arabia" / "Saudi_Arabian_Sign_Language" / "NIV11R_sdl_1").is_dir()
 
 
 def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys):

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -59,8 +61,8 @@ def request_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def select_all(monkeypatch):
-    """Answer the experiment-selection prompt with 'all' and the rename confirmation with 'y'."""
-    monkeypatch.setattr("builtins.input", lambda prompt: "y" if "Rename" in prompt else "all")
+    """Answer the experiment-selection prompt with 'all' and the copy confirmation with 'y'."""
+    monkeypatch.setattr("builtins.input", lambda prompt: "y" if "Copy" in prompt else "all")
 
 
 def test_parse_log(request_dir: Path):
@@ -438,7 +440,7 @@ def test_run_stats_folder_directly_under_experiments_uses_derived_location(tmp_p
     assert f"Experiment location: {tmp_path / 'Saudi_Arabia' / 'Saudi_Arabian_Sign_Language'}" in output
 
 
-def test_run_rename_declined_aborts(request_dir: Path, tmp_path: Path, capsys, monkeypatch):
+def test_run_copy_declined_aborts(request_dir: Path, tmp_path: Path, capsys, monkeypatch):
     log_path = request_dir / "onboarding.log"
     log_path.write_text(log_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
     counts_path = request_dir / "verse_counts.csv"
@@ -447,7 +449,7 @@ def test_run_rename_declined_aborts(request_dir: Path, tmp_path: Path, capsys, m
     scripture_dir.mkdir()
     (scripture_dir / "sdl-A33_2026_07_02.txt").write_text("verses\n", encoding="utf-8")
 
-    monkeypatch.setattr("builtins.input", lambda prompt: "n" if "Rename" in prompt else "all")
+    monkeypatch.setattr("builtins.input", lambda prompt: "n" if "Copy" in prompt else "all")
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -459,8 +461,8 @@ def test_run_rename_declined_aborts(request_dir: Path, tmp_path: Path, capsys, m
         scripture_dir=scripture_dir,
     )
     assert experiments == []
-    assert "Aborted: the rename is required" in capsys.readouterr().out
-    # Nothing was renamed and nothing was created.
+    assert "Aborted: the copy is required" in capsys.readouterr().out
+    # Nothing was copied and nothing was created.
     assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
     assert not (tmp_path / "Saudi_Arabia").exists()
 
@@ -708,7 +710,7 @@ def test_run_test_variants(request_dir: Path, tmp_path: Path, select_all):
             assert "test_size" not in pair
 
 
-def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_path: Path, capsys, select_all):
+def test_run_iso_clash_copies_and_uses_synthetic_code(request_dir: Path, tmp_path: Path, capsys, caplog, select_all):
     # Make NIV11R clash with the main project by giving it the same iso prefix.
     log_path = request_dir / "onboarding.log"
     log_path.write_text(log_path.read_text(encoding="utf-8").replace("en-NIV11R", "sdl-NIV11R"), encoding="utf-8")
@@ -722,7 +724,7 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
     terms_dir.mkdir()
     (terms_dir / "sdl-A33_2026_07_02-Major-renderings.txt").write_text("terms\n", encoding="utf-8")
 
-    # A dry run reports the clash and the would-be rename without touching anything,
+    # A dry run reports the clash and the would-be copy without touching anything,
     # even when no scripture directory is available.
     dry = run(
         request_dir=request_dir,
@@ -737,7 +739,7 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
         dry_run=True,
     )
     assert len(dry) == 3
-    assert "Would rename sdl-A33_2026_07_02.txt" in capsys.readouterr().out
+    assert "Would copy sdl-A33_2026_07_02.txt" in capsys.readouterr().out
     assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
     run(
         request_dir=request_dir,
@@ -769,10 +771,11 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
 
     real_isos = {entry["isoCode"] for entry in load_language_entries(ASSETS_DIR)}
     synthetic = synthesize_trg_iso("sdl", real_isos)
-    # The extract and terms files were renamed and the configs use the synthetic stem and lang code.
-    assert not (scripture_dir / "sdl-A33_2026_07_02.txt").exists()
+    # The extract and terms files were copied (originals kept) and the configs use the
+    # synthetic stem and lang code.
+    assert (scripture_dir / "sdl-A33_2026_07_02.txt").is_file()
     assert (scripture_dir / f"{synthetic}-A33_2026_07_02.txt").is_file()
-    assert not (terms_dir / "sdl-A33_2026_07_02-Major-renderings.txt").exists()
+    assert (terms_dir / "sdl-A33_2026_07_02-Major-renderings.txt").is_file()
     assert (terms_dir / f"{synthetic}-A33_2026_07_02-Major-renderings.txt").is_file()
     by_folder = {e.folder.name: e for e in experiments}
     assert f"NIV11R_{synthetic}_1" in by_folder
@@ -783,7 +786,7 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
     assert lang_codes["sdl"] == "sdl_Latn"  # the source keeps its own (Latn) script tag
     assert lang_codes[synthetic] == f"{synthetic}_Arab"
 
-    # Re-running with the file already renamed reuses the code recorded by the file on disk.
+    # Re-running with the copy already made reuses the code recorded by the file on disk.
     again = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -797,7 +800,7 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
     assert again == []
 
     # Even when no clash is detectable any more (here: the log no longer contains the
-    # clashing stem), the prior rename recorded by the file on disk is adopted so the
+    # clashing stem), the prior copy recorded by the file on disk is adopted so the
     # configs keep matching the file that actually exists.
     log_path.write_text(log_path.read_text(encoding="utf-8").replace("sdl-NIV11R", "en-NIV11R"), encoding="utf-8")
     counts_path.write_text(counts_path.read_text(encoding="utf-8").replace("sdl-NIV11R", "en-NIV11R"), encoding="utf-8")
@@ -813,14 +816,15 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
         scripture_dir=scripture_dir,
         dry_run=True,
     )
-    assert "previously renamed extract file" in capsys.readouterr().out
+    assert "previously copied extract file" in capsys.readouterr().out
     assert adopted  # dry run still proposes experiments
     for experiment in adopted:
         assert experiment.config["data"]["corpus_pairs"][0]["trg"] == f"{synthetic}-A33_2026_07_02"
 
-    # If the original extract reappears next to the renamed one, the ambiguity is an error.
-    (scripture_dir / "sdl-A33_2026_07_02.txt").write_text("verses\n", encoding="utf-8")
-    with pytest.raises(RuntimeError, match="remove the stale one"):
+    # If the original is re-extracted after the copy was made, warn that the copy may be stale.
+    now = time.time()
+    os.utime(scripture_dir / "sdl-A33_2026_07_02.txt", (now + 60, now + 60))
+    with caplog.at_level("WARNING"):
         run(
             request_dir=request_dir,
             experiments_dir=tmp_path,
@@ -830,7 +834,9 @@ def test_run_iso_clash_renames_and_uses_synthetic_code(request_dir: Path, tmp_pa
             min_parallel=2000,
             min_alignment=0.2,
             scripture_dir=scripture_dir,
+            dry_run=True,
         )
+    assert any("may be outdated" in record.message for record in caplog.records)
 
 
 def test_run_rejects_unknown_test_variant(request_dir: Path, tmp_path: Path):
@@ -876,7 +882,7 @@ def test_submit_experiments(monkeypatch, capsys, tmp_path: Path):
     assert "--test" not in capsys.readouterr().out
 
 
-def test_run_dry_run(request_dir: Path, tmp_path: Path):
+def test_run_dry_run(request_dir: Path, tmp_path: Path, capsys):
     experiments = run(
         request_dir=request_dir,
         experiments_dir=tmp_path,
@@ -890,3 +896,7 @@ def test_run_dry_run(request_dir: Path, tmp_path: Path):
     assert len(experiments) == 3
     assert all(e.config["data"]["corpus_pairs"][0]["corpus_books"] == "MAT;MRK;-MAT" for e in experiments)
     assert not (tmp_path / "Saudi_Arabia").exists()
+    # A dry run lists what would be created but does not print run commands.
+    output = capsys.readouterr().out
+    assert "Would create" in output
+    assert "To run the experiments:" not in output

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -61,8 +61,38 @@ def request_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def select_all(monkeypatch):
-    """Answer the experiment-selection prompt with 'all' and the copy confirmation with 'y'."""
-    monkeypatch.setattr("builtins.input", lambda prompt: "y" if "Copy" in prompt else "all")
+    """Answer the selection prompt with 'all', the copy confirmation with 'y', keep translate sources."""
+
+    def answer(prompt: str) -> str:
+        if "Copy" in prompt:
+            return "y"
+        if "different project" in prompt:
+            return ""
+        return "all"
+
+    monkeypatch.setattr("builtins.input", answer)
+
+
+def make_paratext_project(projects_dir: Path, name: str, books: list) -> None:
+    """Create a minimal Paratext project folder with a Settings.xml and the given book files."""
+    from machine.corpora import FileParatextProjectSettingsParser
+
+    project_dir = projects_dir / name
+    project_dir.mkdir(parents=True)
+    (project_dir / "Settings.xml").write_text(
+        "<ScriptureText>\n"
+        "  <Versification>4</Versification>\n"
+        "  <LanguageIsoCode>en:::</LanguageIsoCode>\n"
+        "  <Language>English</Language>\n"
+        "  <Encoding>65001</Encoding>\n"
+        f"  <Name>{name}</Name>\n"
+        f'  <Naming PrePart="" BookNameForm="41MAT" PostPart="{name}.SFM" />\n'
+        "</ScriptureText>\n",
+        encoding="utf-8",
+    )
+    settings = FileParatextProjectSettingsParser(project_dir).parse()
+    for book in books:
+        (project_dir / settings.get_book_file_name(book)).write_text(f"\\id {book}\n", encoding="utf-8")
 
 
 def test_parse_log(request_dir: Path):
@@ -837,6 +867,76 @@ def test_run_iso_clash_copies_and_uses_synthetic_code(request_dir: Path, tmp_pat
             dry_run=True,
         )
     assert any("may be outdated" in record.message for record in caplog.records)
+
+
+def test_check_translate_source(tmp_path: Path):
+    from silnlp.common.create_onboarding_experiments import check_translate_source
+
+    projects_dir = tmp_path / "projects"
+    make_paratext_project(projects_dir, "NIV11R", ["MAT"])
+    assert check_translate_source(projects_dir, "NIV11R", ["MAT"]) is None
+    assert "does not contain RUT" in check_translate_source(projects_dir, "NIV11R", ["MAT", "RUT"])
+    assert "no project folder 'MISSING'" in check_translate_source(projects_dir, "MISSING", ["MAT"])
+    # A project folder without a readable Settings.xml is reported, not crashed on.
+    (projects_dir / "BROKEN").mkdir()
+    assert "could not be read" in check_translate_source(projects_dir, "BROKEN", ["MAT"])
+
+
+def test_run_checks_translate_sources(request_dir: Path, tmp_path: Path, capsys, monkeypatch):
+    # NIV11R has MAT; HINCLBSI's project folder is missing. The user first tries a project
+    # that lacks MAT (warned again), then one that has it; translate_config uses the choice.
+    projects_dir = tmp_path / "projects"
+    make_paratext_project(projects_dir, "NIV11R", ["MAT"])
+    make_paratext_project(projects_dir, "NOMAT", ["RUT"])
+    make_paratext_project(projects_dir, "HINDI2", ["MAT"])
+
+    answers = iter(["NOMAT", "HINDI2"])
+
+    def answer(prompt: str) -> str:
+        if "different project" in prompt:
+            return next(answers)
+        return "all"
+
+    monkeypatch.setattr("builtins.input", answer)
+    experiments = run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        projects_dir=projects_dir,
+    )
+    output = capsys.readouterr().out
+    assert "cannot translate MAT from 'HINCLBSI': there is no project folder 'HINCLBSI'" in output
+    assert "cannot translate MAT from 'NOMAT': project 'NOMAT' does not contain MAT" in output
+    assert "Translating from 'HINDI2' instead of 'HINCLBSI'." in output
+
+    by_folder = {e.folder.name: e for e in experiments}
+    translate = by_folder["NIV11R_HINCLBSI_sdl_1"].translate_config["translate"]
+    assert [entry["src_project"] for entry in translate] == ["NIV11R", "HINDI2"]
+    # The training config still uses the original extract stems.
+    assert by_folder["NIV11R_HINCLBSI_sdl_1"].config["data"]["corpus_pairs"][0]["src"] == ["en-NIV11R", "hi-HINCLBSI"]
+
+
+def test_run_translate_source_warnings_only_in_dry_run(request_dir: Path, tmp_path: Path, capsys, monkeypatch):
+    projects_dir = tmp_path / "projects"
+    make_paratext_project(projects_dir, "NIV11R", ["MAT"])
+    monkeypatch.setattr("builtins.input", lambda prompt: pytest.fail("dry run must not prompt for translate sources"))
+    run(
+        request_dir=request_dir,
+        experiments_dir=tmp_path,
+        assets_dir=ASSETS_DIR,
+        training_books="complete",
+        translate_books="MAT",
+        min_parallel=2000,
+        min_alignment=0.2,
+        projects_dir=projects_dir,
+        dry_run=True,
+    )
+    output = capsys.readouterr().out
+    assert "cannot translate MAT from 'HINCLBSI'" in output
 
 
 def test_run_rejects_unknown_test_variant(request_dir: Path, tmp_path: Path):


### PR DESCRIPTION
## Summary

Adds `silnlp/common/create_onboarding_experiments.py`, a utility that turns a production Serval onboarding request into ready-to-run NMT experiment folders.

Given a request folder name in `MT/experiments/_OnboardingRequests/`, it:

- Parses `onboarding.log` for the main project and every aligned reference project (both the request's onboarded references and the standard alignment set), collecting verse counts, parallel counts, alignment scores, and scripts.
- Looks up the target language's name and country from `assets/languageFamilies.json` and creates `<Country>/<Language>/` folders (title case, underscores for spaces/hyphens).
- Selects references passing configurable thresholds (`--min-parallel`, default 2000; `--min-alignment`, default 0.2) and creates one experiment per passing reference plus two-source `mixed_src` combinations ordered by alignment score (interactive selection when more than 3 pairs qualify).
- Writes `config.yml` (NLLB lang codes, with `<iso3>_<script>` fallback for languages not in NLLB) and `translate_config.yml` (one translate entry per source project). `corpus_books` comes from `--training-books`, either a book selection or `complete`, which derives the books from `verse_counts.csv` using a 98% completeness rule.
- Prints the `silnlp.nmt.experiment` command for each experiment and offers to run them (`--run` skips the prompt). Experiments skipped because an identical `config.yml` already exists are still offered, since they may not have been run yet.
- Supports `--dry-run` to report everything without creating files (run commands are not printed — nothing will be run).

### Distinct src/trg iso codes

The src and trg isos of a corpus pair must differ (silnlp would otherwise collapse both sides into one NLLB language token). When a passing reference shares the main project's iso — e.g. a closely related language whose translation team uses the major language's code — the tool synthesizes a target code that is neither a real iso nor in NLLB (first letter kept, last two letters mutated) and copies the target extract file in `MT/scripture` (plus its `MT/terms` renderings files) to the new stem, keeping the originals. The copy is deferred until an experiment folder is actually created, so a run that creates nothing leaves the shared store untouched, and the copied file on disk is the durable record: later runs reuse the same code even if the clash is no longer visible under different thresholds.

### Translated books are excluded from training

Books in `--translate-books` are always excluded from `corpus_books`, so none of their text is used for training (a config that trains on the books it translates looks invalid even when the target books are empty). Explicit book lists are kept verbatim with subtraction selections appended (`NT` → `NT;-MAT`, `GEN-DEU` → `GEN-DEU;-EXO`, chapter selections subtract exactly the selected chapters); `complete` mode subtracts before NT/OT compaction. The user is warned with the list of excluded books.

### Book-list arguments

`--training-books` and `--translate-books` are parsed and validated with `machine.scripture.get_chapters`: the full silnlp selection syntax is preserved verbatim (ranges like `GEN-DEU`, chapter selections like `"MAT 1-4"`, subtractions like `"NT;-REV"`), comma- or space-separated lists are normalised (`GEN,RUT` works unquoted), input is case-insensitive, and invalid book IDs are rejected at the CLI instead of failing later at preprocess time.

### Translation-source checks

Before the configs are written, each chosen source project (the `src_project` in translate_config.yml) is verified: its folder must exist in `M/Paratext/projects` and contain a book file for every book being translated, with file names derived from the project's Settings.xml naming convention via `FileParatextProjectSettingsParser`. A missing project or book produces a warning and an interactive offer to translate from a different project (checked the same way) or keep the original; the replacement only affects translate_config.yml. Dry runs warn without prompting.

### Test-set options

`--no-test` creates train-only experiments (`type: train`, folder suffix `_notest`, `--test` dropped from the run command); `--test100` uses a 100-verse test set (`test_size: 100`, folder suffix `_test100`). The default remains the standard random 250-verse test set with no suffix.

### Corpus-stats input (preferred) with log fallback

`corpus-stats.csv` written by `silnlp.common.analyze` is the preferred input — it is the stable machine-readable artifact, whereas the log parser scrapes message wording. The tool probes `<folder>/corpus-stats.csv` then `<folder>/alignments/corpus-stats.csv`, falling back to `onboarding.log` only when neither exists (older request folders). The `request` argument therefore also accepts any folder relative to `MT/experiments` containing a stats file — e.g. an alignment folder like `PNG/Taupota/Align`. The main project is the stem appearing in every row on one side (trg for alignment runs, src for onboarding runs); when a log sits next to the CSV its main-project line orients the direction, so single-reference CSVs are never misread. `verse_counts.csv` is read from the same folder so `--training-books complete` works unchanged. A stats folder inside the experiments tree (but not under `_OnboardingRequests`) creates its experiments next to itself (`PNG/Taupota/Align` → `PNG/Taupota`), preserving the existing country/language folder naming.

### --target override

`--target` names the target language by iso code or project name, overriding detection: it may match either corpus-stats.csv column (rows not involving it are ignored), iso codes match across their 2/3-letter forms, and matching two projects that share an iso — or both sides of a row — is an error suggesting the project name. With only an onboarding.log the value is validated against the log's main project. When the override flips the direction away from the analyze run's own target, a note is printed and the derived `<Country>/<Language>` location is used instead of the stats folder's parent.

### Safeguards

The log-derived main-project hint is soft: if it does not fit the CSV the tool warns and falls back to auto-detection, then to parsing the log itself, so a stale or partial CSV never breaks a previously working folder. CSV rows with missing statistics are skipped with a warning. For a synthetic iso the target extract file (and its terms renderings) is **copied** to the new stem — the originals are kept, since they may be referenced by other experiments — after a y/N confirmation (default No), with a warning when --target overrode the direction and a caution when the target's iso is an NLLB code. If the original is later re-extracted, a warning flags the copy as possibly outdated. The create-next-to-stats location rule is disabled for request folders, folders directly under MT/experiments, and flipped targets.

### Experiment selection

Every run displays one numbered list of possible experiments capped at the top 20 (`--top` adjusts the cap) — all single-source experiments first (ranked by alignment), then two-source pairs in best-source-first order — and asks which to create (`1,3`, `all`, or `none`; duplicates are deduplicated). Nothing is created automatically; `--dry-run` prints the list without prompting and reports all displayed experiments.

## Usage

```
poetry run python -m silnlp.common.create_onboarding_experiments SFDH_2026_07_13 --translate-books MAT
poetry run python -m silnlp.common.create_onboarding_experiments SFDH_2026_07_13 --translate-books GEN,RUT --training-books "NT;-REV" --test100
poetry run python -m silnlp.common.create_onboarding_experiments PNG/Taupota/Align --translate-books MAT
```

## Test plan

- 34 tests in `tests/test_create_onboarding_experiments.py` using a real-format fixture log: log parsing, folder naming, NLLB tag resolution, the 98% completeness rule and NT/OT compaction, book-list parsing/validation, translate-book exclusion (plain lists, ranges, chapter selections, complete mode), synthetic iso derivation, deferred extract/terms renames with dry-run and re-run/prior-rename behaviour, test-set variants, index handling and identical-config skipping, corpus-stats parsing (both directions, --target by iso/project/stem, mixed-direction rows, ambiguity detection), CSV-over-log precedence with the log hint, the stats-folder experiment location, the top-20 selection prompt, end-to-end folder/YAML creation, dry-run, and the run-offer behaviour.
- Validated with `--dry-run` against real onboarding request folders (`A33_2026_07_02_Request`, `MKWBe_2026_07_16_Request`) and used to create and launch real experiments.
- black / isort / flake8 / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1120)
<!-- Reviewable:end -->
