### PR TITLE
Remove 10th percentile limit from alignment score filtering

### DIFF
--- a/silnlp/common/corpus.py
+++ b/silnlp/common/corpus.py
@@ -141,7 +141,6 @@ def split_parallel_corpus(
 def filter_parallel_corpus(corpus: pd.DataFrame, score_threshold: float) -> pd.DataFrame:
     if score_threshold < 1:
         # Filter the corpus entries with alignment scores less than the threshold
-        score_threshold = min(corpus["score"].quantile(0.1), score_threshold)
         return corpus[corpus["score"] > score_threshold]
     elif score_threshold < len(corpus):
         # Filter <n> corpus entries with the lowest alignment scores (n = score_threshold)


### PR DESCRIPTION
This PR removes the 10th-percentile limit from the alignment score filtering method in `corpus.py`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1125)
<!-- Reviewable:end -->
