### PR TITLE
Book confidence flag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -102,7 +102,7 @@
 			]
 		}
 	},
-	"postStartCommand": "poetry install && sh /workspaces/silnlp/.devcontainer/update_hosts.sh && sh /workspaces/silnlp/rclone_setup.sh minio"
+	"postStartCommand": "poetry install -E eflomal && sh /workspaces/silnlp/.devcontainer/update_hosts.sh && sh /workspaces/silnlp/rclone_setup.sh minio"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/silnlp/common/create_onboarding_experiments.py
+++ b/silnlp/common/create_onboarding_experiments.py
@@ -728,7 +728,7 @@ def build_translate_config(projects: Sequence[str], translate_books: str) -> dic
             }
             for project in projects
         ],
-        "quality_estimation" : True,
+        "quality_estimation": True,
         "postprocess": [{"paragraph_behavior": "place"}],
     }
 

--- a/silnlp/common/linear_regression.py
+++ b/silnlp/common/linear_regression.py
@@ -27,6 +27,9 @@ class LinearRegressionResult:
         except (KeyError, TypeError, ValueError) as e:
             raise ValueError(f"Invalid linear regression data: {json_str}") from e
 
+    def project_chrf3(self, confidence: float) -> float:
+        return self.slope * confidence + self.intercept
+
 
 class PointWeightingScheme:
     def weight_points(self, _x: List[float], _y: List[float]) -> List[float]: ...

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -21,12 +21,6 @@ NO_LINREGRESS_WARNING = (
 )
 
 
-def project_chrf3(linear_regression_result: Optional[LinearRegressionResult], confidence: float) -> Optional[float]:
-    if linear_regression_result is None:
-        return None
-    return linear_regression_result.slope * confidence + linear_regression_result.intercept
-
-
 @dataclass
 class Score:
     confidence: float
@@ -43,7 +37,10 @@ class VerseScore(Score):
     ) -> List["VerseScore"]:
         verse_scores: List[VerseScore] = []
         for vref, confidence in confidence_file.verse_confidence_iterator():
-            verse_scores.append(cls(confidence, project_chrf3(linear_regression_result, confidence), vref))
+            projected_chrf3 = (
+                None if linear_regression_result is None else linear_regression_result.project_chrf3(confidence)
+            )
+            verse_scores.append(cls(confidence, projected_chrf3, vref))
         return verse_scores
 
 
@@ -64,7 +61,10 @@ class ChapterScores:
         linear_regression_result: Optional[LinearRegressionResult],
     ) -> None:
         for chapter, confidence in confidence_file.chapter_confidence_iterator():
-            score = Score(confidence, project_chrf3(linear_regression_result, confidence))
+            projected_chrf3 = (
+                None if linear_regression_result is None else linear_regression_result.project_chrf3(confidence)
+            )
+            score = Score(confidence, projected_chrf3)
             self.add_score(book, chapter, score)
 
 
@@ -86,7 +86,10 @@ class BookScores:
     ) -> None:
         confidence = confidence_file.get_book_confidence(book)
         if confidence is not None:
-            self.add_score(book, Score(confidence, project_chrf3(linear_regression_result, confidence)))
+            projected_chrf3 = (
+                None if linear_regression_result is None else linear_regression_result.project_chrf3(confidence)
+            )
+            self.add_score(book, Score(confidence, projected_chrf3))
 
 
 @dataclass
@@ -101,10 +104,13 @@ class SequenceScore(Score):
         trg_draft_file_stem = confidence_file.get_trg_draft_file_path().stem
         sequence_scores: List[SequenceScore] = []
         for sequence_num, confidence in confidence_file.verse_confidence_iterator():
