### PR TITLE
update devcontainer for ease of use

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,6 +53,19 @@
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"python.defaultInterpreterPath": "/workspaces/silnlp/.venv/bin/python",
+				"python.useEnvironmentsExtension": false,
+				"isort.interpreter": [
+					"/workspaces/silnlp/.venv/bin/python"
+				],
+				"pylint.interpreter": [
+					"/workspaces/silnlp/.venv/bin/python"
+				],
+				"flake8.interpreter": [
+					"/workspaces/silnlp/.venv/bin/python"
+				],
+				"black-formatter.interpreter": [
+					"/workspaces/silnlp/.venv/bin/python"
+				],
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.codeActionsOnSave": {
@@ -77,7 +90,9 @@
 				"ms-python.flake8",
 				"ms-python.isort",
 				"eamodio.gitlens",
-				"donjayamanne.githistory"
+				"donjayamanne.githistory",
+				"anthropic.claude-code"
+
 			]
 		}
 	},


### PR DESCRIPTION
I updated the devcontainer to make it pick the correct python interpreter from the beginning and ensure the formatting extensions also automatically work from the beginning. There was a relatively new vscode python default extension that was overriding the desired functionality, so I needed to disable that for this to work. I also added claude code to the list of extensions, so that it doesn't need to be manually installed every time a devcontainer is recreated.

@TaperChipmunk32 can you double check that it works properly for you as well when you rebuild your devcontainer from scratch?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1123)
<!-- Reviewable:end -->
