### PR TITLE
Add a remote LLM model and config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -181,6 +181,17 @@ files = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0"},
+    {file = "annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"},
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.2"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
@@ -829,6 +840,17 @@ files = [
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "eflomal"
 version = "2.0.0"
 description = "pip installable eflomal"
@@ -919,6 +941,93 @@ files = [
 
 [package.extras]
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+description = "Python bindings to Rust's UUID library."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a"},
+    {file = "fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00"},
+    {file = "fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470"},
+    {file = "fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d"},
+    {file = "fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8"},
+    {file = "fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219"},
+    {file = "fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6"},
+    {file = "fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe"},
+    {file = "fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d"},
+    {file = "fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a"},
+    {file = "fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4"},
+    {file = "fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34"},
+    {file = "fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7"},
+    {file = "fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1"},
+    {file = "fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc"},
+    {file = "fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8"},
+    {file = "fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7"},
+    {file = "fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73"},
+    {file = "fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36"},
+    {file = "fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94"},
+    {file = "fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24"},
+    {file = "fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa"},
+    {file = "fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a"},
+    {file = "fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d"},
+    {file = "fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070"},
+    {file = "fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796"},
+    {file = "fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09"},
+    {file = "fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8"},
+    {file = "fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741"},
+    {file = "fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057"},
+    {file = "fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8"},
+    {file = "fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176"},
+    {file = "fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397"},
+    {file = "fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021"},
+    {file = "fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc"},
+    {file = "fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5"},
+    {file = "fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f"},
+    {file = "fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87"},
+    {file = "fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b"},
+    {file = "fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022"},
+    {file = "fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995"},
+    {file = "fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab"},
+    {file = "fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad"},
+    {file = "fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed"},
+    {file = "fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad"},
+    {file = "fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b"},
+    {file = "fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714"},
+    {file = "fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f"},
+    {file = "fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f"},
+    {file = "fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75"},
+    {file = "fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4"},
+    {file = "fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad"},
+    {file = "fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8"},
+    {file = "fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06"},
+    {file = "fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a"},
+    {file = "fastuuid-0.14.0-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:47c821f2dfe95909ead0085d4cb18d5149bca704a2b03e03fb3f81a5202d8cea"},
+    {file = "fastuuid-0.14.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:3964bab460c528692c70ab6b2e469dd7a7b152fbe8c18616c58d34c93a6cf8d4"},
+    {file = "fastuuid-0.14.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c501561e025b7aea3508719c5801c360c711d5218fc4ad5d77bf1c37c1a75779"},
+    {file = "fastuuid-0.14.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dce5d0756f046fa792a40763f36accd7e466525c5710d2195a038f93ff96346"},
+    {file = "fastuuid-0.14.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193ca10ff553cf3cc461572da83b5780fc0e3eea28659c16f89ae5202f3958d4"},
+    {file = "fastuuid-0.14.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0737606764b29785566f968bd8005eace73d3666bd0862f33a760796e26d1ede"},
+    {file = "fastuuid-0.14.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e0976c0dff7e222513d206e06341503f07423aceb1db0b83ff6851c008ceee06"},
+    {file = "fastuuid-0.14.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6fbc49a86173e7f074b1a9ec8cf12ca0d54d8070a85a06ebf0e76c309b84f0d0"},
+    {file = "fastuuid-0.14.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:de01280eabcd82f7542828ecd67ebf1551d37203ecdfd7ab1f2e534edb78d505"},
+    {file = "fastuuid-0.14.0-cp38-cp38-win32.whl", hash = "sha256:af5967c666b7d6a377098849b07f83462c4fedbafcf8eb8bc8ff05dcbe8aa209"},
+    {file = "fastuuid-0.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:c3091e63acf42f56a6f74dc65cfdb6f99bfc79b5913c8a9ac498eb7ca09770a8"},
+    {file = "fastuuid-0.14.0-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2ec3d94e13712a133137b2805073b65ecef4a47217d5bac15d8ac62376cefdb4"},
+    {file = "fastuuid-0.14.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:139d7ff12bb400b4a0c76be64c28cbe2e2edf60b09826cbfd85f33ed3d0bbe8b"},
+    {file = "fastuuid-0.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d55b7e96531216fc4f071909e33e35e5bfa47962ae67d9e84b00a04d6e8b7173"},
+    {file = "fastuuid-0.14.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0eb25f0fd935e376ac4334927a59e7c823b36062080e2e13acbaf2af15db836"},
+    {file = "fastuuid-0.14.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:089c18018fdbdda88a6dafd7d139f8703a1e7c799618e33ea25eb52503d28a11"},
+    {file = "fastuuid-0.14.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fc37479517d4d70c08696960fad85494a8a7a0af4e93e9a00af04d74c59f9e3"},
+    {file = "fastuuid-0.14.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:73657c9f778aba530bc96a943d30e1a7c80edb8278df77894fe9457540df4f85"},
+    {file = "fastuuid-0.14.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d31f8c257046b5617fc6af9c69be066d2412bdef1edaa4bdf6a214cf57806105"},
+    {file = "fastuuid-0.14.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5816d41f81782b209843e52fdef757a361b448d782452d96abedc53d545da722"},
+    {file = "fastuuid-0.14.0-cp39-cp39-win32.whl", hash = "sha256:448aa6833f7a84bfe37dd47e33df83250f404d591eb83527fa2cac8d1e57d7f3"},
+    {file = "fastuuid-0.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:84b0779c5abbdec2a9511d5ffbfcd2e53079bf889824b32be170c0d8ef5fc74c"},
+    {file = "fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26"},
+]
 
 [[package]]
 name = "filelock"
@@ -1330,6 +1439,29 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.1"
+description = "Read metadata from Python packages"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "importlib_metadata-9.0.1-py3-none-any.whl", hash = "sha256:bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0"},
+    {file = "importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99"},
+]
+
+[package.dependencies]
+zipp = ">=3.20"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+perf = ["ipython"]
+test = ["packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.17)"]
+type = ["pytest-mypy (>=1.0.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1485,6 +1617,120 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+description = "Fast iterable JSON parser."
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c"},
+    {file = "jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244"},
+    {file = "jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131"},
+    {file = "jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b"},
+    {file = "jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9"},
+    {file = "jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3"},
+    {file = "jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03"},
+    {file = "jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91"},
+    {file = "jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3"},
+    {file = "jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7"},
+    {file = "jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1"},
+    {file = "jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f"},
+    {file = "jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274"},
+    {file = "jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7"},
+    {file = "jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84"},
+    {file = "jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e"},
+    {file = "jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd"},
+    {file = "jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00"},
+    {file = "jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe"},
+    {file = "jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106"},
+    {file = "jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8"},
+    {file = "jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585"},
+    {file = "jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734"},
+    {file = "jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d8f80521644426d451e70f00c7974240cab8f6ee088aedaa9af2697153ab7805"},
+    {file = "jiter-0.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3b21b412b899fd8bd51a3046934b59a3bb068b79f70a5c6010053ac77cc53f0c"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0758ab7747a984797cf048e8eedea1d8ef39d7994b25611daf5b48fc903e8873"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ec553a99b0987efd7a3645a1a825cf29c224e494db267a83369fcc8da9aeda5"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3bd327cdfa118bc1ce69c214c2678571d5bd39b8ccd0ebf43a54db00541ba9a"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26d122613ada2b708eb714695446f40fce5bdf2edb4b02116dec62faa62dfab3"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e03a5f21a5ce96a9441b8cb32719a8b88ed5388f53e0f339c5bcf54f1317f9d0"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:a5c54ef4ff776d9675837ef535b3308d6e31c208d43ebc44a0f7ab8a208c68f7"},
+    {file = "jiter-0.16.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b1e7923093a376d93c6eb507c77045ae258d689ba577392846a1b3f10d0b09a9"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2a0d46ef67cc58d906a6132dd3040ca70ae4f0b0d7c9c052fe432c658a69b3f6"},
+    {file = "jiter-0.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:70a490b55634dc0d2606ce8a8e01b1d62459011beb368d15d76e1eaf62460e3d"},
+    {file = "jiter-0.16.0-cp39-cp39-win32.whl", hash = "sha256:9acf1b2faec82d998811ecce7ae84d9005e53410773e9d37d61cdc424ba4581b"},
+    {file = "jiter-0.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:491e7d072a253b156fff46b78bceac4652a697aa8d7082c9c18c03d7b7917d24"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5"},
+    {file = "jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702"},
+    {file = "jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2"},
+    {file = "jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c"},
+]
 
 [[package]]
 name = "jmespath"
@@ -1859,6 +2105,41 @@ files = [
 
 [package.dependencies]
 rapidfuzz = ">=3.9.0,<4.0.0"
+
+[[package]]
+name = "litellm"
+version = "1.83.0"
+description = "Library to easily interface with LLM API providers"
+optional = true
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8"},
+    {file = "litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.10"
+click = "*"
+fastuuid = ">=0.13.0"
+httpx = ">=0.23.0"
+importlib-metadata = ">=6.8.0"
+jinja2 = ">=3.1.2,<4.0.0"
+jsonschema = ">=4.23.0,<5.0.0"
+openai = ">=2.8.0"
+pydantic = ">=2.5.0,<3.0.0"
+python-dotenv = ">=0.2.0"
+tiktoken = ">=0.7.0"
+tokenizers = "*"
+
+[package.extras]
+caching = ["diskcache (>=5.6.1,<6.0.0)"]
+extra-proxy = ["a2a-sdk (>=0.3.22,<0.4.0)", "azure-identity (>=1.15.0,<2.0.0)", "azure-keyvault-secrets (>=4.8.0,<5.0.0)", "google-cloud-iam (>=2.19.1,<3.0.0)", "google-cloud-kms (>=2.21.3,<3.0.0)", "prisma (>=0.11.0,<0.12.0)", "redisvl (>=0.4.1,<0.5.0)", "resend (>=0.8.0)"]
+google = ["google-cloud-aiplatform (>=1.38.0)"]
+grpc = ["grpcio (>=1.62.3,<1.68.dev0 || >1.71.0,!=1.71.1,!=1.72.0,!=1.72.1,!=1.73.0)", "grpcio (>=1.75.0)"]
+mlflow = ["mlflow (>3.1.4)"]
+proxy = ["PyJWT (>=2.12.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "azure-identity (>=1.15.0,<2.0.0)", "azure-storage-blob (>=12.25.1,<13.0.0)", "backoff", "boto3 (>=1.40.76,<2.0.0)", "cryptography", "fastapi (>=0.120.1)", "fastapi-sso (>=0.16.0,<0.17.0)", "gunicorn (>=23.0.0,<24.0.0)", "litellm-enterprise (==0.1.35)", "litellm-proxy-extras (>=0.4.62,<0.5.0)", "mcp (>=1.25.0,<2.0.0)", "orjson (>=3.9.7,<4.0.0)", "polars (>=1.31.0,<2.0.0)", "pynacl (>=1.5.0,<2.0.0)", "pyroscope-io (>=0.8,<0.9)", "python-multipart (>=0.0.20)", "pyyaml (>=6.0.1,<7.0.0)", "rich (>=13.7.1,<14.0.0)", "rq", "soundfile (>=0.12.1,<0.13.0)", "uvicorn (>=0.32.1,<1.0.0)", "uvloop (>=0.21.0,<0.22.0)", "websockets (>=15.0.1,<16.0.0)"]
+semantic-router = ["semantic-router (>=0.1.12)"]
+utils = ["numpydoc"]
 
 [[package]]
 name = "lxml"
@@ -2705,6 +2986,33 @@ files = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.28.0"
+description = "The official Python library for the openai API"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "openai-2.28.0-py3-none-any.whl", hash = "sha256:79aa5c45dba7fef84085701c235cf13ba88485e1ef4f8dfcedc44fc2a698fc1d"},
+    {file = "openai-2.28.0.tar.gz", hash = "sha256:bb7fdff384d2a787fa82e8822d1dd3c02e8cf901d60f1df523b7da03cbb6d48d"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.10.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<16)"]
+voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
@@ -3313,6 +3621,138 @@ files = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.11.10"
+description = "Data validation using Python type hints"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a"},
+    {file = "pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423"},
+]
+
+[package.dependencies]
+annotated-types = ">=0.6.0"
+pydantic-core = "2.33.2"
+typing-extensions = ">=4.12.2"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+email = ["email-validator (>=2.0.0)"]
+timezone = ["tzdata"]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+description = "Core functionality for Pydantic validation and serialization"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22"},
+    {file = "pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab"},
+    {file = "pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9"},
+    {file = "pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5"},
+    {file = "pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9"},
+    {file = "pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c"},
+    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb"},
+    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039"},
+    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27"},
+    {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
@@ -3691,6 +4131,23 @@ files = [
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+
+[[package]]
+name = "rank-bm25"
+version = "0.2.2"
+description = "Various BM25 algorithms for document ranking"
+optional = true
+python-versions = "*"
+files = [
+    {file = "rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae"},
+    {file = "rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+dev = ["pytest"]
 
 [[package]]
 name = "rapidfuzz"
@@ -4473,6 +4930,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -4543,6 +5011,86 @@ files = [
     {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
     {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
 ]
+
+[[package]]
+name = "tiktoken"
+version = "0.14.0"
+description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "tiktoken-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3b12e54f8bec91433e41aff65d8d1f209a4f678081163747079806e5361f6c91"},
+    {file = "tiktoken-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:94f77b60a8ab23580db19ae822744c9716c1720020d2179ca5605112d12326f1"},
+    {file = "tiktoken-0.14.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f3d6cf93fbe2e7117eb7bedca684216fbe328a41f0843ce34245451d8eb2df1c"},
+    {file = "tiktoken-0.14.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:18a1b651c4b032004bf7b4f1713391a54b2a341a52c6e8a2b59acae9d16e13c7"},
+    {file = "tiktoken-0.14.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4d8d91d68353bd167fdf26467e5ff9e56aaa5f87d6410c0238608629e4dc0d33"},
+    {file = "tiktoken-0.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:10f31e63e40313f2e518d87f7086cfa44e45f64cc14d8ae14103b41220c30a14"},
+    {file = "tiktoken-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:c6cb9896a82b9ee44e15ba0b5c8044072f2e4d48acaa704c8d3feeef5ad9487c"},
+    {file = "tiktoken-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c2edf09b381fafbc014ae8e018ed25087abb9a3dafa8465a0ea63c6558c47a79"},
+    {file = "tiktoken-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cd8ca1305c1c902fe42c486165f2e4808d9997625c98ffb05b9e0366d99d3948"},
+    {file = "tiktoken-0.14.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1f83081065ee5833d35b49e9180f3d8d15622a603dd1c435da0da6cc12b3662f"},
+    {file = "tiktoken-0.14.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f5e7665f6624e052e5e7f6a36919ab69279decdc976d7b16b4fa15e1897d0513"},
+    {file = "tiktoken-0.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:144a3fc369f92b7d548995217c5d6e84038d3572157a0f6f34080d65291d0f78"},
+    {file = "tiktoken-0.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:151d37a150c8f3dfc5f4345597b10e101876bd1bd13494e0185af6b508758d2e"},
+    {file = "tiktoken-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:c77d4a3e1deb2707819df92046b89aad1ac81d27e07616b797cbff3f62c037da"},
+    {file = "tiktoken-0.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8e947aefe98ef74cce94923f90e48c98fe34eb1ec0a6bfdfadfc5a96359bfc36"},
+    {file = "tiktoken-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d6cebe67765569df3dafac8474e4eccf5c19d24140492567a5e58a11445732a4"},
+    {file = "tiktoken-0.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7db45b98e94adf4173a5cd7422b150999a7ee11ff847783a14f6e1b80cc38cb6"},
+    {file = "tiktoken-0.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7896eea257fe497a2b7134474d909156c6744ce8da35bce88011a960e008aa0d"},
+    {file = "tiktoken-0.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b950248272f1b303dc32986396e2dccfa10cf6d1e83ec8f0bba1776660305482"},
+    {file = "tiktoken-0.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3de75343041a1c57333b1e707ac8a9769738241d7d6a55d39e12cf84548337c6"},
+    {file = "tiktoken-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:087538c080e5ff421abd3a0785ed63c5111d06af98e6cd0d374dbe5969147ca3"},
+    {file = "tiktoken-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9c5fe393aab56469f04e432ff851216d3def3436cf5f07e442a240164bf500f"},
+    {file = "tiktoken-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cbe2cc3bba939bcdaf103e03df9d5039d33887080b315624be28ec69059e5f94"},
+    {file = "tiktoken-0.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2157f52e4b4d7ac5ecc7457b3716834706e7ef9a46f5144029bfeb7cf71f4e06"},
+    {file = "tiktoken-0.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:26e60f6a956ee171ab728b37b8439905d7ea1db435c30f9822f291e9861c861d"},
+    {file = "tiktoken-0.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:380873f330b741c4435574f37edb20813d04603ace2d53e0a63560e1fec83010"},
+    {file = "tiktoken-0.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3fd7c14b1cb45b486c39fc9b3443bb341f3e2fc7e6f31247f3435a5836651632"},
+    {file = "tiktoken-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:90a762670c7f968184723769a06ed51f5cf5ce5dcd1e30164f25c72d85c2d1f1"},
+    {file = "tiktoken-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e067f4cbcc5d036e8aff7fe7a6b530a8f4de2e4616ad9005a24a1879e24e6450"},
+    {file = "tiktoken-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f2af4a336ea56d6c14f27741a0e1d8294a35dd0b038bcf990d232ebb54eb994b"},
+    {file = "tiktoken-0.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f702e0aeeb6506e57687e881c59e844ebe8f0a6a097ddafe20e3ab25f387be4e"},
+    {file = "tiktoken-0.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e3442bbb2f0c588cec876061e37ae67b455b9df9978b003c8fe30e45f2ef5b42"},
+    {file = "tiktoken-0.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:979c1524f753b662b0f3cd261b135afe6659cce33caaa7a5ea00dd1756b3055c"},
+    {file = "tiktoken-0.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2cc19ac87b41c9493c9778ff5847f0c8bbcf5bd0ec6b87ce06c1c802adc8a771"},
+    {file = "tiktoken-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:eceeff0c62419bc78d4b6e70a4762a4d25df3ae8f2d5946e3853ce93e7a57098"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6eb94895c45f26bb8f5546e5fd8a069efcf6e3f108ea9d5cbe3bf6f7f3983438"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:86951a971c53979ec857bd8c4a32dc227ab0fd33f6c12a3bd62d3fbf5f0bfcaa"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2eca764c53490f8930dbce329e0769f11108d87d908282a80c5c130e26e7037"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:26cc4b4840fa0e9f4b72ed489883e12f57e00d1021ca794720e3c29a12f0edef"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2fc834fbe3f6a0736905c36ab709537e6840dbd63b982dc9e0216ae7d305ba1a"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ca4db6ff5c5bf600f9b7761a0070ed44dfe5797a76bd432fb978bc480ef40c58"},
+    {file = "tiktoken-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7aab286a020660a039097912a088236b985d18a3090d73f136c4413d29d37ca0"},
+    {file = "tiktoken-0.14.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:14b47e3674f2624803a8acc8fb367b7e24fc53055f9df3296482fe9a3a34a232"},
+    {file = "tiktoken-0.14.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:19d643d701fdaa70e5b9c7f8f96abcaffe77ca5e482a3a1a7dde46feb4284695"},
+    {file = "tiktoken-0.14.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:e4ddf863b59347deaa92302dcd90e5eb003cdc9be06ec2b692c38d1bdd9efd49"},
+    {file = "tiktoken-0.14.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:60c47ca69ddda0dea8256fffd12e1b86f4b59734a20e4a70c61f63cc5f021df4"},
+    {file = "tiktoken-0.14.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:728303a072163130c5b477b1f20d6211895569c1d5302c24ffc93a3009160871"},
+    {file = "tiktoken-0.14.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3c5349c9f916283bba32bec8af69b763e4faa304dc004d0eaaea66a3cf004c1f"},
+    {file = "tiktoken-0.14.0-cp315-cp315-win_amd64.whl", hash = "sha256:1b6e4adcfd285c44502aed51df98aaaca4f0fea028165dbf8a9e857b9f98d8ea"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:11d8211b290855d2721334ff17dd9b3a17bfb26872be01f25d73612ef7ece890"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:d0781223705199b289faa59601bb9c2441712d4c600dd13c43d8fd6a33d22cd5"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:2ea70afba6b9eddbf22c165142e5f0a2ad7aa36a452873c48b57bb2aeb8492ae"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:78571efc311c30b73f31eb949a921d6dac39a5d9dc42d1cfa8f8db157b3447b1"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86f66c85e796f5d05d5c4a60ec1d40cbfebc47a32464053528c797163fa9ab89"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:149d97453c4c98c04b081d64a85e635921269b532710d6faf81e9e82b790e7d3"},
+    {file = "tiktoken-0.14.0-cp315-cp315t-win_amd64.whl", hash = "sha256:561e7580f84a79859af1ef6f676968e9030fcc3fe195700b15235bca64f009c9"},
+    {file = "tiktoken-0.14.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:2ec16eb585332c55d022d86354e209ddf27326b1ea3477585ab248e7776d3b1f"},
+    {file = "tiktoken-0.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:aa428a559d5fd02ae619aacaace86c7474a1f2702d2c01fc828908dd60f20f7a"},
+    {file = "tiktoken-0.14.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:7b7acbb7a4b8383707bce22ad3c162006478c27b56368acd3e1fcb1658a80425"},
+    {file = "tiktoken-0.14.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:c3093001ddce822b4587e6e94bf6de36a5f97b3f31de1c9fc8d4fda144c59ff4"},
+    {file = "tiktoken-0.14.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a140e83317fef02faeeb78d9a8efac623887f2feaf0055c55dcdb2b17f0226ad"},
+    {file = "tiktoken-0.14.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:50a7e5646cbac2a8f7c3e8c0934ffda1a4357ee9c44b652434b23c3ed54d0900"},
+    {file = "tiktoken-0.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:447ada49af4898b5e992f0b5799d2f3af385921102c211947ce3fe960dd919da"},
+    {file = "tiktoken-0.14.0.tar.gz", hash = "sha256:231dec90efcdccf1b565a1416107736f1e09b1a08fe736ef9d6363e626d03874"},
+]
+
+[package.dependencies]
+regex = "*"
+requests = "*"
+
+[package.extras]
+blobfile = ["blobfile (>=3)"]
 
 [[package]]
 name = "tokenizers"
@@ -4857,6 +5405,20 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+description = "Runtime typing introspection tools"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "tzdata"
@@ -5266,11 +5828,31 @@ files = [
     {file = "zhon-2.0.2.tar.gz", hash = "sha256:c834df6b1b182f7e973e796ded80ed1f61f271fd25f6b0dc0c44f7c4ea467184"},
 ]
 
+[[package]]
+name = "zipp"
+version = "4.1.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"},
+    {file = "zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy (>=1.0.1)"]
+
 [extras]
 eflomal = ["eflomal"]
 llm = ["bitsandbytes"]
+remote-llm = ["litellm", "rank-bm25"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "103ccc049e3cf0f0aae63b662f9283b492d9da68d40f557b82cffb48c06ce598"
+content-hash = "4f06e0b599ae4a8b168facae54e8bf3138c99244c66f529f7070457f45ddf76c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ packaging = "^22.0"
 hanzidentifier = "^1.2.0"
 jarowinkler = "^2.0.1"
 wildebeest-nlp = ">=0.9.0"
+litellm = { version = "^1.77", optional = true }
+rank-bm25 = { version = "^0.2.2", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 types-pyyaml = "^6.0.12.12"
@@ -102,6 +104,7 @@ mypy = "^1.7.1"
 [tool.poetry.extras]
 eflomal = ["eflomal"]
 llm = ["bitsandbytes"]
+remote_llm = ["litellm", "rank-bm25"]
 
 [[tool.poetry.source]]
 name = "torch"

--- a/silnlp/nmt/config.py
+++ b/silnlp/nmt/config.py
@@ -134,6 +134,12 @@ def resolve_checkpoint_path(model_dir: Path, ckpt: Union[CheckpointType, str, in
     return ckpt_path, step
 
 
+@dataclass(frozen=True)
+class Language:
+    iso: str
+    name: str
+
+
 @dataclass
 class InferenceModelParams:
     checkpoint: Union[CheckpointType, str, int]

--- a/silnlp/nmt/config_utils.py
+++ b/silnlp/nmt/config_utils.py
@@ -48,7 +48,22 @@ def is_llm_config(config: dict) -> bool:
     return any(model.startswith(prefix) for prefix in LLM_MODEL_PREFIXES)
 
 
+def is_remote_llm_config(config: dict) -> bool:
+    """Decide whether a config targets a remote LLM prompted with in-context examples.
+
+    This requires an explicit ``model_type: remote_llm``: the model name is a LiteLLM model string
+    (e.g. "anthropic/claude-sonnet-4-5", "gpt-4o"), which is arbitrary and cannot be recognized
+    by a prefix match the way the local decoder-only model names can.
+    """
+    return str(config.get("model_type", "")).lower() == "remote_llm"
+
+
 def create_config(exp_dir: Path, config: dict, environment: SilNlpEnv) -> Config:
+    if is_remote_llm_config(config):
+        # Imported lazily so the litellm import cost is only paid for remote LLM experiments.
+        from .remote_llm_config import RemoteLLMConfig
+
+        return RemoteLLMConfig(exp_dir, config, environment)
     if is_llm_config(config):
         # Imported lazily so the peft/bitsandbytes import cost is only paid for LLM experiments.
         from .llm_config import LLMConfig

--- a/silnlp/nmt/example_retrieval.py
+++ b/silnlp/nmt/example_retrieval.py
@@ -1,0 +1,179 @@
+"""Retrieval of in-context translation examples from a parallel corpus.
+
+Used by the remote LLM model (:mod:`silnlp.nmt.remote_llm_config`) to select the most
+relevant source/target pairs from the training corpus for each translation request. Two
+lexical scoring methods are supported, selected with ``infer.retrieval.method``:
+
+* ``tfidf`` - TF-IDF vectors with cosine similarity, via scikit-learn.
+* ``bm25`` - Okapi BM25, via the optional ``rank_bm25`` package.
+
+Both index the *source* side of the corpus and are purely lexical, which suits the
+low-resource languages this pipeline targets: no pretrained embedding model is needed, and
+none is reliably available for them anyway.
+"""
+
+import json
+import logging
+import pickle
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Optional, Sequence
+
+LOGGER = logging.getLogger(__name__ + ".example_retrieval")
+
+BM25_METHOD = "bm25"
+TFIDF_METHOD = "tfidf"
+VALID_RETRIEVAL_METHODS = (BM25_METHOD, TFIDF_METHOD)
+
+RETRIEVER_FILENAME = "retrieval.pkl"
+RETRIEVER_META_FILENAME = "retrieval_meta.json"
+
+# Shared by both methods so that switching between them doesn't also change tokenization.
+_TOKEN_PATTERN = r"\w+"
+
+
+def tokenize_for_retrieval(text: str) -> List[str]:
+    return re.findall(_TOKEN_PATTERN, text.lower())
+
+
+@dataclass(frozen=True)
+class ExamplePair:
+    source: str
+    target: str
+
+
+class ExampleRetriever(ABC):
+    """A fitted index over the source side of a parallel corpus."""
+
+    method: str = ""
+
+    def __init__(self) -> None:
+        self._pairs: List[ExamplePair] = []
+
+    @property
+    def pairs(self) -> List[ExamplePair]:
+        return self._pairs
+
+    def fit(self, pairs: Sequence[ExamplePair]) -> None:
+        self._pairs = list(pairs)
+        self._fit_index([pair.source for pair in self._pairs])
+
+    def retrieve(self, query: str, k: int) -> List[ExamplePair]:
+        """Return up to ``k`` example pairs, most relevant first."""
+        if k <= 0 or len(self._pairs) == 0:
+            return []
+        ranked_indices = self._rank(query, min(k, len(self._pairs)))
+        return [self._pairs[i] for i in ranked_indices]
+
+    @abstractmethod
+    def _fit_index(self, sources: List[str]) -> None:
+        ...
+
+    @abstractmethod
+    def _rank(self, query: str, k: int) -> List[int]:
+        """Return the indices of the ``k`` best-matching sources, most relevant first."""
+
+    def save(self, directory: Path) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        with (directory / RETRIEVER_FILENAME).open("wb") as file:
+            pickle.dump(self, file)
+        meta = {"method": self.method, "num_pairs": len(self._pairs)}
+        with (directory / RETRIEVER_META_FILENAME).open("w", encoding="utf-8") as file:
+            json.dump(meta, file, indent=2)
+
+    @staticmethod
+    def load(directory: Path) -> Optional["ExampleRetriever"]:
+        """Load a previously saved index, or return None if it is missing or unreadable.
+
+        A None return is not an error: the caller rebuilds. The index often will not be there,
+        since the ``run`` directory is deleted unless ``--save-checkpoints`` is set, and it may
+        not unpickle across a scikit-learn upgrade.
+        """
+        path = directory / RETRIEVER_FILENAME
+        try:
+            with path.open("rb") as file:
+                retriever = pickle.load(file)
+        except FileNotFoundError:
+            return None
+        except Exception:
+            LOGGER.warning("Could not load the retrieval index at %s; it will be rebuilt.", path, exc_info=True)
+            return None
+        if not isinstance(retriever, ExampleRetriever):
+            LOGGER.warning("The file at %s is not a retrieval index; it will be rebuilt.", path)
+            return None
+        return retriever
+
+
+class TfidfExampleRetriever(ExampleRetriever):
+    method = TFIDF_METHOD
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._vectorizer: Optional[Any] = None
+        self._matrix: Optional[Any] = None
+
+    def _fit_index(self, sources: List[str]) -> None:
+        from sklearn.feature_extraction.text import TfidfVectorizer
+
+        if len(sources) == 0:
+            self._vectorizer = None
+            self._matrix = None
+            return
+        # TF-IDF vectors are L2-normalized by default, so a linear kernel is cosine similarity.
+        self._vectorizer = TfidfVectorizer(lowercase=True, token_pattern=_TOKEN_PATTERN)
+        self._matrix = self._vectorizer.fit_transform(sources)
+
+    def _rank(self, query: str, k: int) -> List[int]:
+        from sklearn.metrics.pairwise import linear_kernel
+
+        if self._vectorizer is None or self._matrix is None:
+            return []
+        query_vector = self._vectorizer.transform([query])
+        scores = linear_kernel(query_vector, self._matrix)[0]
+        return [int(i) for i in scores.argsort()[-k:][::-1]]
+
+
+class BM25ExampleRetriever(ExampleRetriever):
+    method = BM25_METHOD
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._index: Optional[Any] = None
+
+    def _fit_index(self, sources: List[str]) -> None:
+        bm25_okapi = _import_bm25()
+        tokenized = [tokenize_for_retrieval(source) for source in sources]
+        # BM25Okapi rejects an empty corpus and divides by zero on all-empty documents.
+        if sum(len(tokens) for tokens in tokenized) == 0:
+            self._index = None
+            return
+        self._index = bm25_okapi(tokenized)
+
+    def _rank(self, query: str, k: int) -> List[int]:
+        if self._index is None:
+            return []
+        scores = self._index.get_scores(tokenize_for_retrieval(query))
+        return [int(i) for i in scores.argsort()[-k:][::-1]]
+
+
+def _import_bm25():
+    try:
+        from rank_bm25 import BM25Okapi
+    except ImportError as e:
+        raise ImportError(
+            "BM25 example retrieval requires the 'rank_bm25' package, which is part of the "
+            "'remote_llm' extra. Install it with `poetry install -E remote_llm`, or set "
+            "infer.retrieval.method to 'tfidf' to use the built-in TF-IDF retriever instead."
+        ) from e
+    return BM25Okapi
+
+
+def create_retriever(method: str) -> ExampleRetriever:
+    normalized = method.lower()
+    if normalized == TFIDF_METHOD:
+        return TfidfExampleRetriever()
+    if normalized == BM25_METHOD:
+        return BM25ExampleRetriever()
+    raise ValueError(f"Unknown retrieval method '{method}'. Valid options: {', '.join(VALID_RETRIEVAL_METHODS)}.")

--- a/silnlp/nmt/llm_config.py
+++ b/silnlp/nmt/llm_config.py
@@ -49,6 +49,7 @@ from .config import (
     CheckpointType,
     Config,
     InferenceModelParams,
+    Language,
     NMTModel,
     collect_training_args,
     find_last_checkpoint,
@@ -149,12 +150,6 @@ def build_generation_kwargs(infer: dict, num_return_sequences: int, pad_token_id
             )
         gen_kwargs["num_beams"] = num_beams
     return gen_kwargs
-
-
-@dataclass(frozen=True)
-class Language:
-    iso: str
-    name: str
 
 
 @dataclass

--- a/silnlp/nmt/remote_llm_config.py
+++ b/silnlp/nmt/remote_llm_config.py
@@ -1,0 +1,976 @@
+"""In-context learning translation with a hosted LLM, via LiteLLM.
+
+An implementation of the :class:`Config`/:class:`NMTModel` abstractions that does **no
+fine-tuning**: it translates by prompting a hosted LLM with parallel examples drawn from the
+training corpus. Calls go through LiteLLM, so one ``model`` string selects any supported
+provider (Anthropic, OpenAI, Gemini, Bedrock, a local server, ...).
+
+Setting ``data.tokenize: false`` keeps the model-agnostic parts of the pipeline usable as they
+are: preprocessing writes raw detokenized parallel text, and evaluation
+(:mod:`silnlp.nmt.test`) and inference orchestration (:mod:`silnlp.nmt.translate`) work
+unchanged.
+
+Three things are configurable:
+
+* **Context mode** (``infer.context_mode``): ``rag`` retrieves the most relevant examples per
+  request; ``full_corpus`` puts the entire parallel training corpus in the prompt.
+* **Retrieval method** (``infer.retrieval.method``): ``bm25`` or ``tfidf``; see
+  :mod:`silnlp.nmt.example_retrieval`.
+* **Batch size** (``infer.infer_batch_size``): how many consecutive segments go in one request.
+
+The default prompts are written for scripture: they cast the model as a member of the
+translation team and have it infer the team's style, key terms, exegesis, and orthography from
+the examples, which are that team's own work. All are overridable through ``params.prompt``.
+
+The train step does no fine-tuning, but it is not a no-op: it builds the retrieval index and
+writes ``run/checkpoint-1``, so the checkpoint machinery the test and translate steps rely on
+resolves normally.
+
+Confidence scores come from the provider's token log probabilities. They need a provider that
+returns them (OpenAI, Azure, and Gemini do; Anthropic never does) and one segment per request; see
+``RemoteLLMModel._check_confidences_supported``.
+"""
+
+import json
+import logging
+import re
+import threading
+from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Tuple, Union
+
+import yaml
+
+from ..common.environment import SilNlpEnv
+from ..common.translation_data_structures import DraftGroup, SentenceTranslation, SentenceTranslationGroup
+from ..common.translator import generate_confidence_files
+from ..common.utils import merge_dict
+from .config import CheckpointType, Config, Language, NMTModel
+from .corpora import DataFile
+from .example_retrieval import TFIDF_METHOD, VALID_RETRIEVAL_METHODS, ExamplePair, ExampleRetriever, create_retriever
+from .tokenizer import NullTokenizer, Tokenizer
+
+LOGGER = logging.getLogger(__name__)
+
+CONTEXT_MODE_RAG = "rag"
+CONTEXT_MODE_FULL_CORPUS = "full_corpus"
+VALID_CONTEXT_MODES = (CONTEXT_MODE_RAG, CONTEXT_MODE_FULL_CORPUS)
+
+# The train step writes this checkpoint so that CheckpointType.LAST resolves to step 1.
+CHECKPOINT_STEP = 1
+MODEL_INFO_FILENAME = "remote_llm_model.json"
+
+# The prompts cast the model as a member of the translation team, because consistency with this
+# team's decisions matters more than general translation competence. All are overridable through
+# params.prompt.
+DEFAULT_SYSTEM_MESSAGE_TEMPLATE = (
+    "You are a member of a Bible translation team translating from {src_lang} into {trg_lang}. "
+    "Your job is to produce the translation this team would produce, not a translation of your "
+    "own.\n\n"
+    "Any examples you are given are the team's own completed work, and they are your authority. "
+    "Study them and follow what they show you about:\n"
+    "- Style: how closely the team follows the source wording rather than restructuring it into "
+    "natural {trg_lang}, their sentence length and register, and how much implicit information "
+    "they make explicit.\n"
+    "- Key terms: the rendering the team has settled on for recurring theological terms, and "
+    "their spelling of the names of people, places, and peoples. Reuse these exactly; never "
+    "substitute a synonym or a variant spelling.\n"
+    "- Exegesis: where the source is ambiguous, resolve it the way the team resolved comparable "
+    "passages.\n"
+    "- Orthography: their spelling conventions, punctuation, and the way they mark direct "
+    "speech.\n\n"
+    "Follow the examples in preference to any published {trg_lang} translation you may recall. "
+    "Where they do not settle a question, make the choice a careful member of this team would "
+    "make, and stay consistent with it. Translate what the source says: add nothing it does not "
+    "say, and leave out nothing it does.\n\n"
+    "Reply with only the translation itself - no commentary, notes, alternatives, explanations, "
+    "or verse numbers."
+)
+DEFAULT_SINGLE_INSTRUCTION_TEMPLATE = (
+    "Translate this {src_lang} passage into {trg_lang} as the team would translate it. Reply with "
+    "only the translation.\n\n{source}"
+)
+DEFAULT_BATCH_INSTRUCTION_TEMPLATE = (
+    "Translate the following {num_segments} consecutive {src_lang} passages into {trg_lang} as the "
+    "team would translate them. Some may be section headings rather than verses. Read them "
+    "together, so that participants, pronouns, and the flow of the passage stay consistent across "
+    "them, but translate each one on its own.\n"
+    "Reply with exactly {num_segments} lines, one per passage, in the same order, each formatted "
+    "as `<number>. <translation>`. Do not merge, split, reorder, or omit passages, and do not add "
+    "any other text.\n\n{source}"
+)
+DEFAULT_EXAMPLE_TEMPLATE = "{src_lang}: {source}\n{trg_lang}: {target}"
+EXAMPLES_HEADING = (
+    "The team has already translated these passages. They are your model for this team's style, "
+    "terminology, and exegesis:"
+)
+CORPUS_HEADING = (
+    "This is everything the team has translated so far. It is your reference for this team's "
+    "style, terminology, exegesis, spelling, and punctuation:"
+)
+
+_CODE_FENCE = re.compile(r"^\s*```[^\n]*\n(.*?)\n?\s*```\s*$", re.DOTALL)
+_NUMBERED_LINE = re.compile(r"^\s*(\d{1,4})\s*[.):\]]\s*(.*)$")
+
+
+def strip_code_fence(text: str) -> str:
+    match = _CODE_FENCE.match(text.strip())
+    return match.group(1) if match is not None else text
+
+
+def parse_numbered_response(text: str, num_segments: int) -> Optional[List[str]]:
+    """Parse a numbered list of translations, or return None if the reply is malformed.
+
+    A None return is the signal for the caller's recovery ladder (correct, then split the batch,
+    then fall back to one request per segment). Lines that are not numbered are treated as
+    continuations of the preceding translation, and any preamble before the first numbered line
+    is ignored.
+    """
+    if num_segments <= 0:
+        return []
+    parsed: Dict[int, List[str]] = {}
+    current: Optional[int] = None
+    for line in strip_code_fence(text).splitlines():
+        match = _NUMBERED_LINE.match(line)
+        if match is not None:
+            index = int(match.group(1))
+            if index in parsed:
+                return None
+            current = index
+            parsed[index] = [match.group(2).strip()]
+        elif current is not None and line.strip() != "":
+            parsed[current].append(line.strip())
+    if set(parsed) != set(range(1, num_segments + 1)):
+        return None
+    return [" ".join(part for part in parsed[i] if part != "").strip() for i in range(1, num_segments + 1)]
+
+
+def group_indices_by_size(count: int, size: int) -> List[List[int]]:
+    size = max(1, size)
+    return [list(range(start, min(start + size, count))) for start in range(0, count, size)]
+
+
+@dataclass(frozen=True)
+class TokenLogprob:
+    token: str
+    logprob: float
+
+
+@dataclass(frozen=True)
+class Completion:
+    """A reply from the model, with whatever the provider reported alongside it.
+
+    ``cost`` is None when LiteLLM has no pricing for the model, which is not the same as free.
+    """
+
+    text: str
+    token_logprobs: List[TokenLogprob] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost: Optional[float] = None
+
+    def mean_logprob(self) -> Optional[float]:
+        if len(self.token_logprobs) == 0:
+            return None
+        return sum(entry.logprob for entry in self.token_logprobs) / len(self.token_logprobs)
+
+
+@dataclass
+class UsageTotals:
+    """Running totals for one translation run. Requests are made from several threads."""
+
+    requests: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+    unpriced_requests: int = 0
+
+    def __post_init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def add(self, completion: Completion) -> None:
+        with self._lock:
+            self.requests += 1
+            self.prompt_tokens += completion.prompt_tokens
+            self.completion_tokens += completion.completion_tokens
+            if completion.cost is None:
+                self.unpriced_requests += 1
+            else:
+                self.cost += completion.cost
+
+    def describe(self) -> str:
+        summary = (
+            f"{self.requests:,} requests, {self.prompt_tokens:,} prompt + "
+            f"{self.completion_tokens:,} completion tokens"
+        )
+        if self.unpriced_requests == 0:
+            return f"{summary}, ${self.cost:.4f}"
+        if self.unpriced_requests == self.requests:
+            return f"{summary}; cost unavailable (no pricing for this model)"
+        return f"{summary}, ${self.cost:.4f} excluding {self.unpriced_requests:,} unpriced requests"
+
+
+class CompletionClient(ABC):
+    """Sends a chat completion request and returns the reply text.
+
+    Indirected so tests can substitute a scripted client without a network call.
+    """
+
+    @abstractmethod
+    def complete(self, messages: List[Dict[str, str]], logprobs: bool = False) -> Completion:
+        ...
+
+    def supports_logprobs(self) -> bool:
+        """Whether the configured provider can return token log probabilities."""
+        return False
+
+
+class LiteLLMCompletionClient(CompletionClient):
+    def __init__(self, model: str, infer: dict, extra_kwargs: Optional[dict] = None) -> None:
+        self._model = model
+        self._infer = infer
+        self._extra_kwargs: Dict[str, Any] = dict(extra_kwargs or {})
+
+    def complete(self, messages: List[Dict[str, str]], logprobs: bool = False) -> Completion:
+        litellm = _import_litellm()
+        extra_kwargs = dict(self._extra_kwargs)
+        if logprobs:
+            extra_kwargs["logprobs"] = True
+        response = litellm.completion(
+            model=self._model,
+            messages=messages,
+            temperature=self._infer["temperature"],
+            max_tokens=self._infer["max_new_tokens"],
+            # LiteLLM retries transient failures (rate limits, timeouts, 5xx) itself.
+            num_retries=self._infer["num_retries"],
+            timeout=self._infer["request_timeout"],
+            **extra_kwargs,
+        )
+        choice = response["choices"][0]
+        content = choice["message"]["content"]
+        usage = _get_field(response, "usage")
+        return Completion(
+            content if content is not None else "",
+            extract_token_logprobs(choice) if logprobs else [],
+            prompt_tokens=int(_get_field(usage, "prompt_tokens") or 0),
+            completion_tokens=int(_get_field(usage, "completion_tokens") or 0),
+            cost=_completion_cost(litellm, response),
+        )
+
+    def supports_logprobs(self) -> bool:
+        litellm = _import_litellm()
+        try:
+            supported = litellm.get_supported_openai_params(self._model) or []
+        except Exception:
+            # An unrecognized model is not fatal; the caller just gets no scores.
+            LOGGER.warning("Could not determine which parameters %s supports.", self._model, exc_info=True)
+            return False
+        return "logprobs" in supported
+
+
+def extract_token_logprobs(choice: Any) -> List[TokenLogprob]:
+    """Pull the per-token log probabilities out of a LiteLLM choice, if it has any.
+
+    A provider that does not support logprobs omits them rather than failing, so every level of
+    the normalized OpenAI shape has to be treated as optional.
+    """
+    logprobs = _get_field(choice, "logprobs")
+    content = _get_field(logprobs, "content") if logprobs is not None else None
+    if not content:
+        return []
+    token_logprobs: List[TokenLogprob] = []
+    for entry in content:
+        token = _get_field(entry, "token")
+        logprob = _get_field(entry, "logprob")
+        if token is None or logprob is None:
+            continue
+        token_logprobs.append(TokenLogprob(str(token), float(logprob)))
+    return token_logprobs
+
+
+def _completion_cost(litellm: Any, response: Any) -> Optional[float]:
+    """What the request cost, or None if LiteLLM has no pricing for the model."""
+    try:
+        return float(litellm.completion_cost(completion_response=response))
+    except Exception:
+        LOGGER.debug("No pricing available for this response; reporting its cost as unknown.", exc_info=True)
+        return None
+
+
+def _get_field(obj: Any, name: str) -> Any:
+    """Read a field from a LiteLLM response, which may be a dict or a pydantic model."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def count_tokens(model: str, text: str) -> Optional[int]:
+    """Count the tokens in ``text`` the way ``model``'s tokenizer would, or None if it cannot.
+
+    None means the caller skips its size check rather than run it against a guess. LiteLLM
+    falls back to a default tokenizer for models it does not recognize, so this rarely happens.
+    """
+    try:
+        import litellm
+
+        return int(litellm.token_counter(model=model, text=text))
+    except Exception:
+        LOGGER.warning("Could not count tokens for '%s'; skipping the prompt size check.", model, exc_info=True)
+        return None
+
+
+def _import_litellm():
+    try:
+        import litellm
+    except ImportError as e:
+        raise ImportError(
+            "Remote LLM experiments require the 'litellm' package, which is part of the "
+            "'remote_llm' extra. Install it with `poetry install -E remote_llm`."
+        ) from e
+    return litellm
+
+
+class CompletionClientFactory:
+    def create(self, config: "RemoteLLMConfig") -> CompletionClient:
+        raise NotImplementedError
+
+
+class LiteLLMCompletionClientFactory(CompletionClientFactory):
+    def create(self, config: "RemoteLLMConfig") -> CompletionClient:
+        return LiteLLMCompletionClient(config.model, config.infer, config.params.get("litellm"))
+
+
+class RemoteLLMConfig(Config):
+    def __init__(self, exp_dir: Path, config: dict, environment: SilNlpEnv) -> None:
+        config = merge_dict(
+            {
+                "data": {
+                    "mirror": False,
+                    "seed": 111,
+                    # The hosted model tokenizes for itself; use the raw parallel text.
+                    "tokenize": False,
+                    "aligner": "fast_align",
+                    "stats_max_size": 100000,
+                    "terms": {"train": False, "categories": "PN", "include_glosses": False, "dictionary": False},
+                    "lang_codes": {},
+                    "add_new_lang_code": False,
+                },
+                "train": {
+                    "output_dir": str(exp_dir / "run"),
+                },
+                # No training loop, so none of this applies; the keys exist because the shared
+                # config plumbing reads and writes them.
+                "eval": {
+                    "eval_strategy": "no",
+                    "early_stopping": None,
+                    "load_best_model_at_end": False,
+                    "metric_for_best_model": None,
+                    "greater_is_better": False,
+                    "multi_ref_eval": False,
+                },
+                "infer": {
+                    "context_mode": CONTEXT_MODE_RAG,
+                    "retrieval": {
+                        # TF-IDF by default so a plain install works; BM25 generally ranks
+                        # better but needs rank_bm25 from the 'remote_llm' extra.
+                        "method": TFIDF_METHOD,
+                        "num_examples": 10,
+                    },
+                    "infer_batch_size": 1,
+                    "num_drafts": 1,
+                    "temperature": 0.2,
+                    "max_new_tokens": 4096,
+                    "concurrency": 4,
+                    "num_retries": 3,
+                    "request_timeout": 120,
+                    "max_context_tokens": 180000,
+                },
+                "params": {
+                    "prompt": {
+                        "system_message": DEFAULT_SYSTEM_MESSAGE_TEMPLATE,
+                        "instruction_template": DEFAULT_SINGLE_INSTRUCTION_TEMPLATE,
+                        "batch_instruction_template": DEFAULT_BATCH_INSTRUCTION_TEMPLATE,
+                        "example_template": DEFAULT_EXAMPLE_TEMPLATE,
+                    },
+                    # Passed straight through to litellm.completion (api_base, extra_headers, ...).
+                    "litellm": {},
+                },
+                "model": "",
+            },
+            config,
+        )
+
+        super().__init__(exp_dir, config, environment)
+
+        if len(self.src_isos) > 1 or len(self.trg_isos) > 1:
+            raise RuntimeError(
+                "In-context learning experiments only support a single source language and a single " "target language."
+            )
+        self._validate()
+        self._disable_eval_if_no_val_split()
+
+    def _validate(self) -> None:
+        if not str(self.model).strip():
+            raise ValueError(
+                "An in-context learning experiment needs a 'model' in LiteLLM format, "
+                "e.g. 'anthropic/claude-sonnet-4-5', 'gpt-4o', or 'gemini/gemini-2.5-pro'."
+            )
+        if self.context_mode not in VALID_CONTEXT_MODES:
+            raise ValueError(
+                f"Unknown infer.context_mode '{self.infer['context_mode']}'. "
+                f"Valid options: {', '.join(VALID_CONTEXT_MODES)}."
+            )
+        if self.retrieval_method not in VALID_RETRIEVAL_METHODS:
+            raise ValueError(
+                f"Unknown infer.retrieval.method '{self.retrieval['method']}'. "
+                f"Valid options: {', '.join(VALID_RETRIEVAL_METHODS)}."
+            )
+        for name, value in (
+            ("infer.infer_batch_size", self.infer_batch_size),
+            ("infer.num_drafts", self.infer["num_drafts"]),
+            ("infer.concurrency", self.infer["concurrency"]),
+        ):
+            if not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be an integer of at least 1, but it is {value!r}.")
+        if self.num_examples < 0:
+            raise ValueError(f"infer.retrieval.num_examples cannot be negative, but it is {self.num_examples}.")
+
+    @property
+    def context_mode(self) -> str:
+        return str(self.infer["context_mode"]).lower()
+
+    @property
+    def retrieval(self) -> dict:
+        return self.infer["retrieval"]
+
+    @property
+    def retrieval_method(self) -> str:
+        return str(self.retrieval["method"]).lower()
+
+    @property
+    def num_examples(self) -> int:
+        return self.retrieval["num_examples"]
+
+    @property
+    def infer_batch_size(self) -> int:
+        return self.infer["infer_batch_size"]
+
+    @property
+    def prompt(self) -> dict:
+        return self.params["prompt"]
+
+    def lang_name(self, iso: str) -> str:
+        return self.data["lang_codes"].get(iso, iso)
+
+    def language(self, iso: str) -> Language:
+        return Language(iso=iso, name=self.lang_name(iso))
+
+    @property
+    def train_src_iso(self) -> str:
+        return self.default_test_src_iso or (next(iter(self.src_isos)) if len(self.src_isos) > 0 else "")
+
+    @property
+    def train_trg_iso(self) -> str:
+        return self.default_test_trg_iso or (next(iter(self.trg_isos)) if len(self.trg_isos) > 0 else "")
+
+    def render_examples(self, examples: Sequence[ExamplePair], src_lang: Language, trg_lang: Language) -> str:
+        template: str = self.prompt["example_template"]
+        return "\n\n".join(
+            template.format(
+                src_lang=src_lang.name, trg_lang=trg_lang.name, source=example.source, target=example.target
+            )
+            for example in examples
+        )
+
+    def build_system_message(self, src_lang: Language, trg_lang: Language, corpus_block: Optional[str] = None) -> str:
+        system_message: str = self.prompt["system_message"].format(src_lang=src_lang.name, trg_lang=trg_lang.name)
+        if corpus_block:
+            system_message = f"{system_message}\n\n{corpus_block}"
+        return system_message
+
+    def build_user_message(
+        self,
+        sources: Sequence[str],
+        examples: Sequence[ExamplePair],
+        src_lang: Language,
+        trg_lang: Language,
+    ) -> str:
+        parts: List[str] = []
+        if len(examples) > 0:
+            parts.append(f"{EXAMPLES_HEADING}\n\n{self.render_examples(examples, src_lang, trg_lang)}")
+        if len(sources) == 1:
+            template: str = self.prompt["instruction_template"]
+            parts.append(template.format(src_lang=src_lang.name, trg_lang=trg_lang.name, source=sources[0]))
+        else:
+            numbered = "\n".join(f"{i}. {source}" for i, source in enumerate(sources, 1))
+            batch_template: str = self.prompt["batch_instruction_template"]
+            parts.append(
+                batch_template.format(
+                    src_lang=src_lang.name,
+                    trg_lang=trg_lang.name,
+                    num_segments=len(sources),
+                    source=numbered,
+                )
+            )
+        return "\n\n".join(parts)
+
+    def build_messages(
+        self,
+        sources: Sequence[str],
+        examples: Sequence[ExamplePair],
+        src_lang: Language,
+        trg_lang: Language,
+        corpus_block: Optional[str] = None,
+    ) -> List[Dict[str, str]]:
+        """Build the chat messages for one translation request.
+
+        In full-corpus mode the corpus goes in the system message, ahead of everything that
+        varies per request, so the prompt prefix is byte-identical across requests and
+        provider-side prompt caching can apply.
+        """
+        messages: List[Dict[str, str]] = []
+        system_message = self.build_system_message(src_lang, trg_lang, corpus_block)
+        if system_message:
+            messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "user", "content": self.build_user_message(sources, examples, src_lang, trg_lang)})
+        return messages
+
+    def create_model(
+        self,
+        mixed_precision: bool = True,
+        num_devices: int = 1,
+        clearml_queue: Optional[str] = None,
+        completion_client_factory: Optional[CompletionClientFactory] = None,
+    ) -> NMTModel:
+        if completion_client_factory is None:
+            completion_client_factory = LiteLLMCompletionClientFactory()
+        return RemoteLLMModel(self, completion_client_factory)
+
+    def create_tokenizer(self) -> Tokenizer:
+        # Data prep and test.py only tokenize and detokenize with this; both are raw text here.
+        return NullTokenizer()
+
+    def _build_vocabs(self, stats: bool = False) -> None:
+        # The hosted model has its own vocabulary.
+        return
+
+    def _write_dictionary(
+        self,
+        tokenizer: Tokenizer,
+        src_terms_files: List[Tuple[DataFile, List[str]]],
+        trg_terms_files: List[Tuple[DataFile, List[str]]],
+    ) -> int:
+        return 0
+
+
+class RemoteLLMModel(NMTModel):
+    def __init__(
+        self,
+        config: RemoteLLMConfig,
+        completion_client_factory: Optional[CompletionClientFactory] = None,
+    ) -> None:
+        super().__init__(config)
+        self._config: RemoteLLMConfig = config
+        self._client_factory = completion_client_factory or LiteLLMCompletionClientFactory()
+        self._client: Optional[CompletionClient] = None
+        self._retriever: Optional[ExampleRetriever] = None
+        self._corpus_block: Optional[str] = None
+        # Requests run on a thread pool; guards the lazily built client, index, and corpus block.
+        self._lock = threading.Lock()
+
+    def train(self) -> None:
+        """Build the retrieval index. There is no fine-tuning.
+
+        The saved index is only a cache: ``experiment.py`` deletes the ``run`` directory unless
+        ``--save-checkpoints`` is passed, so inference rebuilds it when it is missing.
+        """
+        checkpoint_dir = self._checkpoint_dir()
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+        pairs = self._load_training_pairs()
+        info: Dict[str, Any] = {
+            "context_mode": self._config.context_mode,
+            "model": self._config.model,
+            "num_training_pairs": len(pairs),
+        }
+        if self._config.context_mode == CONTEXT_MODE_RAG:
+            if len(pairs) == 0:
+                LOGGER.warning(
+                    "No training examples were found, so translation will run with no in-context "
+                    "examples. Check that the preprocess step ran and produced a training corpus."
+                )
+            retriever = create_retriever(self._config.retrieval_method)
+            retriever.fit(pairs)
+            retriever.save(checkpoint_dir)
+            with self._lock:
+                self._retriever = retriever
+            info["retrieval_method"] = self._config.retrieval_method
+            LOGGER.info(
+                "Built a %s retrieval index over %d training examples.", self._config.retrieval_method, len(pairs)
+            )
+        else:
+            rendered = self._config.render_examples(
+                pairs,
+                self._config.language(self._config.train_src_iso),
+                self._config.language(self._config.train_trg_iso),
+            )
+            corpus_tokens = count_tokens(self._config.model, rendered)
+            info["corpus_tokens"] = corpus_tokens
+            LOGGER.info(
+                "Full-corpus mode: %d training examples (%s tokens) go in every request.",
+                len(pairs),
+                corpus_tokens if corpus_tokens is not None else "an unknown number of",
+            )
+            self._warn_if_corpus_too_large(corpus_tokens)
+
+        with (checkpoint_dir / MODEL_INFO_FILENAME).open("w", encoding="utf-8") as file:
+            json.dump(info, file, indent=2)
+
+    def save_effective_config(self, path: Path) -> None:
+        # There are no training arguments to overlay, so the merged config is the effective one.
+        with path.open("w") as file:
+            yaml.dump(deepcopy(self._config.root), file)
+
+    def _checkpoint_dir(self) -> Path:
+        return self._config.model_dir / f"checkpoint-{CHECKPOINT_STEP}"
+
+    def _warn_if_corpus_too_large(self, corpus_tokens: Optional[int]) -> None:
+        limit: int = self._config.infer["max_context_tokens"]
+        if corpus_tokens is not None and corpus_tokens > limit:
+            LOGGER.warning(
+                "The training corpus is %d tokens, which exceeds infer.max_context_tokens (%d). "
+                "Requests may be rejected for exceeding the model's context window. Consider using "
+                "context_mode 'rag' instead.",
+                corpus_tokens,
+                limit,
+            )
+
+    def _load_training_pairs(self) -> List[ExamplePair]:
+        src_path = self._resolve_train_path(self._config.train_src_detok_filename(), self._config.train_src_filename())
+        trg_path = self._resolve_train_path(self._config.train_trg_detok_filename(), self._config.train_trg_filename())
+        if src_path is None or trg_path is None:
+            LOGGER.warning(
+                "No training corpus was found in %s, so no in-context examples are available.",
+                self._config.exp_dir,
+            )
+            return []
+        sources = _read_lines(src_path)
+        targets = _read_lines(trg_path)
+        if len(sources) != len(targets):
+            LOGGER.warning(
+                "The training corpus files are not the same length (%d vs %d lines); using the "
+                "first %d aligned pairs.",
+                len(sources),
+                len(targets),
+                min(len(sources), len(targets)),
+            )
+        return [
+            ExamplePair(source, target) for source, target in zip(sources, targets) if source != "" and target != ""
+        ]
+
+    def _resolve_train_path(self, *filenames: str) -> Optional[Path]:
+        for filename in filenames:
+            path = self._config.exp_dir / filename
+            if path.is_file():
+                return path
+        return None
+
+    def _get_client(self) -> CompletionClient:
+        with self._lock:
+            if self._client is None:
+                self._client = self._client_factory.create(self._config)
+            return self._client
+
+    def _get_retriever(self) -> Optional[ExampleRetriever]:
+        if self._config.context_mode != CONTEXT_MODE_RAG:
+            return None
+        with self._lock:
+            if self._retriever is None:
+                retriever = ExampleRetriever.load(self._checkpoint_dir())
+                if retriever is None or retriever.method != self._config.retrieval_method:
+                    if retriever is not None:
+                        LOGGER.info(
+                            "The saved retrieval index uses '%s' but the config asks for '%s'; rebuilding it.",
+                            retriever.method,
+                            self._config.retrieval_method,
+                        )
+                    retriever = create_retriever(self._config.retrieval_method)
+                    retriever.fit(self._load_training_pairs())
+                self._retriever = retriever
+            return self._retriever
+
+    def _get_corpus_block(self, src_lang: Language, trg_lang: Language) -> Optional[str]:
+        if self._config.context_mode != CONTEXT_MODE_FULL_CORPUS:
+            return None
+        with self._lock:
+            if self._corpus_block is None:
+                rendered = self._config.render_examples(self._load_training_pairs(), src_lang, trg_lang)
+                self._warn_if_corpus_too_large(count_tokens(self._config.model, rendered))
+                self._corpus_block = f"{CORPUS_HEADING}\n\n{rendered}" if rendered else ""
+            return self._corpus_block
+
+    def translate(
+        self,
+        sentences: Iterable[str],
+        src_iso: str,
+        trg_iso: str,
+        produce_multiple_translations: bool = False,
+        ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
+    ) -> Generator[SentenceTranslationGroup, None, None]:
+        sentence_list = list(sentences)
+        batches = self._batch_indices(len(sentence_list))
+        yield from self._translate_batches(
+            sentence_list,
+            batches,
+            self._config.language(src_iso),
+            self._config.language(trg_iso),
+            produce_multiple_translations,
+        )
+
+    def translate_test_files(
+        self,
+        input_paths: List[Path],
+        translation_paths: List[Path],
+        produce_multiple_translations: bool = False,
+        save_confidences: bool = False,
+        ckpt: Union[CheckpointType, str, int] = CheckpointType.LAST,
+    ) -> None:
+        if save_confidences:
+            # Fail before paying for inference; test.py would otherwise fail later with a
+            # confusing FileNotFoundError for the missing confidences file.
+            self._check_confidences_supported()
+
+        default_src_iso = self._config.train_src_iso
+        default_trg_iso = self._config.train_trg_iso
+        for input_path, translation_path in zip(input_paths, translation_paths):
+            src_iso, trg_iso = self._isos_for_test_file(input_path, default_src_iso, default_trg_iso)
+            sentences = _read_lines(input_path)
+            batches = self._batch_indices(len(sentences))
+            groups = list(
+                self._translate_batches(
+                    sentences,
+                    batches,
+                    self._config.language(src_iso),
+                    self._config.language(trg_iso),
+                    produce_multiple_translations,
+                    save_confidences,
+                )
+            )
+            draft_group = DraftGroup(groups)
+            for draft_index, translated_draft in enumerate(draft_group.get_drafts(), 1):
+                if produce_multiple_translations:
+                    draft_path = translation_path.with_suffix(f".{draft_index}{translation_path.suffix}")
+                else:
+                    draft_path = translation_path
+                with draft_path.open("w", encoding="utf-8", newline="\n") as out_file:
+                    out_file.write("\n".join(translated_draft.get_all_tokenized_translations()) + "\n")
+                if save_confidences:
+                    generate_confidence_files(translated_draft, draft_path)
+
+    def _check_confidences_supported(self) -> None:
+        """Raise unless the provider returns log probabilities and each request is one segment.
+
+        LiteLLM omits logprobs silently rather than failing, so an unsupported provider has to be
+        caught here.
+        """
+        if self._config.infer_batch_size != 1:
+            raise RuntimeError(
+                "Confidence scores are only available when each request translates a single "
+                "segment, because a batched reply's token log probabilities cannot be attributed "
+                "to individual segments. Set infer.infer_batch_size to 1, or run without "
+                "--save-confidences."
+            )
+        if not self._get_client().supports_logprobs():
+            raise RuntimeError(
+                f"Confidence scores are not available for '{self._config.model}', because the "
+                "provider does not return token log probabilities (Anthropic models never do). "
+                "Use a model that supports logprobs, such as an OpenAI, Azure, or Gemini "
+                "model, or run without --save-confidences."
+            )
+
+    def _isos_for_test_file(self, input_path: Path, default_src_iso: str, default_trg_iso: str) -> Tuple[str, str]:
+        match = re.match(r"^test\.([a-z]{2,3})\.([a-z]{2,3})\..*", input_path.name)
+        if match:
+            return match.group(1), match.group(2)
+        return default_src_iso, default_trg_iso
+
+    def _batch_indices(self, count: int) -> List[List[int]]:
+        return group_indices_by_size(count, self._config.infer_batch_size)
+
+    def _translate_batches(
+        self,
+        sentences: Sequence[str],
+        batches: Sequence[Sequence[int]],
+        src_lang: Language,
+        trg_lang: Language,
+        produce_multiple_translations: bool,
+        want_logprobs: bool = False,
+    ) -> Generator[SentenceTranslationGroup, None, None]:
+        num_drafts = self.get_num_drafts() if produce_multiple_translations else 1
+        if num_drafts > 1 and not self._config.infer["temperature"]:
+            LOGGER.warning(
+                "infer.num_drafts is %d but infer.temperature is 0, so the drafts are likely to be "
+                "identical. Raise the temperature to get varied drafts.",
+                num_drafts,
+            )
+
+        # One slot per (draft, sentence). Tasks write to disjoint slots, so no lock is needed.
+        results: List[List[Optional[Completion]]] = [[None] * len(sentences) for _ in range(num_drafts)]
+
+        def run_task(task: Tuple[int, int]) -> None:
+            batch_index, draft_index = task
+            indices = batches[batch_index]
+            completions = self._translate_batch(
+                [sentences[i] for i in indices], src_lang, trg_lang, want_logprobs, usage
+            )
+            for index, completion in zip(indices, completions):
+                results[draft_index][index] = completion
+
+        usage = UsageTotals()
+        tasks = [(batch_index, draft_index) for draft_index in range(num_drafts) for batch_index in range(len(batches))]
+        concurrency = max(1, self._config.infer["concurrency"])
+        if concurrency == 1 or len(tasks) <= 1:
+            for task in tasks:
+                run_task(task)
+        else:
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                # Consume the iterator so that any exception raised in a worker propagates here.
+                list(executor.map(run_task, tasks))
+
+        LOGGER.info("Translated %s segments using %s.", f"{len(sentences):,}", usage.describe())
+
+        for index in range(len(sentences)):
+            yield SentenceTranslationGroup(
+                [_to_sentence_translation(results[draft][index] or Completion("")) for draft in range(num_drafts)]
+            )
+
+    def _translate_batch(
+        self,
+        texts: Sequence[str],
+        src_lang: Language,
+        trg_lang: Language,
+        want_logprobs: bool = False,
+        usage: Optional[UsageTotals] = None,
+    ) -> List[Completion]:
+        translations: List[Completion] = [Completion("")] * len(texts)
+        # Blank segments are verses absent from the source; no request needed.
+        non_blank = [(index, text) for index, text in enumerate(texts) if text.strip() != ""]
+        if len(non_blank) == 0:
+            return translations
+        completed = self._complete_texts([text for _, text in non_blank], src_lang, trg_lang, want_logprobs, usage)
+        for (index, _), completion in zip(non_blank, completed):
+            translations[index] = completion
+        return translations
+
+    def _complete_texts(
+        self,
+        texts: Sequence[str],
+        src_lang: Language,
+        trg_lang: Language,
+        want_logprobs: bool = False,
+        usage: Optional[UsageTotals] = None,
+    ) -> List[Completion]:
+        """Translate a batch, recovering from a reply that does not have one line per segment.
+
+        The ladder is: ask again with a correction, then split the batch in half, and finally
+        fall back to one request per segment, which cannot be miscounted. Log probabilities are
+        only attached in that last case, since a batched reply's token stream cannot be split
+        per segment.
+        """
+        if len(texts) == 1:
+            return [self._complete_single(texts[0], src_lang, trg_lang, want_logprobs, usage)]
+
+        messages = self._build_messages(texts, src_lang, trg_lang)
+        response = self._complete(messages, usage=usage).text
+        parsed = parse_numbered_response(response, len(texts))
+        if parsed is None:
+            correction = messages + [
+                {"role": "assistant", "content": response},
+                {
+                    "role": "user",
+                    "content": (
+                        f"That reply did not have the required format. Reply again with exactly "
+                        f"{len(texts)} lines, one per segment, in the same order, each formatted as "
+                        f"`<number>. <translation>`, and nothing else."
+                    ),
+                },
+            ]
+            parsed = parse_numbered_response(self._complete(correction, usage=usage).text, len(texts))
+        if parsed is not None:
+            return [Completion(text) for text in parsed]
+
+        LOGGER.warning(
+            "Could not read %d translations from the model's reply; splitting the batch and retrying.", len(texts)
+        )
+        middle = len(texts) // 2
+        return self._complete_texts(texts[:middle], src_lang, trg_lang, want_logprobs, usage) + self._complete_texts(
+            texts[middle:], src_lang, trg_lang, want_logprobs, usage
+        )
+
+    def _complete_single(
+        self,
+        text: str,
+        src_lang: Language,
+        trg_lang: Language,
+        want_logprobs: bool = False,
+        usage: Optional[UsageTotals] = None,
+    ) -> Completion:
+        completion = self._complete(self._build_messages([text], src_lang, trg_lang), want_logprobs, usage)
+        stripped = strip_code_fence(completion.text).strip()
+        if stripped == completion.text:
+            return completion
+        # Stripping a code fence or surrounding whitespace leaves the per-token scores covering
+        # text that is no longer there, so drop them rather than report a misaligned sequence.
+        return replace(completion, text=stripped, token_logprobs=[])
+
+    def _complete(
+        self, messages: List[Dict[str, str]], logprobs: bool = False, usage: Optional[UsageTotals] = None
+    ) -> Completion:
+        """Send one request, counting it against the run's totals."""
+        completion = self._get_client().complete(messages, logprobs)
+        if usage is not None:
+            usage.add(completion)
+        return completion
+
+    def _build_messages(self, texts: Sequence[str], src_lang: Language, trg_lang: Language) -> List[Dict[str, str]]:
+        return self._config.build_messages(
+            texts,
+            self._retrieve_examples(texts),
+            src_lang,
+            trg_lang,
+            self._get_corpus_block(src_lang, trg_lang),
+        )
+
+    def _retrieve_examples(self, texts: Sequence[str]) -> List[ExamplePair]:
+        retriever = self._get_retriever()
+        if retriever is None:
+            return []
+        examples = retriever.retrieve("\n".join(texts), self._config.num_examples)
+        # Render the most relevant example last, nearest the text to be translated.
+        return list(reversed(examples))
+
+
+def _to_sentence_translation(completion: Completion) -> SentenceTranslation:
+    """Convert a completion into the pipeline's translation type.
+
+    ``tokens`` holds the whole translation rather than the provider's subword tokens: the
+    predictions file is raw text and is written by space-joining them. The log probabilities go
+    into the scores, which is all the confidence files read.
+    """
+    return SentenceTranslation(
+        completion.text,
+        [completion.text],
+        [entry.logprob for entry in completion.token_logprobs],
+        completion.mean_logprob(),
+        starts_with_special_token=False,
+    )
+
+
+def _read_lines(path: Path) -> List[str]:
+    with path.open("r", encoding="utf-8-sig") as file:
+        return [line.strip() for line in file]

--- a/tests/smoke_tests/experiments/test_experiment_remote_llm/config.yml
+++ b/tests/smoke_tests/experiments/test_experiment_remote_llm/config.yml
@@ -1,0 +1,19 @@
+model_type: remote_llm
+# Never actually called: the smoke test injects a mock completion client. The string is a
+# realistic LiteLLM model name so that the config is representative.
+model: anthropic/claude-sonnet-4-5
+data:
+  corpus_pairs:
+  - src: en-BSB
+    trg: es-LBLA
+    test_size: 16
+  lang_codes:
+    en: English
+    es: Spanish
+infer:
+  context_mode: rag
+  retrieval:
+    method: tfidf
+    num_examples: 3
+  infer_batch_size: 4
+  concurrency: 2

--- a/tests/smoke_tests/experiments/test_experiment_remote_llm/translate_config.yml
+++ b/tests/smoke_tests/experiments/test_experiment_remote_llm/translate_config.yml
@@ -1,0 +1,4 @@
+translate:
+- books: 3JN
+  checkpoint: last
+  src_project: BSB

--- a/tests/smoke_tests/mock_completion_client.py
+++ b/tests/smoke_tests/mock_completion_client.py
@@ -1,0 +1,73 @@
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from silnlp.nmt.remote_llm_config import (
+    Completion,
+    CompletionClient,
+    CompletionClientFactory,
+    RemoteLLMConfig,
+    TokenLogprob,
+)
+
+# Matches the numbered source segments that the batch prompt asks the model to translate.
+_NUMBERED_SEGMENT = re.compile(r"^\s*(\d{1,4})\.\s+(.*)$")
+
+
+@dataclass
+class CompletionStats:
+    requests: List[List[Dict[str, str]]] = field(default_factory=list)
+
+    @property
+    def num_requests(self) -> int:
+        return len(self.requests)
+
+
+class MockCompletionClient(CompletionClient):
+    """Answers translation requests locally, in the format the prompt asks for.
+
+    The "translations" are just marked-up source text: the smoke test asserts structural
+    properties (one output line per input segment, files in the right places), not translation
+    quality, and a real call would need a provider API key and cost money.
+    """
+
+    def __init__(self, stats: CompletionStats) -> None:
+        self._stats = stats
+
+    def complete(self, messages: List[Dict[str, str]], logprobs: bool = False) -> Completion:
+        self._stats.requests.append(messages)
+        segments = self._numbered_segments(messages[-1]["content"])
+        if len(segments) == 0:
+            # The single-segment prompt is unnumbered and expects a bare translation.
+            text = "translated"
+        else:
+            text = "\n".join(f"{number}. translated {segment}" for number, segment in segments)
+        if not logprobs:
+            return Completion(text)
+        return Completion(text, [TokenLogprob(token, -0.1) for token in text.split()])
+
+    def supports_logprobs(self) -> bool:
+        return True
+
+    @staticmethod
+    def _numbered_segments(user_message: str) -> List[tuple]:
+        # The segments to translate are the numbered lines in the final block of the prompt,
+        # after the instruction; retrieved examples are rendered without numbering.
+        segments = []
+        for line in user_message.splitlines():
+            match = _NUMBERED_SEGMENT.match(line)
+            if match is not None:
+                segments.append((int(match.group(1)), match.group(2)))
+        return segments
+
+
+class MockCompletionClientFactory(CompletionClientFactory):
+    def __init__(self, stats: Optional[CompletionStats] = None) -> None:
+        self._stats = stats or CompletionStats()
+
+    @property
+    def stats(self) -> CompletionStats:
+        return self._stats
+
+    def create(self, config: RemoteLLMConfig) -> CompletionClient:
+        return MockCompletionClient(self._stats)

--- a/tests/smoke_tests/test_experiment_remote_llm.py
+++ b/tests/smoke_tests/test_experiment_remote_llm.py
@@ -1,0 +1,71 @@
+from typing import Tuple
+
+from silnlp.common.environment import SilNlpEnv
+from silnlp.nmt.config_utils import load_config
+from silnlp.nmt.experiment import SILExperiment
+from silnlp.nmt.remote_llm_config import RemoteLLMConfig
+from tests.smoke_tests.mock_completion_client import CompletionStats, MockCompletionClientFactory
+from tests.smoke_tests.smoke_test_utils import (
+    PIPELINE_OUTPUT_PATTERNS,
+    count_lines,
+    create_full_pipeline_experiment,
+    delete_generated_paths,
+    set_up_environment,
+)
+
+EXPERIMENT_NAME = "test_experiment_remote_llm"
+
+
+def test_remote_llm_experiment_full_pipeline():
+    # Like test_experiment.py, this runs the full pipeline and needs an active MinIO connection
+    # for the "Scripture"/"Paratext" data. No LLM provider is contacted; the client is mocked.
+    environment = set_up_environment()
+    exp_dir = environment.get_mt_exp_dir(EXPERIMENT_NAME)
+    delete_generated_paths(exp_dir, PIPELINE_OUTPUT_PATTERNS)
+
+    experiment, stats = create_experiment_with_mock_client(environment)
+    experiment.run()
+
+    check_training_step(environment)
+    check_test_step(environment)
+    check_translate_step(environment)
+    assert stats.num_requests > 0
+
+    delete_generated_paths(exp_dir, PIPELINE_OUTPUT_PATTERNS)
+
+
+def create_experiment_with_mock_client(environment: SilNlpEnv) -> Tuple[SILExperiment, CompletionStats]:
+    factory = MockCompletionClientFactory()
+
+    config = load_config(EXPERIMENT_NAME, environment)
+    assert isinstance(config, RemoteLLMConfig)
+
+    # A remote LLM model takes a completion client factory rather than a pretrained model provider, so
+    # it cannot be created with create_model_with_mock_pretrained_model.
+    model = config.create_model(completion_client_factory=factory)
+
+    experiment = create_full_pipeline_experiment(EXPERIMENT_NAME, config, model, environment)
+    return experiment, factory.stats
+
+
+def check_training_step(environment: SilNlpEnv):
+    # There is no fine-tuning; the train step builds the retrieval index and writes the
+    # checkpoint that the test and translate steps resolve.
+    checkpoint_dir = environment.get_mt_exp_dir(EXPERIMENT_NAME) / "run" / "checkpoint-1"
+    assert checkpoint_dir.is_dir()
+    assert (checkpoint_dir / "retrieval.pkl").is_file()
+
+
+def check_test_step(environment: SilNlpEnv):
+    exp_dir = environment.get_mt_exp_dir(EXPERIMENT_NAME)
+    predictions_path = exp_dir / "test.trg-predictions.detok.txt.1"
+    assert predictions_path.exists()
+
+    # There should be exactly one prediction line per test source sentence.
+    assert count_lines(predictions_path) == count_lines(exp_dir / "test.src.txt")
+
+
+def check_translate_step(environment: SilNlpEnv):
+    infer_dir = environment.get_mt_exp_dir(EXPERIMENT_NAME) / "infer"
+    translated_files = list(infer_dir.glob("*/BSB/653JN.SFM"))
+    assert len(translated_files) == 1

--- a/tests/unit_tests/test_remote_llm_config.py
+++ b/tests/unit_tests/test_remote_llm_config.py
@@ -1,0 +1,895 @@
+import math
+import pickle
+import re
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from silnlp.nmt.config import Language
+from silnlp.nmt.config_utils import is_llm_config, is_remote_llm_config
+from silnlp.nmt.example_retrieval import (
+    BM25ExampleRetriever,
+    ExamplePair,
+    ExampleRetriever,
+    TfidfExampleRetriever,
+    create_retriever,
+    tokenize_for_retrieval,
+)
+from silnlp.nmt.remote_llm_config import (
+    CONTEXT_MODE_FULL_CORPUS,
+    CONTEXT_MODE_RAG,
+    Completion,
+    CompletionClient,
+    CompletionClientFactory,
+    RemoteLLMConfig,
+    RemoteLLMModel,
+    TokenLogprob,
+    UsageTotals,
+    count_tokens,
+    extract_token_logprobs,
+    group_indices_by_size,
+    parse_numbered_response,
+    strip_code_fence,
+)
+
+EN = Language("en", "English")
+ES = Language("es", "Spanish")
+
+
+# --- dispatch ---------------------------------------------------------------------------
+
+
+def test_is_remote_llm_config_requires_an_explicit_model_type():
+    assert is_remote_llm_config({"model_type": "remote_llm", "model": "anthropic/claude-sonnet-4-5"})
+    assert is_remote_llm_config({"model_type": "REMOTE_LLM", "model": "gpt-4o"})
+    # A LiteLLM model string is arbitrary, so it is never recognized on its own.
+    assert not is_remote_llm_config({"model": "anthropic/claude-sonnet-4-5"})
+    assert not is_remote_llm_config({})
+
+
+def test_an_remote_llm_config_is_not_claimed_by_the_llm_dispatch():
+    # google/gemma matches LLM_MODEL_PREFIXES, but the explicit model_type has to win.
+    config = {"model_type": "remote_llm", "model": "google/gemma-2-2b-it"}
+    assert is_remote_llm_config(config)
+    assert not is_llm_config(config)
+
+
+# --- response parsing -------------------------------------------------------------------
+
+
+def test_parse_numbered_response_reads_one_translation_per_line():
+    assert parse_numbered_response("1. uno\n2. dos\n3. tres", 3) == ["uno", "dos", "tres"]
+
+
+@pytest.mark.parametrize("delimiter", [".", ")", ":", "]"])
+def test_parse_numbered_response_accepts_common_delimiters(delimiter: str):
+    assert parse_numbered_response(f"1{delimiter} uno\n2{delimiter} dos", 2) == ["uno", "dos"]
+
+
+def test_parse_numbered_response_ignores_preamble_and_reorders():
+    assert parse_numbered_response("Certainly! Here you go:\n\n2. dos\n1. uno", 2) == ["uno", "dos"]
+
+
+def test_parse_numbered_response_strips_code_fences():
+    assert parse_numbered_response("```text\n1. uno\n2. dos\n```", 2) == ["uno", "dos"]
+
+
+def test_parse_numbered_response_treats_unnumbered_lines_as_continuations():
+    assert parse_numbered_response("1. uno\nand more\n2. dos", 2) == ["uno and more", "dos"]
+
+
+def test_parse_numbered_response_rejects_a_miscount():
+    assert parse_numbered_response("1. uno\n2. dos", 3) is None
+    assert parse_numbered_response("1. uno\n2. dos\n3. tres", 2) is None
+
+
+def test_parse_numbered_response_rejects_gaps_and_duplicates():
+    assert parse_numbered_response("1. uno\n3. tres", 2) is None
+    assert parse_numbered_response("1. uno\n1. otro", 2) is None
+
+
+def test_parse_numbered_response_rejects_unnumbered_prose():
+    assert parse_numbered_response("uno dos tres", 3) is None
+
+
+def test_strip_code_fence_leaves_unfenced_text_alone():
+    assert strip_code_fence("plain text") == "plain text"
+    assert strip_code_fence("```\nfenced\n```") == "fenced"
+
+
+# --- batching ---------------------------------------------------------------------------
+
+
+def test_group_indices_by_size():
+    assert group_indices_by_size(5, 2) == [[0, 1], [2, 3], [4]]
+    assert group_indices_by_size(3, 1) == [[0], [1], [2]]
+    assert group_indices_by_size(0, 4) == []
+    # A nonsensical size still yields usable batches rather than an empty or infinite grouping.
+    assert group_indices_by_size(3, 0) == [[0], [1], [2]]
+
+
+# --- retrieval --------------------------------------------------------------------------
+
+
+PAIRS = [
+    ExamplePair("In the beginning God created the heavens and the earth.", "target one"),
+    ExamplePair("And God said, Let there be light, and there was light.", "target two"),
+    ExamplePair("Jesus wept.", "target three"),
+]
+
+
+def test_tokenize_for_retrieval_lowercases_and_splits_on_word_characters():
+    assert tokenize_for_retrieval("Let there be LIGHT!") == ["let", "there", "be", "light"]
+
+
+def make_retriever(method: str) -> ExampleRetriever:
+    if method == "bm25":
+        pytest.importorskip("rank_bm25")
+    return create_retriever(method)
+
+
+@pytest.mark.parametrize("method", ["tfidf", "bm25"])
+def test_retriever_ranks_the_most_similar_example_first(method: str):
+    retriever = make_retriever(method)
+    retriever.fit(PAIRS)
+    assert retriever.retrieve("let there be light", 1) == [PAIRS[1]]
+
+
+@pytest.mark.parametrize("method", ["tfidf", "bm25"])
+def test_retriever_returns_at_most_the_whole_corpus(method: str):
+    retriever = make_retriever(method)
+    retriever.fit(PAIRS)
+    assert len(retriever.retrieve("light", 99)) == len(PAIRS)
+    assert retriever.retrieve("light", 0) == []
+
+
+@pytest.mark.parametrize("method", ["tfidf", "bm25"])
+def test_retriever_handles_an_empty_corpus(method: str):
+    retriever = make_retriever(method)
+    retriever.fit([])
+    assert retriever.retrieve("anything", 5) == []
+
+
+def test_retriever_classes_report_their_method():
+    assert TfidfExampleRetriever.method == "tfidf"
+    assert BM25ExampleRetriever.method == "bm25"
+
+
+def test_retriever_save_and_load_roundtrip(tmp_path: Path):
+    retriever = create_retriever("tfidf")
+    retriever.fit(PAIRS)
+    retriever.save(tmp_path)
+
+    loaded = ExampleRetriever.load(tmp_path)
+    assert loaded is not None
+    assert loaded.method == "tfidf"
+    assert loaded.pairs == PAIRS
+    assert loaded.retrieve("let there be light", 1) == [PAIRS[1]]
+
+
+def test_retriever_load_returns_none_when_missing(tmp_path: Path):
+    assert ExampleRetriever.load(tmp_path) is None
+
+
+def test_retriever_load_returns_none_for_a_corrupt_index(tmp_path: Path):
+    # An unreadable index is a signal to rebuild, not an error: it can be left behind by a
+    # scikit-learn upgrade.
+    (tmp_path / "retrieval.pkl").write_bytes(b"not a pickle")
+    assert ExampleRetriever.load(tmp_path) is None
+
+
+def test_retriever_load_returns_none_for_an_unrelated_pickle(tmp_path: Path):
+    with (tmp_path / "retrieval.pkl").open("wb") as file:
+        pickle.dump({"not": "a retriever"}, file)
+    assert ExampleRetriever.load(tmp_path) is None
+
+
+def test_create_retriever_rejects_an_unknown_method():
+    with pytest.raises(ValueError, match="Unknown retrieval method"):
+        create_retriever("embeddings")
+
+
+# --- config -----------------------------------------------------------------------------
+
+
+def make_config(exp_dir: Path, **overrides) -> RemoteLLMConfig:
+    config: dict = {
+        "model_type": "remote_llm",
+        "model": "gpt-4o",
+        "data": {"corpus_pairs": [], "lang_codes": {"en": "English", "es": "Spanish"}},
+    }
+    for key, value in overrides.items():
+        section = config.setdefault(key, {})
+        if isinstance(section, dict) and isinstance(value, dict):
+            section.update(value)
+        else:
+            config[key] = value
+    return RemoteLLMConfig(exp_dir, config, Mock())
+
+
+def test_config_defaults(tmp_path: Path):
+    config = make_config(tmp_path)
+    assert config.context_mode == CONTEXT_MODE_RAG
+    assert config.retrieval_method == "tfidf"
+    assert config.num_examples == 10
+    assert config.infer_batch_size == 1
+    # The hosted model tokenizes for itself, so preprocessing writes raw text.
+    assert config.data["tokenize"] is False
+    assert config.model_dir == tmp_path / "run"
+
+
+def test_config_requires_a_model(tmp_path: Path):
+    with pytest.raises(ValueError, match="LiteLLM format"):
+        RemoteLLMConfig(tmp_path, {"model_type": "remote_llm", "model": "", "data": {"corpus_pairs": []}}, Mock())
+
+
+@pytest.mark.parametrize(
+    "infer, message",
+    [
+        ({"context_mode": "magic"}, "Unknown infer.context_mode"),
+        ({"retrieval": {"method": "embeddings"}}, "Unknown infer.retrieval.method"),
+        ({"infer_batch_size": 0}, "infer.infer_batch_size"),
+        ({"num_drafts": 0}, "infer.num_drafts"),
+        ({"concurrency": 0}, "infer.concurrency"),
+        ({"retrieval": {"num_examples": -1}}, "num_examples"),
+    ],
+)
+def test_config_validation(tmp_path: Path, infer: dict, message: str):
+    with pytest.raises(ValueError, match=message):
+        make_config(tmp_path, infer=infer)
+
+
+def test_language_falls_back_to_the_iso_code(tmp_path: Path):
+    config = make_config(tmp_path)
+    assert config.language("en") == EN
+    assert config.language("xyz") == Language("xyz", "xyz")
+
+
+def test_create_tokenizer_is_a_no_op(tmp_path: Path):
+    from silnlp.common.utils import Side
+
+    tokenizer = make_config(tmp_path).create_tokenizer()
+    assert tokenizer.tokenize(Side.SOURCE, "unchanged text") == "unchanged text"
+    assert tokenizer.detokenize("unchanged text") == "unchanged text"
+
+
+# --- prompts ----------------------------------------------------------------------------
+
+
+def test_single_segment_prompt_has_no_numbering(tmp_path: Path):
+    config = make_config(tmp_path)
+    messages = config.build_messages(["hello"], [], EN, ES)
+
+    assert [message["role"] for message in messages] == ["system", "user"]
+    assert "English" in messages[0]["content"] and "Spanish" in messages[0]["content"]
+    assert messages[1]["content"].endswith("hello")
+    assert "1. hello" not in messages[1]["content"]
+
+
+def test_batch_prompt_numbers_the_segments(tmp_path: Path):
+    config = make_config(tmp_path)
+    user = config.build_messages(["one", "two", "three"], [], EN, ES)[1]["content"]
+
+    assert "1. one\n2. two\n3. three" in user
+    assert "exactly 3 lines" in user
+
+
+def test_system_message_casts_the_model_as_a_team_member(tmp_path: Path):
+    # Consistency with one project's decisions is the point, so the examples have to be
+    # authoritative rather than the prompt asking for a generically good translation.
+    system = make_config(tmp_path).build_messages(["hello"], [], EN, ES)[0]["content"]
+
+    assert "Bible translation team" in system
+    assert "not a translation of your own" in system
+    assert "your authority" in system
+
+
+@pytest.mark.parametrize("dimension", ["Style", "Key terms", "Exegesis", "Orthography"])
+def test_system_message_names_what_to_infer_from_the_examples(tmp_path: Path, dimension: str):
+    system = make_config(tmp_path).build_messages(["hello"], [], EN, ES)[0]["content"]
+    assert dimension in system
+
+
+def test_system_message_prefers_the_examples_over_a_remembered_translation(tmp_path: Path):
+    # A model asked for a well-known verse will otherwise reproduce a published version it has
+    # memorized, which is exactly the wrong output for a team with its own conventions.
+    system = make_config(tmp_path).build_messages(["hello"], [], EN, ES)[0]["content"]
+    assert "in preference to any published Spanish translation you may recall" in system
+
+
+def test_examples_are_presented_as_the_team_own_work(tmp_path: Path):
+    config = make_config(tmp_path)
+    user = config.build_messages(["hello"], [ExamplePair("greeting", "saludo")], EN, ES)[1]["content"]
+    assert "The team has already translated these passages" in user
+
+
+def test_full_corpus_block_is_presented_as_the_team_own_work(tmp_path: Path):
+    model, client = make_model(tmp_path, lambda messages: "hola", infer={"context_mode": CONTEXT_MODE_FULL_CORPUS})
+    write_training_corpus(tmp_path)
+    list(model.translate(["anything"], "en", "es"))
+
+    assert "everything the team has translated so far" in client.calls[0][0]["content"]
+
+
+def test_batch_prompt_tells_the_model_to_read_the_passages_together(tmp_path: Path):
+    # Chapter batching exists so that the model can see a passage as a unit; the prompt has to
+    # actually ask it to use that context for participants and pronouns.
+    user = make_config(tmp_path).build_messages(["one", "two"], [], EN, ES)[1]["content"]
+    assert "consecutive" in user
+    assert "translate each one on its own" in user
+
+
+def test_prompt_includes_retrieved_examples(tmp_path: Path):
+    config = make_config(tmp_path)
+    user = config.build_messages(["hello"], [ExamplePair("greeting", "saludo")], EN, ES)[1]["content"]
+
+    assert "English: greeting" in user
+    assert "Spanish: saludo" in user
+
+
+def test_example_template_is_configurable(tmp_path: Path):
+    config = make_config(tmp_path, params={"prompt": {"example_template": "{source} => {target}"}})
+    user = config.build_messages(["hello"], [ExamplePair("greeting", "saludo")], EN, ES)[1]["content"]
+    assert "greeting => saludo" in user
+
+
+def test_system_message_is_configurable(tmp_path: Path):
+    config = make_config(tmp_path, params={"prompt": {"system_message": "Be terse."}})
+    assert config.build_messages(["hello"], [], EN, ES)[0]["content"] == "Be terse."
+
+
+def test_full_corpus_block_goes_in_the_system_message(tmp_path: Path):
+    # The corpus has to sit ahead of everything that varies per request, so that the prompt
+    # prefix is byte-identical across requests and provider-side caching can apply.
+    config = make_config(tmp_path)
+    corpus_block = "CORPUS"
+    first = config.build_messages(["one"], [], EN, ES, corpus_block)
+    second = config.build_messages(["two"], [], EN, ES, corpus_block)
+
+    assert first[0]["content"] == second[0]["content"]
+    assert corpus_block in first[0]["content"]
+    assert corpus_block not in first[1]["content"]
+
+
+# --- model ------------------------------------------------------------------------------
+
+_NUMBERED_SOURCE = re.compile(r"^\d+\. ")
+
+
+class ScriptedClient(CompletionClient):
+    """A completion client that answers with a scripted function instead of a network call."""
+
+    def __init__(
+        self,
+        responder: Callable[[List[Dict[str, str]]], str],
+        logprobs_supported: bool = False,
+        token_logprobs: Optional[List[TokenLogprob]] = None,
+    ) -> None:
+        self._responder = responder
+        self._logprobs_supported = logprobs_supported
+        self._token_logprobs = token_logprobs
+        self.calls: List[List[Dict[str, str]]] = []
+        self.logprobs_requested: List[bool] = []
+
+    def complete(self, messages: List[Dict[str, str]], logprobs: bool = False) -> Completion:
+        self.calls.append(messages)
+        self.logprobs_requested.append(logprobs)
+        text = self._responder(messages)
+        if logprobs and self._token_logprobs is not None:
+            return Completion(text, list(self._token_logprobs))
+        return Completion(text)
+
+    def supports_logprobs(self) -> bool:
+        return self._logprobs_supported
+
+
+class ScriptedClientFactory(CompletionClientFactory):
+    def __init__(self, client: CompletionClient) -> None:
+        self._client = client
+
+    def create(self, config: RemoteLLMConfig) -> CompletionClient:
+        return self._client
+
+
+def echo_translations(messages: List[Dict[str, str]]) -> str:
+    """Reply in the requested format, for however many segments the prompt asked about."""
+    user = messages[-1]["content"]
+    num_segments = sum(1 for line in user.splitlines() if _NUMBERED_SOURCE.match(line))
+    if num_segments == 0:
+        return "translated"
+    return "\n".join(f"{i}. translated {i}" for i in range(1, num_segments + 1))
+
+
+def make_model(
+    tmp_path: Path,
+    responder,
+    logprobs_supported: bool = False,
+    token_logprobs: Optional[List[TokenLogprob]] = None,
+    **overrides,
+) -> Tuple[RemoteLLMModel, ScriptedClient]:
+    client = ScriptedClient(responder, logprobs_supported, token_logprobs)
+    config = make_config(tmp_path, **overrides)
+    return RemoteLLMModel(config, ScriptedClientFactory(client)), client
+
+
+def translations_of(groups, draft: int = 0) -> List[str]:
+    return [list(group)[draft].get_translation() for group in groups]
+
+
+def test_translate_yields_one_group_per_sentence_in_order(tmp_path: Path):
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+    groups = list(model.translate(["one", "two", "three"], "en", "es"))
+
+    assert len(groups) == 3
+    assert translations_of(groups) == ["hola", "hola", "hola"]
+
+
+def test_translate_batches_several_segments_into_one_request(tmp_path: Path):
+    model, client = make_model(tmp_path, echo_translations, infer={"infer_batch_size": 3, "concurrency": 1})
+    groups = list(model.translate(["one", "two", "three"], "en", "es"))
+
+    assert len(client.calls) == 1
+    assert translations_of(groups) == ["translated 1", "translated 2", "translated 3"]
+
+
+def test_translate_leaves_blank_segments_blank_without_a_request(tmp_path: Path):
+    model, client = make_model(tmp_path, echo_translations, infer={"infer_batch_size": 4, "concurrency": 1})
+    groups = list(model.translate(["", "  ", ""], "en", "es"))
+
+    assert translations_of(groups) == ["", "", ""]
+    assert client.calls == []
+
+
+def test_translate_keeps_blank_segments_aligned_within_a_batch(tmp_path: Path):
+    model, _ = make_model(tmp_path, echo_translations, infer={"infer_batch_size": 3, "concurrency": 1})
+    groups = list(model.translate(["one", "", "three"], "en", "es"))
+
+    # The blank segment is not sent, so the two real segments are numbered 1 and 2.
+    assert translations_of(groups) == ["translated 1", "", "translated 2"]
+
+
+def test_translate_falls_back_to_single_requests_when_the_reply_is_malformed(tmp_path: Path):
+    # The recovery ladder is: correct, split the batch, then one request per segment, which
+    # cannot be miscounted.
+    model, client = make_model(
+        tmp_path, lambda messages: "I translated everything for you!", infer={"infer_batch_size": 2, "concurrency": 1}
+    )
+    groups = list(model.translate(["one", "two"], "en", "es"))
+
+    assert translations_of(groups) == ["I translated everything for you!"] * 2
+    # batch attempt, corrective retry, then one request per segment
+    assert len(client.calls) == 4
+    assert client.calls[1][-1]["content"].startswith("That reply did not have the required format")
+
+
+def test_translate_recovers_after_a_corrective_retry(tmp_path: Path):
+    replies = iter(["nonsense", "1. uno\n2. dos"])
+    model, client = make_model(
+        tmp_path, lambda messages: next(replies), infer={"infer_batch_size": 2, "concurrency": 1}
+    )
+    groups = list(model.translate(["one", "two"], "en", "es"))
+
+    assert translations_of(groups) == ["uno", "dos"]
+    assert len(client.calls) == 2
+
+
+def test_multiple_translations_make_one_request_per_draft(tmp_path: Path):
+    model, client = make_model(
+        tmp_path, lambda messages: "hola", infer={"num_drafts": 3, "temperature": 0.8, "concurrency": 1}
+    )
+    groups = list(model.translate(["one"], "en", "es", produce_multiple_translations=True))
+
+    assert len(groups) == 1
+    assert groups[0].num_drafts == 3
+    assert len(client.calls) == 3
+
+
+def test_a_single_draft_is_produced_when_multiple_translations_are_not_requested(tmp_path: Path):
+    model, client = make_model(tmp_path, lambda messages: "hola", infer={"num_drafts": 3, "concurrency": 1})
+    groups = list(model.translate(["one"], "en", "es"))
+
+    assert groups[0].num_drafts == 1
+    assert len(client.calls) == 1
+
+
+def test_concurrent_requests_keep_the_translations_in_order(tmp_path: Path):
+    model, _ = make_model(tmp_path, echo_translations, infer={"infer_batch_size": 1, "concurrency": 4})
+    groups = list(model.translate([f"segment {i}" for i in range(20)], "en", "es"))
+
+    assert translations_of(groups) == ["translated"] * 20
+
+
+def test_translations_carry_no_confidence_scores_when_none_were_requested(tmp_path: Path):
+    model, client = make_model(tmp_path, lambda messages: "hola")
+    translation = list(list(model.translate(["one"], "en", "es"))[0])[0]
+
+    assert not translation.has_sequence_confidence_score()
+    assert client.logprobs_requested == [False]
+    # The text has to survive the test-file path, which drops a leading special token for
+    # seq2seq models but must not for this one.
+    assert translation.join_tokens_for_test_file() == "hola"
+
+
+def test_translate_test_files_writes_one_line_per_source(tmp_path: Path):
+    (tmp_path / "test.src.txt").write_text("one\ntwo\n", encoding="utf-8")
+    model, _ = make_model(tmp_path, lambda messages: "hola", infer={"concurrency": 1})
+
+    model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"])
+
+    assert (tmp_path / "out.txt").read_text(encoding="utf-8").splitlines() == ["hola", "hola"]
+
+
+def test_translate_test_files_writes_one_file_per_draft(tmp_path: Path):
+    (tmp_path / "test.src.txt").write_text("one\n", encoding="utf-8")
+    model, _ = make_model(
+        tmp_path, lambda messages: "hola", infer={"num_drafts": 2, "temperature": 0.8, "concurrency": 1}
+    )
+
+    model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], produce_multiple_translations=True)
+
+    assert (tmp_path / "out.1.txt").is_file()
+    assert (tmp_path / "out.2.txt").is_file()
+
+
+# --- training ---------------------------------------------------------------------------
+
+
+def write_training_corpus(exp_dir: Path) -> None:
+    (exp_dir / "train.src.detok.txt").write_text("in the beginning\nlet there be light\n", encoding="utf-8")
+    (exp_dir / "train.trg.detok.txt").write_text("en el principio\nsea la luz\n", encoding="utf-8")
+
+
+def test_train_builds_and_saves_the_retrieval_index(tmp_path: Path):
+    write_training_corpus(tmp_path)
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+
+    model.train()
+
+    checkpoint_dir = tmp_path / "run" / "checkpoint-1"
+    assert (checkpoint_dir / "retrieval.pkl").is_file()
+    loaded = ExampleRetriever.load(checkpoint_dir)
+    assert loaded is not None and len(loaded.pairs) == 2
+
+
+def test_train_writes_a_checkpoint_so_the_last_checkpoint_resolves(tmp_path: Path):
+    write_training_corpus(tmp_path)
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+
+    model.train()
+
+    path, step = model.get_checkpoint_path("last")
+    assert step == 1
+    assert path == tmp_path / "run" / "checkpoint-1"
+
+
+def test_train_in_full_corpus_mode_writes_a_checkpoint_but_no_index(tmp_path: Path):
+    write_training_corpus(tmp_path)
+    model, _ = make_model(tmp_path, lambda messages: "hola", infer={"context_mode": CONTEXT_MODE_FULL_CORPUS})
+
+    model.train()
+
+    checkpoint_dir = tmp_path / "run" / "checkpoint-1"
+    assert checkpoint_dir.is_dir()
+    assert not (checkpoint_dir / "retrieval.pkl").exists()
+
+
+def test_train_tolerates_a_missing_training_corpus(tmp_path: Path):
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+    model.train()
+    assert (tmp_path / "run" / "checkpoint-1").is_dir()
+
+
+def test_retrieved_examples_reach_the_prompt(tmp_path: Path):
+    write_training_corpus(tmp_path)
+    model, client = make_model(tmp_path, lambda messages: "hola", infer={"retrieval": {"num_examples": 1}})
+    model.train()
+
+    list(model.translate(["let there be light"], "en", "es"))
+
+    user = client.calls[0][1]["content"]
+    assert "let there be light" in user
+    assert "sea la luz" in user
+
+
+def test_the_index_is_rebuilt_when_the_checkpoint_is_gone(tmp_path: Path):
+    # experiment.py deletes the run directory unless --save-checkpoints is passed, so the saved
+    # index is only a cache; inference has to rebuild it from the training corpus.
+    write_training_corpus(tmp_path)
+    model, client = make_model(tmp_path, lambda messages: "hola", infer={"retrieval": {"num_examples": 1}})
+
+    list(model.translate(["let there be light"], "en", "es"))
+
+    assert "sea la luz" in client.calls[0][1]["content"]
+
+
+def test_full_corpus_mode_puts_the_whole_corpus_in_the_system_message(tmp_path: Path):
+    write_training_corpus(tmp_path)
+    model, client = make_model(tmp_path, lambda messages: "hola", infer={"context_mode": CONTEXT_MODE_FULL_CORPUS})
+
+    list(model.translate(["anything"], "en", "es"))
+
+    system = client.calls[0][0]["content"]
+    assert "en el principio" in system
+    assert "sea la luz" in system
+
+
+def test_save_effective_config_writes_the_merged_config(tmp_path: Path):
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+    path = tmp_path / "effective-config.yml"
+    model.save_effective_config(path)
+
+    with path.open(encoding="utf-8") as file:
+        written = yaml.safe_load(file)
+    assert written["model"] == "gpt-4o"
+    assert written["infer"]["context_mode"] == CONTEXT_MODE_RAG
+
+
+# --- confidence scores from log probabilities ---------------------------------------------
+
+
+SCORES = [TokenLogprob("ho", -0.2), TokenLogprob("la", -0.4)]
+
+
+def test_completion_mean_logprob():
+    assert Completion("hola", SCORES).mean_logprob() == pytest.approx(-0.3)
+    assert Completion("hola").mean_logprob() is None
+
+
+def test_extract_token_logprobs_reads_the_openai_shape():
+    choice = {"logprobs": {"content": [{"token": "ho", "logprob": -0.2}, {"token": "la", "logprob": -0.4}]}}
+    assert extract_token_logprobs(choice) == SCORES
+
+
+class _Obj:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_extract_token_logprobs_reads_pydantic_style_objects():
+    # LiteLLM returns model objects rather than plain dicts for most providers.
+    choice = _Obj(logprobs=_Obj(content=[_Obj(token="ho", logprob=-0.2), _Obj(token="la", logprob=-0.4)]))
+    assert extract_token_logprobs(choice) == SCORES
+
+
+@pytest.mark.parametrize(
+    "choice",
+    [
+        {},
+        {"logprobs": None},
+        {"logprobs": {"content": None}},
+        {"logprobs": {"content": []}},
+    ],
+)
+def test_extract_token_logprobs_tolerates_a_provider_that_omits_them(choice: dict):
+    # Providers that do not support logprobs silently omit them rather than failing.
+    assert extract_token_logprobs(choice) == []
+
+
+def test_extract_token_logprobs_skips_incomplete_entries():
+    choice = {"logprobs": {"content": [{"token": "ho"}, {"token": "la", "logprob": -0.4}]}}
+    assert extract_token_logprobs(choice) == [TokenLogprob("la", -0.4)]
+
+
+def test_confidence_scores_come_from_the_token_logprobs(tmp_path: Path):
+    (tmp_path / "test.src.txt").write_text("one\n", encoding="utf-8")
+    model, client = make_model(
+        tmp_path,
+        lambda messages: "hola",
+        logprobs_supported=True,
+        token_logprobs=SCORES,
+        infer={"concurrency": 1},
+    )
+
+    model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], save_confidences=True)
+
+    assert client.logprobs_requested == [True]
+    confidences = tmp_path / "out.txt.confidences.tsv"
+    assert confidences.is_file()
+    rows = confidences.read_text(encoding="utf-8").splitlines()
+    # Two header rows, then one token row and one score row for the single sentence.
+    assert len(rows) == 4
+    # The score row leads with the exponentiated mean log probability.
+    assert float(rows[3].split("\t")[0]) == pytest.approx(math.exp(-0.3))
+
+
+def test_confidence_scores_do_not_corrupt_the_predictions_file(tmp_path: Path):
+    # The predictions file is raw text, so it must hold the translation, not the provider's
+    # subword tokens.
+    (tmp_path / "test.src.txt").write_text("one\n", encoding="utf-8")
+    model, _ = make_model(
+        tmp_path,
+        lambda messages: "hola mundo",
+        logprobs_supported=True,
+        token_logprobs=SCORES,
+        infer={"concurrency": 1},
+    )
+
+    model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], save_confidences=True)
+
+    assert (tmp_path / "out.txt").read_text(encoding="utf-8").splitlines() == ["hola mundo"]
+
+
+def test_confidences_are_rejected_in_chapter_mode(tmp_path: Path):
+    model, client = make_model(
+        tmp_path,
+        lambda messages: "hola",
+        logprobs_supported=True,
+        token_logprobs=SCORES,
+        infer={"infer_batch_size": 4},
+    )
+
+    with pytest.raises(RuntimeError, match="single segment"):
+        model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], save_confidences=True)
+    # It fails before spending anything on inference.
+    assert client.calls == []
+
+
+def test_confidences_are_rejected_when_batches_hold_several_segments(tmp_path: Path):
+    model, _ = make_model(
+        tmp_path,
+        lambda messages: "hola",
+        logprobs_supported=True,
+        token_logprobs=SCORES,
+        infer={"infer_batch_size": 4},
+    )
+
+    with pytest.raises(RuntimeError, match="single segment"):
+        model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], save_confidences=True)
+
+
+def test_confidences_are_rejected_when_the_provider_has_no_logprobs(tmp_path: Path):
+    model, _ = make_model(tmp_path, lambda messages: "hola", logprobs_supported=False)
+
+    with pytest.raises(RuntimeError, match="does not return token log probabilities"):
+        model.translate_test_files([tmp_path / "test.src.txt"], [tmp_path / "out.txt"], save_confidences=True)
+
+
+def test_scores_are_dropped_when_a_code_fence_is_stripped(tmp_path: Path):
+    # Stripping the fence changes the text, so the per-token scores no longer line up with it.
+    model, _ = make_model(
+        tmp_path,
+        lambda messages: "```\nhola\n```",
+        logprobs_supported=True,
+        token_logprobs=SCORES,
+        infer={"concurrency": 1},
+    )
+
+    translation = list(list(model.translate(["one"], "en", "es"))[0])[0]
+    assert translation.get_translation() == "hola"
+    assert not translation.has_sequence_confidence_score()
+
+
+def test_an_empty_system_message_is_omitted_rather_than_sent_blank(tmp_path: Path):
+    config = make_config(tmp_path, params={"prompt": {"system_message": ""}})
+    messages = config.build_messages(["hello"], [], EN, ES)
+    assert [message["role"] for message in messages] == ["user"]
+
+
+def test_the_effective_config_records_the_prompts_actually_used(tmp_path: Path):
+    # The prompt is the model here, so a run is only reproducible if the saved config has it.
+    model, _ = make_model(tmp_path, lambda messages: "hola")
+    path = tmp_path / "effective-config.yml"
+    model.save_effective_config(path)
+
+    prompt = yaml.safe_load(path.read_text(encoding="utf-8"))["params"]["prompt"]
+    assert "Bible translation team" in prompt["system_message"]
+    assert "{source}" in prompt["instruction_template"]
+    assert "{num_segments}" in prompt["batch_instruction_template"]
+
+
+# --- token counting -----------------------------------------------------------------------
+
+
+def test_count_tokens_uses_the_provider_tokenizer():
+    pytest.importorskip("litellm")
+    text = "In the beginning God created the heavens and the earth. " * 20
+    tokens = count_tokens("gpt-4o", text)
+    assert tokens is not None
+    # A real tokenization, not the character-count approximation it replaced.
+    assert 150 < tokens < len(text) // 4
+
+
+def test_count_tokens_falls_back_to_none_for_an_unusable_model():
+    pytest.importorskip("litellm")
+    # LiteLLM tokenizes unknown models with a default tokenizer rather than failing, so this
+    # asserts the contract (an int or None) rather than a specific outcome.
+    assert count_tokens("made-up/nonexistent", "hello") in (None, 1, 2)
+
+
+def test_full_corpus_mode_warns_when_the_corpus_exceeds_the_context_limit(tmp_path: Path, caplog):
+    pytest.importorskip("litellm")
+    write_training_corpus(tmp_path)
+    model, _ = make_model(
+        tmp_path,
+        lambda messages: "hola",
+        infer={"context_mode": CONTEXT_MODE_FULL_CORPUS, "max_context_tokens": 1},
+    )
+
+    with caplog.at_level("WARNING"):
+        list(model.translate(["anything"], "en", "es"))
+
+    assert "exceeds infer.max_context_tokens" in caplog.text
+
+
+def test_full_corpus_mode_is_quiet_when_the_corpus_fits(tmp_path: Path, caplog):
+    pytest.importorskip("litellm")
+    write_training_corpus(tmp_path)
+    model, _ = make_model(
+        tmp_path,
+        lambda messages: "hola",
+        infer={"context_mode": CONTEXT_MODE_FULL_CORPUS, "max_context_tokens": 100000},
+    )
+
+    with caplog.at_level("WARNING"):
+        list(model.translate(["anything"], "en", "es"))
+
+    assert "exceeds infer.max_context_tokens" not in caplog.text
+
+
+def test_count_tokens_handles_an_unrecognized_model():
+    pytest.importorskip("litellm")
+    # LiteLLM tokenizes with a default tokenizer rather than failing on an unknown model.
+    assert count_tokens("made-up/nonexistent", "In the beginning God created the heavens.") is not None
+
+
+# --- usage and cost reporting ---------------------------------------------------------------
+
+
+def test_usage_totals_accumulate():
+    totals = UsageTotals()
+    totals.add(Completion("a", [], prompt_tokens=100, completion_tokens=10, cost=0.01))
+    totals.add(Completion("b", [], prompt_tokens=200, completion_tokens=20, cost=0.02))
+
+    assert (totals.requests, totals.prompt_tokens, totals.completion_tokens) == (2, 300, 30)
+    assert totals.cost == pytest.approx(0.03)
+    assert "2 requests, 300 prompt + 30 completion tokens, $0.0300" == totals.describe()
+
+
+def test_usage_totals_report_an_unpriced_model_rather_than_calling_it_free():
+    totals = UsageTotals()
+    totals.add(Completion("a", [], prompt_tokens=100, completion_tokens=10, cost=None))
+    assert "cost unavailable" in totals.describe()
+    assert "$" not in totals.describe()
+
+
+def test_usage_totals_flag_a_partial_cost():
+    totals = UsageTotals()
+    totals.add(Completion("a", [], prompt_tokens=100, completion_tokens=10, cost=0.01))
+    totals.add(Completion("b", [], prompt_tokens=100, completion_tokens=10, cost=None))
+
+    assert "$0.0100 excluding 1 unpriced requests" in totals.describe()
+
+
+def test_usage_totals_are_thread_safe():
+    totals = UsageTotals()
+    completion = Completion("a", [], prompt_tokens=1, completion_tokens=1, cost=0.001)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda _: totals.add(completion), range(2000)))
+
+    assert totals.requests == 2000
+    assert totals.prompt_tokens == 2000
+
+
+def test_translating_logs_the_usage_and_cost(tmp_path: Path, caplog):
+    def priced(messages):
+        return "hola"
+
+    client = ScriptedClient(priced)
+    # The scripted client reports no usage, so patch in a priced reply.
+    client.complete = lambda messages, logprobs=False: Completion(  # type: ignore[method-assign]
+        "hola", [], prompt_tokens=500, completion_tokens=5, cost=0.002
+    )
+    config = make_config(tmp_path, infer={"concurrency": 1})
+    model = RemoteLLMModel(config, ScriptedClientFactory(client))
+
+    with caplog.at_level("INFO"):
+        list(model.translate(["one", "two"], "en", "es"))
+
+    assert "Translated 2 segments using 2 requests" in caplog.text
+    assert "1,000 prompt + 10 completion tokens" in caplog.text
+    assert "$0.0040" in caplog.text


