### PR TITLE
Use UTC for datestamps

### DIFF
--- a/scripts/clean_projects.py
+++ b/scripts/clean_projects.py
@@ -1,7 +1,7 @@
 import argparse
 import csv
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from tqdm import tqdm
@@ -50,7 +50,7 @@ def find_items_to_delete(root_path: Path, delete_subfolders: bool):
 
 
 def clean_projects(args):
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     now_filestamp = now.strftime("%Y%m%d_%H%M%S")
     now_csv_date = now.strftime("%Y %m %d")
     now_csv_time = now.strftime("%H:%M:%S")

--- a/scripts/onboarding_requests.py
+++ b/scripts/onboarding_requests.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import List
@@ -236,7 +236,7 @@ def get_onboarding_requests() -> List[dict]:
 
 
 def append_datestamp(project_name: str) -> str:
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     datestamp = now.strftime("%Y_%m_%d")
     return f"{project_name}_{datestamp}"
 

--- a/silnlp/common/extract_corpora.py
+++ b/silnlp/common/extract_corpora.py
@@ -52,7 +52,8 @@ def main() -> None:
         from clearml import Task
 
         Task.init(
-            project_name="LangTech_ExtractCorpora", task_name=str(args.projects) + "_" + str(datetime.datetime.now())
+            project_name="LangTech_ExtractCorpora",
+            task_name=str(args.projects) + "_" + str(datetime.datetime.now(datetime.timezone.utc)),
         )
 
     # Which projects have data we can find?

--- a/silnlp/common/onboard_project.py
+++ b/silnlp/common/onboard_project.py
@@ -9,7 +9,7 @@ import sys
 import zipfile
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Iterator, List
@@ -42,7 +42,6 @@ class ProjectType(Enum):
 
 
 class OnboardingProject:
-
     def __init__(self, project_name: str, project_type: ProjectType, overwrite: bool, environment: SilNlpEnv) -> None:
         self.project_name: str = project_name
         self.local_project_path: Path | None = None
@@ -401,7 +400,6 @@ class OnboardingProject:
 
 
 class OnboardingReport:
-
     def __init__(self, project: OnboardingProject, project_type: ProjectType) -> None:
         self.project = project
         self.project_type: ProjectType = project_type
@@ -544,7 +542,6 @@ class OnboardingReportFlag:
 
 
 class OnboardingReportCreator:
-
     def __init__(
         self,
         report_path: Path,
@@ -617,9 +614,9 @@ class OnboardingReportCreator:
         self.report_df.loc[self.report_df["Project Type"] == ProjectType.MAIN.value, "Books to Translate"] = ";".join(
             self.planned_books
         )
-        self.report_df.loc[self.report_df["Project Type"] == ProjectType.MAIN.value, "Books Missing/Incomplete"] = (
-            ";".join([book for book in self.completed_books if book not in self.main_project.report.completed_books])
-        )
+        self.report_df.loc[
+            self.report_df["Project Type"] == ProjectType.MAIN.value, "Books Missing/Incomplete"
+        ] = ";".join([book for book in self.completed_books if book not in self.main_project.report.completed_books])
         self.report_df.loc[self.report_df["Project Type"] == ProjectType.MAIN.value, "Extra Books"] = ";".join(
             [book for book in self.main_project.report.completed_books if book not in self.completed_books]
         )
@@ -637,9 +634,9 @@ class OnboardingReportCreator:
             self.report_df.loc[self.report_df["Name on Bucket"] == project.project_name, "Books to Translate"] = (
                 "yes" if len(books_missing) == 0 else "no"
             )
-            self.report_df.loc[self.report_df["Name on Bucket"] == project.project_name, "Books Missing/Incomplete"] = (
-                ";".join(books_missing)
-            )
+            self.report_df.loc[
+                self.report_df["Name on Bucket"] == project.project_name, "Books Missing/Incomplete"
+            ] = ";".join(books_missing)
             self.report_df.loc[self.report_df["Name on Bucket"] == project.project_name, "Extra Books"] = ";".join(
                 extra_books
             )
@@ -654,7 +651,6 @@ class OnboardingReportCreator:
 
 
 class OnboardingRequest:
-
     def __init__(
         self,
         config: dict,
@@ -1023,7 +1019,7 @@ def copy_directory(source_dir: Path, target_dir: Path, overwrite=False) -> None:
 
 
 def append_datestamp(project_name: str) -> str:
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     datestamp = now.strftime("%Y_%m_%d")
     return f"{project_name}_{datestamp}"
 


### PR DESCRIPTION
This PR updates uses of `datetime.now` to use UTC to standardize all datestamps. This was prompted by some edge-cases where an OnboardingRequest would use a different datestamp for the folder name and for the comment on SF, since the folder name datestamp is done within a Docker container and the comment is done on Aqua directly. This seems like a good solution for this, but we could also update the Docker container to use the host machine's timezone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1146)
<!-- Reviewable:end -->