+            projected_chrf3 = (
+                None if linear_regression_result is None else linear_regression_result.project_chrf3(confidence)
+            )
             sequence_scores.append(
                 cls(
                     confidence,
-                    project_chrf3(linear_regression_result, confidence),
+                    projected_chrf3,
                     sequence_num,
                     trg_draft_file_stem,
                 )
@@ -130,7 +136,10 @@ class TxtFileScores:
         if files_path.is_file() and files_path not in self.seen_files:
             self.seen_files.add(files_path)
             for trg_draft_file_stem, confidence in confidence_file.file_confidence_iterator():
-                score = Score(confidence, project_chrf3(linear_regression_result, confidence))
+                projected_chrf3 = (
+                    None if linear_regression_result is None else linear_regression_result.project_chrf3(confidence)
+                )
+                score = Score(confidence, projected_chrf3)
                 self.add_score(trg_draft_file_stem, score)
 
 

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -3,8 +3,9 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, TextIO, Tuple
 
+from machine.quality_estimation import is_book_confidence_unusually_low
 from machine.scripture import ALL_BOOK_IDS, VerseRef
 
 from ..common.environment import SilNlpEnv
@@ -12,14 +13,24 @@ from ..common.linear_regression import LinearRegressionResult
 from ..common.translator import CONFIDENCE_SUFFIX, ConfidenceFile, TxtConfidenceFile, UsfmConfidenceFile
 from .test import LINREGRESS_PREFIX
 
-LOGGER = logging.getLogger(__package__ + ".quality_estimation")
+LOGGER = logging.getLogger((__package__ or "") + ".quality_estimation")
 CANONICAL_ORDER = {book: i for i, book in enumerate(ALL_BOOK_IDS)}
+NO_LINREGRESS_WARNING = (
+    "No linear regression file provided. Projected chrF3 scores and "
+    "usability labels cannot be computed; the usability files will report confidence only."
+)
+
+
+def project_chrf3(linear_regression_result: Optional[LinearRegressionResult], confidence: float) -> Optional[float]:
+    if linear_regression_result is None:
+        return None
+    return linear_regression_result.slope * confidence + linear_regression_result.intercept
 
 
 @dataclass
 class Score:
     confidence: float
-    projected_chrf3: float
+    projected_chrf3: Optional[float]
 
 
 @dataclass
@@ -28,12 +39,11 @@ class VerseScore(Score):
 
     @classmethod
     def get_scores_from_confidence_file(
-        cls, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
+        cls, confidence_file: UsfmConfidenceFile, linear_regression_result: Optional[LinearRegressionResult]
     ) -> List["VerseScore"]:
         verse_scores: List[VerseScore] = []
         for vref, confidence in confidence_file.verse_confidence_iterator():
-            projected_chrf3 = slope * confidence + intercept
-            verse_scores.append(cls(confidence, projected_chrf3, vref))
+            verse_scores.append(cls(confidence, project_chrf3(linear_regression_result, confidence), vref))
         return verse_scores
 
 
@@ -48,11 +58,13 @@ class ChapterScores:
         return self.scores.get(book, {}).get(chapter)
 
     def add_scores_from_confidence_file(
-        self, book: str, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
+        self,
+        book: str,
+        confidence_file: UsfmConfidenceFile,
+        linear_regression_result: Optional[LinearRegressionResult],
     ) -> None:
         for chapter, confidence in confidence_file.chapter_confidence_iterator():
-            projected_chrf3 = slope * confidence + intercept
-            score = Score(confidence, projected_chrf3)
+            score = Score(confidence, project_chrf3(linear_regression_result, confidence))
             self.add_score(book, chapter, score)
 
 
@@ -67,12 +79,14 @@ class BookScores:
         return self.scores.get(book)
 
     def add_scores_from_confidence_file(
-        self, book: str, confidence_file: UsfmConfidenceFile, slope: float, intercept: float
+        self,
+        book: str,
+        confidence_file: UsfmConfidenceFile,
+        linear_regression_result: Optional[LinearRegressionResult],
     ) -> None:
         confidence = confidence_file.get_book_confidence(book)
         if confidence is not None:
-            projected_chrf3 = slope * confidence + intercept
-            self.add_score(book, Score(confidence, projected_chrf3))
+            self.add_score(book, Score(confidence, project_chrf3(linear_regression_result, confidence)))
 
 
 @dataclass
@@ -82,13 +96,19 @@ class SequenceScore(Score):
 
     @classmethod
     def get_scores_from_confidence_file(
-        cls, confidence_file: TxtConfidenceFile, slope: float, intercept: float
+        cls, confidence_file: TxtConfidenceFile, linear_regression_result: Optional[LinearRegressionResult]
     ) -> List["SequenceScore"]:
         trg_draft_file_stem = confidence_file.get_trg_draft_file_path().stem
         sequence_scores: List[SequenceScore] = []
         for sequence_num, confidence in confidence_file.verse_confidence_iterator():
-            projected_chrf3 = slope * confidence + intercept
-            sequence_scores.append(cls(confidence, projected_chrf3, sequence_num, trg_draft_file_stem))
+            sequence_scores.append(
+                cls(
+                    confidence,
+                    project_chrf3(linear_regression_result, confidence),
+                    sequence_num,
+                    trg_draft_file_stem,
+                )
+            )
         return sequence_scores
 
 
@@ -104,20 +124,19 @@ class TxtFileScores:
         return self.scores.get(trg_draft_file_stem)
 
     def add_scores_from_confidence_file(
-        self, confidence_file: TxtConfidenceFile, slope: float, intercept: float
+        self, confidence_file: TxtConfidenceFile, linear_regression_result: Optional[LinearRegressionResult]
     ) -> None:
         files_path = confidence_file.get_files_path()
         if files_path.is_file() and files_path not in self.seen_files:
             self.seen_files.add(files_path)
             for trg_draft_file_stem, confidence in confidence_file.file_confidence_iterator():
-                projected_chrf3 = slope * confidence + intercept
-                score = Score(confidence, projected_chrf3)
+                score = Score(confidence, project_chrf3(linear_regression_result, confidence))
                 self.add_score(trg_draft_file_stem, score)
 
 
-def estimate_quality(linregress_path: Path, confidence_file_paths: List[Path]) -> None:
+def estimate_quality(linregress_path: Optional[Path], confidence_file_paths: List[Path]) -> None:
     linear_regression_result, confidence_files = validate_inputs(linregress_path, confidence_file_paths)
-    verse_scores, chapter_scores, book_scores, sequence_scores, txt_file_scores = project_chrf3(
+    verse_scores, chapter_scores, book_scores, sequence_scores, txt_file_scores = compute_scores(
         linear_regression_result, confidence_files
     )
     compute_quality_labels(
@@ -127,22 +146,27 @@ def estimate_quality(linregress_path: Path, confidence_file_paths: List[Path]) -
         sequence_scores,
         txt_file_scores,
         confidence_files[0].get_path().parent,
+        linear_regression_result is not None,
     )
 
 
 def validate_inputs(
-    linregress_path: Path, confidence_file_paths: List[Path]
-) -> Tuple[LinearRegressionResult, List[ConfidenceFile]]:
-    if not linregress_path.exists():
+    linregress_path: Optional[Path], confidence_file_paths: List[Path]
+) -> Tuple[Optional[LinearRegressionResult], List[ConfidenceFile]]:
+    if linregress_path is None:
+        LOGGER.warning(NO_LINREGRESS_WARNING)
+    elif not linregress_path.exists():
         raise FileNotFoundError(f"Linear regression file {linregress_path} does not exist.")
     elif linregress_path.is_dir():
         pattern = f"{LINREGRESS_PREFIX}.*.json"
         LOGGER.info(f"Searching for files matching {pattern} in directory {linregress_path}.")
         linregress_files = list(linregress_path.glob(pattern))
         if not linregress_files:
-            raise ValueError(f"No file matching {pattern} found in directory {linregress_path}.")
-        linregress_path = linregress_files[0]
-        LOGGER.info(f"Using linear regression file {linregress_path}.")
+            LOGGER.warning(f"No file matching {pattern} found in directory {linregress_path}. {NO_LINREGRESS_WARNING}")
+            linregress_path = None
+        else:
+            linregress_path = linregress_files[0]
+            LOGGER.info(f"Using linear regression file {linregress_path}.")
 
     if len(confidence_file_paths) == 0:
         raise ValueError("At least one confidence file must be provided.")
@@ -150,8 +174,10 @@ def validate_inputs(
         missing_files = [str(cf) for cf in confidence_file_paths if not cf.is_file()]
         raise FileNotFoundError(f"The following confidence files do not exist: {', '.join(missing_files)}")
 
-    with open(linregress_path, "r", encoding="utf-8") as f:
-        linear_regression_result = LinearRegressionResult.fromJSON(f.read())
+    linear_regression_result: Optional[LinearRegressionResult] = None
+    if linregress_path is not None:
+        with open(linregress_path, "r", encoding="utf-8") as f:
+            linear_regression_result = LinearRegressionResult.fromJSON(f.read())
 
     confidence_files: List[ConfidenceFile] = []
     for cf in confidence_file_paths:
@@ -160,12 +186,11 @@ def validate_inputs(
     return linear_regression_result, confidence_files
 
 
-def project_chrf3(
-    linear_regression_result: LinearRegressionResult, confidence_files: List[ConfidenceFile]
+def compute_scores(
+    linear_regression_result: Optional[LinearRegressionResult], confidence_files: List[ConfidenceFile]
 ) -> Tuple[List[VerseScore], ChapterScores, BookScores, List[SequenceScore], TxtFileScores]:
-    slope = linear_regression_result.slope
-    intercept = linear_regression_result.intercept
-    LOGGER.info(f"Linear regression data:\n{linear_regression_result.toJSON()}")
+    if linear_regression_result is not None:
+        LOGGER.info(f"Linear regression data:\n{linear_regression_result.toJSON()}")
 
     verse_scores: List[VerseScore] = []
     chapter_scores: ChapterScores = ChapterScores()
@@ -174,24 +199,26 @@ def project_chrf3(
     txt_file_scores: TxtFileScores = TxtFileScores()
     for confidence_file in confidence_files:
         if isinstance(confidence_file, UsfmConfidenceFile):
-            file_verse_scores = VerseScore.get_scores_from_confidence_file(confidence_file, slope, intercept)
+            file_verse_scores = VerseScore.get_scores_from_confidence_file(confidence_file, linear_regression_result)
             if not file_verse_scores:
                 LOGGER.warning(f"No verse scores found in confidence file {confidence_file.get_path()}. Skipping.")
                 continue
             verse_scores += file_verse_scores
             chapter_scores.add_scores_from_confidence_file(
-                file_verse_scores[0].vref.book, confidence_file, slope, intercept
+                file_verse_scores[0].vref.book, confidence_file, linear_regression_result
             )
             book_scores.add_scores_from_confidence_file(
-                file_verse_scores[0].vref.book, confidence_file, slope, intercept
+                file_verse_scores[0].vref.book, confidence_file, linear_regression_result
             )
         elif isinstance(confidence_file, TxtConfidenceFile):
-            file_sequence_scores = SequenceScore.get_scores_from_confidence_file(confidence_file, slope, intercept)
+            file_sequence_scores = SequenceScore.get_scores_from_confidence_file(
+                confidence_file, linear_regression_result
+            )
             if not file_sequence_scores:
                 LOGGER.warning(f"No sequence scores found in confidence file {confidence_file.get_path()}. Skipping.")
                 continue
             sequence_scores += file_sequence_scores
-            txt_file_scores.add_scores_from_confidence_file(confidence_file, slope, intercept)
+            txt_file_scores.add_scores_from_confidence_file(confidence_file, linear_regression_result)
     return verse_scores, chapter_scores, book_scores, sequence_scores, txt_file_scores
 
 
@@ -212,6 +239,22 @@ class Thresholds:
             return cls.RED_LABEL
 
 
+def chrf3_headers(include_projected_chrf3: bool) -> List[str]:
+    return ["Projected chrF3", "Label"] if include_projected_chrf3 else []
+
+
+def chrf3_cells(projected_chrf3: Optional[float], include_projected_chrf3: bool) -> List[str]:
+    if not include_projected_chrf3:
+        return []
+    if projected_chrf3 is None:
+        return ["", ""]
+    return [f"{projected_chrf3:.2f}", Thresholds.return_label(projected_chrf3)]
+
+
+def write_row(file: TextIO, cells: List[str]) -> None:
+    file.write("\t".join(cells) + "\n")
+
+
 def compute_quality_labels(
     verse_scores: List[VerseScore],
     chapter_scores: ChapterScores,
@@ -219,88 +262,112 @@ def compute_quality_labels(
     sequence_scores: List[SequenceScore],
     txt_file_scores: TxtFileScores,
     output_dir: Path,
+    include_projected_chrf3: bool,
 ) -> None:
     if verse_scores:
         with open(output_dir / "usability_verses.tsv", "w", encoding="utf-8", newline="\n") as verse_file:
-            verse_file.write("Book\tChapter\tVerse\tProjected chrF3\tLabel\n")
+            write_row(verse_file, ["Book", "Chapter", "Verse", "Confidence"] + chrf3_headers(include_projected_chrf3))
             for verse_score in verse_scores:
                 vref = verse_score.vref
                 if vref.verse_num == 0:
                     continue
-                if verse_score.projected_chrf3 is None:
+                if include_projected_chrf3 and verse_score.projected_chrf3 is None:
                     LOGGER.warning(f"{vref} does not have a projected chrf3. Skipping.")
                     continue
 
-                label = Thresholds.return_label(verse_score.projected_chrf3)
-
-                verse_file.write(
-                    f"{vref.book}\t{vref.chapter_num}\t{vref.verse_num}\t{verse_score.projected_chrf3:.2f}\t{label}\n"
+                write_row(
+                    verse_file,
+                    [str(vref.book), str(vref.chapter_num), str(vref.verse_num), f"{verse_score.confidence:.4f}"]
+                    + chrf3_cells(verse_score.projected_chrf3, include_projected_chrf3),
                 )
-        compute_chapter_labels(chapter_scores, output_dir)
-        compute_book_labels(book_scores, output_dir)
+        compute_chapter_labels(chapter_scores, output_dir, include_projected_chrf3)
+        compute_book_labels(book_scores, output_dir, include_projected_chrf3)
     if sequence_scores:
         with open(output_dir / "usability_sequences.tsv", "w", encoding="utf-8", newline="\n") as sequence_file:
-            sequence_file.write("Trg Draft File\tSequence Number\tProjected chrF3\tLabel\n")
+            write_row(
+                sequence_file,
+                ["Trg Draft File", "Sequence Number", "Confidence"] + chrf3_headers(include_projected_chrf3),
+            )
             for sequence_score in sequence_scores:
-                if sequence_score.projected_chrf3 is None:
+                if include_projected_chrf3 and sequence_score.projected_chrf3 is None:
                     LOGGER.warning(f"Sequence {sequence_score.sequence_num} does not have a projected chrf3. Skipping.")
                     continue
 
-                label = Thresholds.return_label(sequence_score.projected_chrf3)
-
-                sequence_file.write(
-                    f"{sequence_score.trg_draft_file_stem}\t{sequence_score.sequence_num}\t"
-                    f"{sequence_score.projected_chrf3:.2f}\t{label}\n"
+                write_row(
+                    sequence_file,
+                    [
+                        sequence_score.trg_draft_file_stem,
+                        str(sequence_score.sequence_num),
+                        f"{sequence_score.confidence:.4f}",
+                    ]
+                    + chrf3_cells(sequence_score.projected_chrf3, include_projected_chrf3),
                 )
-        compute_txt_file_labels(txt_file_scores, output_dir)
+        compute_txt_file_labels(txt_file_scores, output_dir, include_projected_chrf3)
 
 
 def compute_chapter_labels(
     chapter_scores: ChapterScores,
     output_dir: Path,
+    include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_chapters.tsv", "w", encoding="utf-8", newline="\n") as chapter_file:
-        chapter_file.write("Book\tChapter\tProjected chrF3\tLabel\n")
+        write_row(chapter_file, ["Book", "Chapter", "Confidence"] + chrf3_headers(include_projected_chrf3))
         for book in sorted(chapter_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             for chapter in sorted(chapter_scores.scores[book]):
                 score = chapter_scores.scores[book][chapter]
-                label = Thresholds.return_label(score.projected_chrf3)
-                chapter_file.write(f"{book}\t{chapter}\t{score.projected_chrf3:.2f}\t{label}\n")
+                write_row(
+                    chapter_file,
+                    [book, str(chapter), f"{score.confidence:.4f}"]
+                    + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+                )
 
 
 def compute_book_labels(
     book_scores: BookScores,
     output_dir: Path,
+    include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_books.tsv", "w", encoding="utf-8", newline="\n") as book_file:
-        book_file.write("Book\tProjected chrF3\tLabel\n")
+        write_row(book_file, ["Book", "Confidence", "Low Confidence"] + chrf3_headers(include_projected_chrf3))
         for book in sorted(book_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             score = book_scores.scores[book]
-            label = Thresholds.return_label(score.projected_chrf3)
-            book_file.write(f"{book}\t{score.projected_chrf3:.2f}\t{label}\n")
+            low_confidence = is_book_confidence_unusually_low(score.confidence, book_id=book)
+            write_row(
+                book_file,
+                [book, f"{score.confidence:.4f}", str(low_confidence)]
+                + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+            )
 
 
 def compute_txt_file_labels(
     txt_file_scores: TxtFileScores,
     output_dir: Path,
+    include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_txt_files.tsv", "w", encoding="utf-8", newline="\n") as txt_file:
-        txt_file.write("Trg Draft File\tProjected chrF3\tLabel\n")
+        write_row(txt_file, ["Trg Draft File", "Confidence"] + chrf3_headers(include_projected_chrf3))
         for trg_draft_file_stem in sorted(txt_file_scores.scores):
             score = txt_file_scores.scores[trg_draft_file_stem]
-            label = Thresholds.return_label(score.projected_chrf3)
-            txt_file.write(f"{trg_draft_file_stem}\t{score.projected_chrf3:.2f}\t{label}\n")
+            write_row(
+                txt_file,
+                [trg_draft_file_stem, f"{score.confidence:.4f}"]
+                + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+            )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Estimate the quality of drafts created by an NMT model.")
     parser.add_argument(
         "linregress_file",
+        nargs="?",
+        default=None,
         type=str,
         help="Path relative to MT/experiments to a linregress file containing the confidence-to-chrF3 line of best "
         + f"fit produced by the test step, e.g., project_folder/exp_folder/{LINREGRESS_PREFIX}.5000.json (or "
         + f"{LINREGRESS_PREFIX}.eng.fra.5000.json for an experiment with multiple language pairs). "
-        + f"If a directory is provided instead, the first {LINREGRESS_PREFIX}.*.json match is used.",
+        + f"If a directory is provided instead, the first {LINREGRESS_PREFIX}.*.json match is used. "
+        + "Omit this argument (and use --confidence-dir or --experiment-dir) to run without a test set, in which "
+        + "case the usability files report confidence only.",
     )
     parser.add_argument(
         "confidence_files",
@@ -326,8 +393,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.linregress_file is not None and args.linregress_file.endswith(CONFIDENCE_SUFFIX):
+        args.confidence_files.insert(0, args.linregress_file)
+        args.linregress_file = None
+
     environment = SilNlpEnv.create_standard_environment()
-    linregress_path = environment.get_mt_exp_dir(args.linregress_file)
+    linregress_path = environment.get_mt_exp_dir(args.linregress_file) if args.linregress_file is not None else None
 
     using_experiment_dir = args.experiment_dir is not None
     using_files = bool(args.confidence_files)

--- a/silnlp/nmt/quality_estimation.py
+++ b/silnlp/nmt/quality_estimation.py
@@ -239,11 +239,11 @@ class Thresholds:
             return cls.RED_LABEL
 
 
-def chrf3_headers(include_projected_chrf3: bool) -> List[str]:
+def get_chrf3_headers(include_projected_chrf3: bool) -> List[str]:
     return ["Projected chrF3", "Label"] if include_projected_chrf3 else []
 
 
-def chrf3_cells(projected_chrf3: Optional[float], include_projected_chrf3: bool) -> List[str]:
+def get_chrf3_cells(projected_chrf3: Optional[float], include_projected_chrf3: bool) -> List[str]:
     if not include_projected_chrf3:
         return []
     if projected_chrf3 is None:
@@ -266,7 +266,9 @@ def compute_quality_labels(
 ) -> None:
     if verse_scores:
         with open(output_dir / "usability_verses.tsv", "w", encoding="utf-8", newline="\n") as verse_file:
-            write_row(verse_file, ["Book", "Chapter", "Verse", "Confidence"] + chrf3_headers(include_projected_chrf3))
+            write_row(
+                verse_file, ["Book", "Chapter", "Verse", "Confidence"] + get_chrf3_headers(include_projected_chrf3)
+            )
             for verse_score in verse_scores:
                 vref = verse_score.vref
                 if vref.verse_num == 0:
@@ -278,7 +280,7 @@ def compute_quality_labels(
                 write_row(
                     verse_file,
                     [str(vref.book), str(vref.chapter_num), str(vref.verse_num), f"{verse_score.confidence:.4f}"]
-                    + chrf3_cells(verse_score.projected_chrf3, include_projected_chrf3),
+                    + get_chrf3_cells(verse_score.projected_chrf3, include_projected_chrf3),
                 )
         compute_chapter_labels(chapter_scores, output_dir, include_projected_chrf3)
         compute_book_labels(book_scores, output_dir, include_projected_chrf3)
@@ -286,7 +288,7 @@ def compute_quality_labels(
         with open(output_dir / "usability_sequences.tsv", "w", encoding="utf-8", newline="\n") as sequence_file:
             write_row(
                 sequence_file,
-                ["Trg Draft File", "Sequence Number", "Confidence"] + chrf3_headers(include_projected_chrf3),
+                ["Trg Draft File", "Sequence Number", "Confidence"] + get_chrf3_headers(include_projected_chrf3),
             )
             for sequence_score in sequence_scores:
                 if include_projected_chrf3 and sequence_score.projected_chrf3 is None:
@@ -300,7 +302,7 @@ def compute_quality_labels(
                         str(sequence_score.sequence_num),
                         f"{sequence_score.confidence:.4f}",
                     ]
-                    + chrf3_cells(sequence_score.projected_chrf3, include_projected_chrf3),
+                    + get_chrf3_cells(sequence_score.projected_chrf3, include_projected_chrf3),
                 )
         compute_txt_file_labels(txt_file_scores, output_dir, include_projected_chrf3)
 
@@ -311,14 +313,14 @@ def compute_chapter_labels(
     include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_chapters.tsv", "w", encoding="utf-8", newline="\n") as chapter_file:
-        write_row(chapter_file, ["Book", "Chapter", "Confidence"] + chrf3_headers(include_projected_chrf3))
+        write_row(chapter_file, ["Book", "Chapter", "Confidence"] + get_chrf3_headers(include_projected_chrf3))
         for book in sorted(chapter_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             for chapter in sorted(chapter_scores.scores[book]):
                 score = chapter_scores.scores[book][chapter]
                 write_row(
                     chapter_file,
                     [book, str(chapter), f"{score.confidence:.4f}"]
-                    + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+                    + get_chrf3_cells(score.projected_chrf3, include_projected_chrf3),
                 )
 
 
@@ -328,14 +330,14 @@ def compute_book_labels(
     include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_books.tsv", "w", encoding="utf-8", newline="\n") as book_file:
-        write_row(book_file, ["Book", "Confidence", "Low Confidence"] + chrf3_headers(include_projected_chrf3))
+        write_row(book_file, ["Book", "Confidence", "Low Confidence"] + get_chrf3_headers(include_projected_chrf3))
         for book in sorted(book_scores.scores, key=lambda b: CANONICAL_ORDER[b]):
             score = book_scores.scores[book]
             low_confidence = is_book_confidence_unusually_low(score.confidence, book_id=book)
             write_row(
                 book_file,
                 [book, f"{score.confidence:.4f}", str(low_confidence)]
-                + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+                + get_chrf3_cells(score.projected_chrf3, include_projected_chrf3),
             )
 
 
@@ -345,13 +347,13 @@ def compute_txt_file_labels(
     include_projected_chrf3: bool,
 ) -> None:
     with open(output_dir / "usability_txt_files.tsv", "w", encoding="utf-8", newline="\n") as txt_file:
-        write_row(txt_file, ["Trg Draft File", "Confidence"] + chrf3_headers(include_projected_chrf3))
+        write_row(txt_file, ["Trg Draft File", "Confidence"] + get_chrf3_headers(include_projected_chrf3))
         for trg_draft_file_stem in sorted(txt_file_scores.scores):
             score = txt_file_scores.scores[trg_draft_file_stem]
             write_row(
                 txt_file,
                 [trg_draft_file_stem, f"{score.confidence:.4f}"]
-                + chrf3_cells(score.projected_chrf3, include_projected_chrf3),
+                + get_chrf3_cells(score.projected_chrf3, include_projected_chrf3),
             )
 
 

--- a/tests/smoke_tests/experiments/test_train/config.yml
+++ b/tests/smoke_tests/experiments/test_train/config.yml
@@ -23,6 +23,9 @@ data:
     update_trg: false
 eval:
   per_device_eval_batch_size: 4
+  eval_strategy: "no"
+  load_best_model_at_end: false
+  metric_for_best_model: null
 model: facebook/nllb-200-distilled-1.3B
 train:
   gradient_accumulation_steps: 1

--- a/tests/smoke_tests/test_preprocess.py
+++ b/tests/smoke_tests/test_preprocess.py
@@ -22,8 +22,6 @@ EXPECTED_OUTPUTS_DIR = TEST_MT_DIR / "expected_outputs" / EXPERIMENT_NAME
 TOKENIZER_FILE_NAMES = [
     "tokenizer.json",
     "tokenizer_config.json",
-    "special_tokens_map.json",
-    "sentencepiece.bpe.model",
 ]
 
 # The tokenization statistics are written as both a CSV file, which is compared against the

--- a/tests/test_create_onboarding_experiments.py
+++ b/tests/test_create_onboarding_experiments.py
@@ -972,6 +972,7 @@ def test_run_creates_experiments(request_dir: Path, tmp_path: Path, capsys, sele
             {"books": "MAT", "src_project": "NIV11R", "checkpoint": 5000},
             {"books": "MAT", "src_project": "HINCLBSI", "checkpoint": 5000},
         ],
+        "quality_estimation": True,
         "postprocess": [{"paragraph_behavior": "place"}],
     }
 

--- a/tests/unit_tests/test_linear_regression.py
+++ b/tests/unit_tests/test_linear_regression.py
@@ -1,0 +1,7 @@
+from silnlp.common.linear_regression import LinearRegressionResult
+
+
+def test_project_chrf3() -> None:
+    result = LinearRegressionResult(version="0.1", slope=50.0, intercept=20.0)
+
+    assert result.project_chrf3(0.8) == 60.0

--- a/tests/unit_tests/test_quality_estimation.py
+++ b/tests/unit_tests/test_quality_estimation.py
@@ -57,7 +57,6 @@ def test_books_report_confidence_and_low_confidence_flag(tmp_path: Path) -> None
 
     header, *rows = read_rows(tmp_path / "usability_books.tsv")
     assert header == ["Book", "Confidence", "Low Confidence", "Projected chrF3", "Label"]
-    # 50.0 * 0.8 + 20.0 = 60.0 (Green); 50.0 * 0.3 + 20.0 = 35.0 (Red)
     assert rows == [
         ["MAT", "0.8000", "False", "60.00", "Green"],
         ["MRK", "0.3000", "True", "35.00", "Red"],

--- a/tests/unit_tests/test_quality_estimation.py
+++ b/tests/unit_tests/test_quality_estimation.py
@@ -1,110 +1,81 @@
 import logging
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 import pytest
 
-from silnlp.nmt.quality_estimation import NO_LINREGRESS_WARNING, estimate_quality
-
-LOW_BOOK_CONFIDENCE = 0.3
-HIGH_BOOK_CONFIDENCE = 0.8
+from silnlp.nmt.quality_estimation import BookScores, Score, compute_book_labels, get_chrf3_cells, validate_inputs
 
 
-def write_tsv(path: Path, header: str, rows: Dict[str, float]) -> None:
-    with path.open("w", encoding="utf-8", newline="\n") as f:
-        f.write(f"{header}\tConfidence\n")
-        for key, confidence in rows.items():
-            f.write(f"{key}\t{confidence}\n")
+def touch_confidence_file(directory: Path, name: str = "41MAT.SFM.confidences.tsv") -> List[Path]:
+    confidence_file_path = directory / name
+    confidence_file_path.touch()
+    return [confidence_file_path]
 
 
-def make_confidence_files(directory: Path) -> List[Path]:
-    confidence_file_paths: List[Path] = []
-    for book, confidence in (("MAT", HIGH_BOOK_CONFIDENCE), ("MRK", LOW_BOOK_CONFIDENCE)):
-        confidence_file_path = directory / f"41{book}.SFM.confidences.tsv"
-        confidence_file_path.touch()
-        write_tsv(
-            confidence_file_path.with_suffix(".verses.tsv"),
-            "VRef",
-            {f"{book} 1:1": confidence, f"{book} 1:2": confidence},
-        )
-        write_tsv(confidence_file_path.with_suffix(".chapters.tsv"), "Chapter", {"1": confidence})
-        confidence_file_paths.append(confidence_file_path)
-
-    write_tsv(
-        directory / "confidences.books.tsv",
-        "Book",
-        {"MAT": HIGH_BOOK_CONFIDENCE, "MRK": LOW_BOOK_CONFIDENCE},
-    )
-    return confidence_file_paths
+def test_get_chrf3_cells_when_projected_chrf3_not_included() -> None:
+    assert get_chrf3_cells(60.0, False) == []
 
 
-def write_linregress_file(path: Path) -> None:
-    path.write_text('{"version": "0.1", "slope": 50.0, "intercept": 20.0}', encoding="utf-8")
+def test_get_chrf3_cells_when_projected_chrf3_is_none() -> None:
+    assert get_chrf3_cells(None, True) == ["", ""]
 
 
-def read_rows(path: Path) -> List[List[str]]:
-    return [line.split("\t") for line in path.read_text(encoding="utf-8").splitlines()]
+def test_get_chrf3_cells_when_projected_chrf3_is_included() -> None:
+    assert get_chrf3_cells(100.0, True) == ["100.00", "Green"]
 
 
-def test_books_report_confidence_and_low_confidence_flag(tmp_path: Path) -> None:
-    confidence_file_paths = make_confidence_files(tmp_path)
-    linregress_path = tmp_path / "linregress.5000.json"
-    write_linregress_file(linregress_path)
-
-    estimate_quality(linregress_path, confidence_file_paths)
-
-    header, *rows = read_rows(tmp_path / "usability_books.tsv")
-    assert header == ["Book", "Confidence", "Low Confidence", "Projected chrF3", "Label"]
-    assert rows == [
-        ["MAT", "0.8000", "False", "60.00", "Green"],
-        ["MRK", "0.3000", "True", "35.00", "Red"],
-    ]
-
-    assert read_rows(tmp_path / "usability_chapters.tsv")[0] == [
-        "Book",
-        "Chapter",
-        "Confidence",
-        "Projected chrF3",
-        "Label",
-    ]
-    assert read_rows(tmp_path / "usability_verses.tsv")[0] == [
-        "Book",
-        "Chapter",
-        "Verse",
-        "Confidence",
-        "Projected chrF3",
-        "Label",
-    ]
-
-
-@pytest.mark.parametrize("pass_directory_without_linregress", [False, True])
-def test_no_linregress_file_reports_confidence_only(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture, pass_directory_without_linregress: bool
-) -> None:
-    confidence_file_paths = make_confidence_files(tmp_path)
-    linregress_path = tmp_path if pass_directory_without_linregress else None
+def test_validate_inputs_with_no_linregress_path(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    confidence_file_paths = touch_confidence_file(tmp_path)
 
     with caplog.at_level(logging.WARNING):
-        estimate_quality(linregress_path, confidence_file_paths)
+        linear_regression_result, confidence_files = validate_inputs(None, confidence_file_paths)
 
-    assert any(NO_LINREGRESS_WARNING in record.message for record in caplog.records)
-
-    header, *rows = read_rows(tmp_path / "usability_books.tsv")
-    assert header == ["Book", "Confidence", "Low Confidence"]
-    assert rows == [["MAT", "0.8000", "False"], ["MRK", "0.3000", "True"]]
-
-    assert read_rows(tmp_path / "usability_chapters.tsv")[0] == ["Book", "Chapter", "Confidence"]
-    assert read_rows(tmp_path / "usability_verses.tsv") == [
-        ["Book", "Chapter", "Verse", "Confidence"],
-        ["MAT", "1", "1", "0.8000"],
-        ["MAT", "1", "2", "0.8000"],
-        ["MRK", "1", "1", "0.3000"],
-        ["MRK", "1", "2", "0.3000"],
-    ]
+    assert linear_regression_result is None
+    assert len(confidence_files) == 1
 
 
-def test_explicitly_named_missing_linregress_file_still_raises(tmp_path: Path) -> None:
-    confidence_file_paths = make_confidence_files(tmp_path)
+def test_validate_inputs_with_directory_missing_linregress_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    confidence_file_paths = touch_confidence_file(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        linear_regression_result, confidence_files = validate_inputs(tmp_path, confidence_file_paths)
+
+    assert linear_regression_result is None
+    assert len(confidence_files) == 1
+
+
+def test_validate_inputs_with_explicit_missing_linregress_path(tmp_path: Path) -> None:
+    confidence_file_paths = touch_confidence_file(tmp_path)
 
     with pytest.raises(FileNotFoundError):
-        estimate_quality(tmp_path / "linregress.5000.json", confidence_file_paths)
+        validate_inputs(tmp_path / "linregress.5000.json", confidence_file_paths)
+
+
+def test_compute_book_labels_with_projected_chrf3_not_included(tmp_path: Path) -> None:
+    book_scores = BookScores()
+    book_scores.add_score("MAT", Score(confidence=0.8, projected_chrf3=None))
+    book_scores.add_score("COL", Score(confidence=0.3, projected_chrf3=None))
+
+    compute_book_labels(book_scores, tmp_path, include_projected_chrf3=False)
+
+    rows = [line.split("\t") for line in (tmp_path / "usability_books.tsv").read_text(encoding="utf-8").splitlines()]
+    assert rows[0] == ["Book", "Confidence", "Low Confidence"]
+    assert rows[1:] == [["MAT", "0.8000", "False"], ["COL", "0.3000", "True"]]
+
+
+def test_compute_book_labels_with_projected_chrf3_included(tmp_path: Path) -> None:
+    book_scores = BookScores()
+    book_scores.add_score("MAT", Score(confidence=0.8, projected_chrf3=60.0))
+    book_scores.add_score("COL", Score(confidence=0.3, projected_chrf3=30.0))
+
+    compute_book_labels(book_scores, tmp_path, include_projected_chrf3=True)
+
+    rows = [line.split("\t") for line in (tmp_path / "usability_books.tsv").read_text(encoding="utf-8").splitlines()]
+    assert rows[0] == ["Book", "Confidence", "Low Confidence", "Projected chrF3", "Label"]
+    assert rows[1:] == [
+        ["MAT", "0.8000", "False", "60.00", "Green"],
+        ["COL", "0.3000", "True", "30.00", "Red"],
+    ]

--- a/tests/unit_tests/test_quality_estimation.py
+++ b/tests/unit_tests/test_quality_estimation.py
@@ -1,0 +1,113 @@
+import logging
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from silnlp.nmt.quality_estimation import NO_LINREGRESS_WARNING, estimate_quality
+
+LOW_BOOK_CONFIDENCE = 0.3
+HIGH_BOOK_CONFIDENCE = 0.8
+
+
+def write_tsv(path: Path, header: str, rows: Dict[str, float]) -> None:
+    with path.open("w", encoding="utf-8", newline="\n") as f:
+        f.write(f"{header}\tConfidence\n")
+        for key, confidence in rows.items():
+            f.write(f"{key}\t{confidence}\n")
+
+
+def make_confidence_files(directory: Path) -> List[Path]:
+    """Write the confidence files the translate step produces for two drafted books."""
+    confidence_file_paths: List[Path] = []
+    for book, confidence in (("MAT", HIGH_BOOK_CONFIDENCE), ("MRK", LOW_BOOK_CONFIDENCE)):
+        confidence_file_path = directory / f"41{book}.SFM.confidences.tsv"
+        # Quality estimation only checks that this file exists; it reads the siblings below.
+        confidence_file_path.touch()
+        write_tsv(
+            confidence_file_path.with_suffix(".verses.tsv"),
+            "VRef",
+            {f"{book} 1:1": confidence, f"{book} 1:2": confidence},
+        )
+        write_tsv(confidence_file_path.with_suffix(".chapters.tsv"), "Chapter", {"1": confidence})
+        confidence_file_paths.append(confidence_file_path)
+
+    write_tsv(
+        directory / "confidences.books.tsv",
+        "Book",
+        {"MAT": HIGH_BOOK_CONFIDENCE, "MRK": LOW_BOOK_CONFIDENCE},
+    )
+    return confidence_file_paths
+
+
+def write_linregress_file(path: Path) -> None:
+    path.write_text('{"version": "0.1", "slope": 50.0, "intercept": 20.0}', encoding="utf-8")
+
+
+def read_rows(path: Path) -> List[List[str]]:
+    return [line.split("\t") for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_books_report_confidence_and_low_confidence_flag(tmp_path: Path) -> None:
+    confidence_file_paths = make_confidence_files(tmp_path)
+    linregress_path = tmp_path / "linregress.5000.json"
+    write_linregress_file(linregress_path)
+
+    estimate_quality(linregress_path, confidence_file_paths)
+
+    header, *rows = read_rows(tmp_path / "usability_books.tsv")
+    assert header == ["Book", "Confidence", "Low Confidence", "Projected chrF3", "Label"]
+    # 50.0 * 0.8 + 20.0 = 60.0 (Green); 50.0 * 0.3 + 20.0 = 35.0 (Red)
+    assert rows == [
+        ["MAT", "0.8000", "False", "60.00", "Green"],
+        ["MRK", "0.3000", "True", "35.00", "Red"],
+    ]
+
+    assert read_rows(tmp_path / "usability_chapters.tsv")[0] == [
+        "Book",
+        "Chapter",
+        "Confidence",
+        "Projected chrF3",
+        "Label",
+    ]
+    assert read_rows(tmp_path / "usability_verses.tsv")[0] == [
+        "Book",
+        "Chapter",
+        "Verse",
+        "Confidence",
+        "Projected chrF3",
+        "Label",
+    ]
+
+
+@pytest.mark.parametrize("pass_directory_without_linregress", [False, True])
+def test_no_linregress_file_reports_confidence_only(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, pass_directory_without_linregress: bool
+) -> None:
+    confidence_file_paths = make_confidence_files(tmp_path)
+    linregress_path = tmp_path if pass_directory_without_linregress else None
+
+    with caplog.at_level(logging.WARNING):
+        estimate_quality(linregress_path, confidence_file_paths)
+
+    assert any(NO_LINREGRESS_WARNING in record.message for record in caplog.records)
+
+    header, *rows = read_rows(tmp_path / "usability_books.tsv")
+    assert header == ["Book", "Confidence", "Low Confidence"]
+    assert rows == [["MAT", "0.8000", "False"], ["MRK", "0.3000", "True"]]
+
+    assert read_rows(tmp_path / "usability_chapters.tsv")[0] == ["Book", "Chapter", "Confidence"]
+    assert read_rows(tmp_path / "usability_verses.tsv") == [
+        ["Book", "Chapter", "Verse", "Confidence"],
+        ["MAT", "1", "1", "0.8000"],
+        ["MAT", "1", "2", "0.8000"],
+        ["MRK", "1", "1", "0.3000"],
+        ["MRK", "1", "2", "0.3000"],
+    ]
+
+
+def test_explicitly_named_missing_linregress_file_still_raises(tmp_path: Path) -> None:
+    confidence_file_paths = make_confidence_files(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        estimate_quality(tmp_path / "linregress.5000.json", confidence_file_paths)

--- a/tests/unit_tests/test_quality_estimation.py
+++ b/tests/unit_tests/test_quality_estimation.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 from typing import List
 
@@ -25,23 +24,19 @@ def test_get_chrf3_cells_when_projected_chrf3_is_included() -> None:
     assert get_chrf3_cells(100.0, True) == ["100.00", "Green"]
 
 
-def test_validate_inputs_with_no_linregress_path(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_validate_inputs_with_no_linregress_path(tmp_path: Path) -> None:
     confidence_file_paths = touch_confidence_file(tmp_path)
 
-    with caplog.at_level(logging.WARNING):
-        linear_regression_result, confidence_files = validate_inputs(None, confidence_file_paths)
+    linear_regression_result, confidence_files = validate_inputs(None, confidence_file_paths)
 
     assert linear_regression_result is None
     assert len(confidence_files) == 1
 
 
-def test_validate_inputs_with_directory_missing_linregress_file(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_validate_inputs_with_directory_missing_linregress_file(tmp_path: Path) -> None:
     confidence_file_paths = touch_confidence_file(tmp_path)
 
-    with caplog.at_level(logging.WARNING):
-        linear_regression_result, confidence_files = validate_inputs(tmp_path, confidence_file_paths)
+    linear_regression_result, confidence_files = validate_inputs(tmp_path, confidence_file_paths)
 
     assert linear_regression_result is None
     assert len(confidence_files) == 1

--- a/tests/unit_tests/test_quality_estimation.py
+++ b/tests/unit_tests/test_quality_estimation.py
@@ -18,11 +18,9 @@ def write_tsv(path: Path, header: str, rows: Dict[str, float]) -> None:
 
 
 def make_confidence_files(directory: Path) -> List[Path]:
-    """Write the confidence files the translate step produces for two drafted books."""
     confidence_file_paths: List[Path] = []
     for book, confidence in (("MAT", HIGH_BOOK_CONFIDENCE), ("MRK", LOW_BOOK_CONFIDENCE)):
         confidence_file_path = directory / f"41{book}.SFM.confidences.tsv"
-        # Quality estimation only checks that this file exists; it reads the siblings below.
         confidence_file_path.touch()
         write_tsv(
             confidence_file_path.with_suffix(".verses.tsv"),


### PR DESCRIPTION
This PR adds support for silnlp to use machine.py's `is_book_confidence_unusually_low` method to flag low confidence in `usability_books.tsv`. Quality estimation now no longer requires a linear regression file; if it's not provided, it will output only the confidence information and skip providing a projected chrf3 or label. Methods also now use the `LinearRegressionResult` object rather than pass slope and intercept individually. Unit tests for quality estimation have been added to the unit test folder.

There are also some miscellaneous changes to fix a few unrelated failing tests and to simplify running experiments in the devcontainer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1147)
<!-- Reviewable:end -->