### PR DESCRIPTION
Adds an `NMTModel` implementation that translates by prompting a remote LLM through LiteLLM, with no fine-tuning. One `model` string selects any supported provider (OpenAI, Anthropic, Gemini, Bedrock, a local server).

Selected with `model_type: remote_llm`. Three knobs:

- `infer.context_mode` — `rag` retrieves the most relevant training examples per request; `full_corpus` puts the whole parallel corpus in the prompt.
- `infer.retrieval.method` — `tfidf` (default, uses scikit-learn) or `bm25`.
- `infer.infer_batch_size` — segments per request. Batched replies are parsed as a numbered list, falling back to a correction, then a split batch, then one request per segment.

The default prompts are written for scripture: they cast the model as a member of the translation team and have it infer the team's style, key terms, exegesis and orthography from the examples, which are that team's own work. All are overridable through `params.prompt` and are recorded in `effective-config.yml`.

`train()` does no fine-tuning but is not a no-op — it builds the retrieval index and writes `run/checkpoint-1`, so the existing checkpoint machinery resolves normally. The index is only a cache; inference rebuilds it if the `run` directory was deleted.

Also:

- New optional `remote_llm` extra (`litellm`, `rank-bm25`) — `poetry install -E remote_llm`.
- Token usage and cost are logged per translation run; a model LiteLLM has no pricing for is reported as unknown rather than free.
- `--save-confidences` works where the provider returns log probabilities and each request covers one segment, and fails up front otherwise rather than after paying for inference.

The only changes outside the new files are the `remote_llm` dispatch in `config_utils.py` and moving the `Language` dataclass to `config.py` so this module does not have to import the torch-heavy `llm_config`.

### Testing

123 unit tests pass. The smoke test (`tests/smoke_tests/test_experiment_remote_llm.py`) needs a MinIO connection and has **not** been run — it should be before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/silnlp/1148)
<!-- Reviewable:end -->
